### PR TITLE
Feature/attachments process bug fixes

### DIFF
--- a/app/Attachment.php
+++ b/app/Attachment.php
@@ -2,7 +2,12 @@
 
 namespace App;
 
+use Illuminate\Support\Facades\Storage;
+
 class Attachment extends BaseModel {
+
+    const STORAGE_TMP_UPLOAD = 'tmp_uploads';
+    const STORAGE_ATTACHMENTS = 'attachments';
 
     protected $table = 'attachments';
     protected $primaryKey = 'uuid';
@@ -37,6 +42,61 @@ class Attachment extends BaseModel {
     public function get_hashed_filename(){
         $ext = $this->get_filename_extension();
         return sha1($this->attachment.$this->uuid).'.'.$ext;
+    }
+
+    /**
+     * @return string
+     */
+    public function get_tmp_filename(){
+        return $this->uuid.'.'.str_replace(' ', '_', $this->attachment);
+    }
+
+    /**
+     * @param $file_contents
+     * @param bool $is_tmp
+     * @return bool
+     */
+    public function storage_store($file_contents, $is_tmp = false){
+        $storage_filename = $is_tmp ? $this->get_tmp_file_path() : $this->get_storage_file_path();
+        return Storage::put($storage_filename, $file_contents);
+    }
+
+    /**
+     * @param bool $is_tmp
+     * @return bool
+     */
+    public function storage_exists($is_tmp = false){
+        $storage_filename = $is_tmp ? $this->get_tmp_file_path() : $this->get_storage_file_path();
+        return Storage::exists($storage_filename);
+    }
+
+    /**
+     * @param bool $is_tmp
+     * @return bool
+     */
+    public function storage_delete($is_tmp = false){
+        $storage_filename = $is_tmp ? $this->get_tmp_file_path() : $this->get_storage_file_path();
+        return Storage::delete($storage_filename);
+    }
+
+    public function storage_move_from_tmp_to_main(){
+        if($this->storage_exists(true) && !$this->storage_exists()){
+            Storage::move($this->get_tmp_file_path(), $this->get_storage_file_path());
+        }
+    }
+
+    /**
+     * @return string
+     */
+    private function get_tmp_file_path(){
+        return self::STORAGE_TMP_UPLOAD.DIRECTORY_SEPARATOR.$this->get_tmp_filename();
+    }
+
+    /**
+     * @return string
+     */
+    public function get_storage_file_path(){
+        return self::STORAGE_ATTACHMENTS.DIRECTORY_SEPARATOR.$this->get_hashed_filename();
     }
 
 }

--- a/app/Entry.php
+++ b/app/Entry.php
@@ -147,7 +147,6 @@ class Entry extends BaseModel {
                     });
                     break;
                 case 'attachments':
-                    // FIXME: displaying too many and duplicate entries
                     if($filter_constraint == true){
                         // to get COUNT(attachment.id) > 0 use:
                         // INNER JOIN attachments ON attachments.entry_id=entries.id
@@ -156,18 +155,15 @@ class Entry extends BaseModel {
                         // to get COUNT(attachments.id) == 0 use:
                         // LEFT JOIN attachments
                         //   ON attachments.entry_id=entries.id
-                        //   AND attachments.entry_id IS NULL
-                        $entries_query->leftJoin('attachments', function($join){
-                            $join->on('entries.id', '=', 'attachments.entry_id')
-                                ->whereNull('attachments.entry_id');
-                        });
+                        // WHERE attachments.entry_id IS NULL
+                        $entries_query->leftJoin('attachments', 'entries.id', '=', 'attachments.entry_id')
+                            ->whereNull('attachments.entry_id');
                     }
                     break;
                 case 'tags':
-                    // LEFT JOIN entry_tags
+                    // RIGHT JOIN entry_tags
                     //   ON entry_tags.entry_id=entries.id
                     //   AND entry_tags.tag_id IN ($tags)
-                    // TODO: prevent duplicates from appearing
                     $tag_ids = (is_array($filters[$filter_name])) ? $filter_constraint : [$filter_constraint];
                     $entries_query->rightJoin('entry_tags', function($join) use ($tag_ids){
                         $join->on('entry_tags.entry_id', '=', 'entries.id')

--- a/app/Http/Controllers/Api/AttachmentController.php
+++ b/app/Http/Controllers/Api/AttachmentController.php
@@ -6,17 +6,18 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 
 use App\Attachment;
-use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Response as HttpStatus;
 
 class AttachmentController extends Controller {
 
     public function delete_attachment($uuid){
         $attachment = Attachment::find($uuid);
         if(empty($attachment)){
-            return response('', Response::HTTP_NOT_FOUND);
+            return response('', HttpStatus::HTTP_NOT_FOUND);
         } else {
             $attachment->forceDelete();
-            return response('', Response::HTTP_NO_CONTENT);
+            $attachment->storage_delete();
+            return response('', HttpStatus::HTTP_NO_CONTENT);
         }
     }
 

--- a/app/Http/Controllers/Api/EntryController.php
+++ b/app/Http/Controllers/Api/EntryController.php
@@ -239,11 +239,16 @@ class EntryController extends Controller {
                 if(!is_array($attachment_data)){
                     continue;
                 }
-                $new_attachment = new Attachment();
-                $new_attachment->uuid = $attachment_data['uuid'];
-                $new_attachment->attachment = $attachment_data['attachment'];
-                $new_attachment->entry_id = $entry->id;
-                $new_attachment->save();
+
+                $existing_attachment = Attachment::find($attachment_data['uuid']);
+                if(is_null($existing_attachment)){
+                    $new_attachment = new Attachment();
+                    $new_attachment->uuid = $attachment_data['uuid'];
+                    $new_attachment->attachment = $attachment_data['attachment'];
+                    $new_attachment->entry_id = $entry->id;
+                    $new_attachment->storage_move_from_tmp_to_main();
+                    $new_attachment->save();
+                }
             }
         }
     }

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -371,28 +371,28 @@ var entry = {
 };
 
 var attachment = {
+    uri: '/api/attachment/',
     open: function(uuid){
         var url = '/attachment/'+uuid;
         var win=window.open(url, '_blank');
         win.focus();
     },
-    remove: function(uuid){
-        var entryId = $('#entry_id').val();
+    remove: function(attachmentUuid, attachmentName){
         if(confirm('Are you sure you want to delete attachment: '+attachmentName)){
             $.ajax({
                 type: 'DELETE',
-                url: url+nocache(),
-                data: {
-                    type: 'delete_attachment',
-                    entry_id : entryId,
-                    id: attachmentId
-                },
+                url: attachment.uri+attachmentUuid,
                 beforeSend:function(){
                     notice.remove();
                 },
                 success:function(data){
-                    $('#attachment_'+attachmentId).remove();
-                    $('#entry_has_attachment').val( parseInt(data) );
+                    $.each(entry.value.attachments, function(idx, entryAttachment){
+                        if(entryAttachment.uuid === attachmentUuid){
+                            delete entry.value.attachments[idx];
+                        }
+                    });
+                    $('#attachment_'+attachmentUuid).remove();
+                    notice.display(notice.typeInfo, "Attachment has been deleted");
                 },
                 error:function(){
                     notice.display(notice.typeDanger, 'Could not delete attachment');
@@ -411,7 +411,6 @@ function completeEntryUpdate(){
     } else {
         entries.load();
     }
-    // TODO: rewrite below... msybe?
     institutions.load();
     accounts.load();
     institutionsPane.displayAccountTypes();

--- a/public/js/institutions-pane.js
+++ b/public/js/institutions-pane.js
@@ -81,6 +81,7 @@ var institutionsPane = {
         institutionsPane.accountsDisplayed = false;
         institutionsPane.closedAccountsDisplayed = false;
         $('.institutions-pane-institution').remove();
+        $('.institutions-pane-account').remove();
     },
     clearActiveState: function(){
         $('#entry-overview').removeClass('active');

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -64,7 +64,6 @@
 <div class="container-fluid">
     <div class="row">
         <div class="col-sm-3 col-md-2 sidebar">
-            <!-- TODO: reset active institution/account after filter has been activated -->
             <ul id="institution-display-pane" class="nav nav-sidebar">
                 <li><h4>Institutions</h4></li>
                 <li id="entry-overview" class="active">

--- a/resources/views/modal/entry.blade.php
+++ b/resources/views/modal/entry.blade.php
@@ -51,7 +51,7 @@
                 </label>
 
                 <div id="attachment-uploader">Upload</div>
-                <input type="hidden" name="entry-attachments" id="entry-attachments" />
+                <input type="hidden" name="entry-new-attachments" id="entry-new-attachments" value="[]" />
             </div>
 
             <div class="modal-footer">

--- a/tests/Feature/Api/PostEntriesTest.php
+++ b/tests/Feature/Api/PostEntriesTest.php
@@ -351,9 +351,7 @@ class PostEntriesTest extends ListEntriesBase {
                     }
                     break;
                 case 'attachments':
-                    if($constraint == true){
-                        $entry_components['has_attachments'] = $constraint;
-                    }
+                    $entry_components['has_attachments'] = $constraint;
                     break;
                 case 'tags':
                     $entry_components[$filter_name] = [$this->_faker->randomElement($constraint)];

--- a/tests/Feature/Api/PutEntryTest.php
+++ b/tests/Feature/Api/PutEntryTest.php
@@ -314,15 +314,17 @@ class PutEntryTest extends TestCase {
 
         // WHEN
         $put_response = $this->json("PUT", $this->_base_uri.$this->_generated_entry->id, $put_entry_data);
-        $get_response = $this->get($this->_base_uri.$this->_generated_entry->id);
 
-        // THEN - check PUT response
+        // THEN
         $put_response->assertStatus(Response::HTTP_OK);
         $put_response_as_array = $this->getResponseAsArray($put_response);
         $this->assertPutResponseHasCorrectKeys($put_response_as_array);
         $this->assertSuccessPutResponse($put_response_as_array);
 
-        // THEN - check GET response
+        // WHEN
+        $get_response = $this->get($this->_base_uri.$this->_generated_entry->id);
+
+        // THEN
         $get_response->assertStatus(Response::HTTP_OK);
         $get_response_as_array = $this->getResponseAsArray($get_response);
         $this->assertArrayHasKey('attachments', $get_response_as_array);
@@ -363,6 +365,9 @@ class PutEntryTest extends TestCase {
         $this->assertEquals($put_entry_data['account_type'], $get_response_as_array['account_type'], $get_response->getContent());
     }
 
+    /**
+     * @param array $response_as_array
+     */
     private function assertPutResponseHasCorrectKeys($response_as_array){
         $failure_message = "PUT Response is ".json_encode($response_as_array);
         $this->assertTrue(is_array($response_as_array), $failure_message);
@@ -370,6 +375,10 @@ class PutEntryTest extends TestCase {
         $this->assertArrayHasKey(EntryController::RESPONSE_SAVE_KEY_ERROR, $response_as_array, $failure_message);
     }
 
+    /**
+     * @param array $response_as_array
+     * @param string $response_error_msg
+     */
     private function assertFailedPutResponse($response_as_array, $response_error_msg){
         $failure_message = "PUT response is ".json_encode($response_as_array);
         $this->assertEquals(EntryController::ERROR_ENTRY_ID, $response_as_array[EntryController::RESPONSE_SAVE_KEY_ID], $failure_message);
@@ -377,10 +386,14 @@ class PutEntryTest extends TestCase {
         $this->assertContains($response_error_msg, $response_as_array[EntryController::RESPONSE_SAVE_KEY_ERROR], $failure_message);
     }
 
+    /**
+     * @param array $response_as_array
+     */
     private function assertSuccessPutResponse($response_as_array){
         $failure_message = "PUT response is ".json_encode($response_as_array);
         $this->assertEmpty($response_as_array[EntryController::RESPONSE_SAVE_KEY_ERROR], $failure_message);
         $this->assertGreaterThan(EntryController::ERROR_ENTRY_ID, $response_as_array[EntryController::RESPONSE_SAVE_KEY_ID], $failure_message);
+        $this->assertEquals($this->_generated_entry->id, $response_as_array[EntryController::RESPONSE_SAVE_KEY_ID], $failure_message." while updating entry ID ".$this->_generated_entry->id);
     }
 
 }

--- a/tests/Feature/Api/PutEntryTest.php
+++ b/tests/Feature/Api/PutEntryTest.php
@@ -301,6 +301,43 @@ class PutEntryTest extends TestCase {
         }
     }
 
+    public function testUpdateEntryWithAttachmentsAndAttachmentsAreAlreadyAttached(){
+        // GIVEN
+        $unattached_attachment = factory(Attachment::class)->make();
+        $put_entry_data = ['attachments'=>[
+            ['uuid'=>$unattached_attachment->uuid, 'attachment'=>$unattached_attachment->attachment]
+        ]];
+        $attached_attachments = factory(Attachment::class, 3)->create(['entry_id'=>$this->_generated_entry->id]);
+        foreach($attached_attachments as $attached_attachment){
+            $put_entry_data['attachments'][] = ['uuid'=>$attached_attachment->uuid, 'attachment'=>$attached_attachment->attachment];
+        }
+
+        // WHEN
+        $put_response = $this->json("PUT", $this->_base_uri.$this->_generated_entry->id, $put_entry_data);
+        $get_response = $this->get($this->_base_uri.$this->_generated_entry->id);
+
+        // THEN - check PUT response
+        $put_response->assertStatus(Response::HTTP_OK);
+        $put_response_as_array = $this->getResponseAsArray($put_response);
+        $this->assertPutResponseHasCorrectKeys($put_response_as_array);
+        $this->assertSuccessPutResponse($put_response_as_array);
+
+        // THEN - check GET response
+        $get_response->assertStatus(Response::HTTP_OK);
+        $get_response_as_array = $this->getResponseAsArray($get_response);
+        $this->assertArrayHasKey('attachments', $get_response_as_array);
+        $this->assertTrue(is_array($get_response_as_array['attachments']));
+        $this->assertNotEmpty($get_response_as_array['attachments']);
+        foreach($get_response_as_array['attachments'] as $response_attachment){
+            $attachment_data = [
+                'uuid'=>$response_attachment['uuid'],
+                'attachment'=>$response_attachment['attachment']
+            ];
+            // This step really makes sure that entries have not been duplicated
+            $this->assertContains($attachment_data, $put_entry_data['attachments'], 'Generated attachments:'.json_encode($put_entry_data['attachments']));
+        }
+    }
+
     public function testUpdateEntryWithNoUpdates(){
         // GIVEN
         $put_entry_data = $this->_generated_entry->toArray();


### PR DESCRIPTION
- Corrected bug where entries with attachments were still being shown when we filtered for entry without attachments.
- Corrected bug in PostEntriesTest where when attachment filter is false, then attachments may be created.
- Migrated Attachment upload storage handling from the Web/AttachmentController to the Attachment model.
- Added a check to Api/EntryController when attaching attachments to an entry to make sure that the attachment hasn't already been attached to the entry.
- Improved GUI for uploading & deleting entry attachment.