### PR TITLE
Feature/pagination-buttons

### DIFF
--- a/public/js/filter-modal.js
+++ b/public/js/filter-modal.js
@@ -1,8 +1,3 @@
-var filterTags = $('#filter-tags');
-$.each(tags.value, function(idx, obj){
-    filterTags.append('<label class="btn btn-info"><input type="checkbox" value="'+obj.id+'"/>'+obj.tag+'</label>');
-});
-
 var bootstrapSwitchObject = {
     size: "small",
     handleWidth: 79,    // forces display width to 200px
@@ -62,17 +57,22 @@ var filterModal = {
         });
     },
     reset: function(){
+        // traditional inputs
         $('#filter-start-date').val('');
         $('#filter-end-date').val('');
-        $('#filter-account-type').val('');
+        $('#filter-min-value').val('');
+        $('#filter-max-value').val('');
+        $('#filter-account-or-account-type').val('');
+        // tags
         $('#filter-tags label').removeClass('active');
+        $('input[name="filter-tag"]').prop('checked', false);
+        // toggle/switches
         $('input[name="filter-expense').prop('checked', false)
             .bootstrapSwitch('state', false);
         $('input[name="filter-attachments"]').prop('checked', false)
             .bootstrapSwitch('state', false);
         $('#filter-unconfirmed').prop('checked', false)
             .bootstrapSwitch('state', false);
-        $('.is_filtered').hide();
     },
     submit: function(){
         loading.start();

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -200,12 +200,12 @@ var entries = {
             beforeSend: function() {
                 loading.start();
                 filterModal.active = false;
+                paginate.filterState = {};
             },
             statusCode: entries.ajaxStatusCodeProcessing,
             complete: entries.ajaxCompleteProcessing
         });
     },
-
     filter: function(filterParameters, pageNumber){
         $.each(filterParameters, function(parameter, value){
             if(value === null){
@@ -218,6 +218,7 @@ var entries = {
             type: 'POST',
             beforeSend: function(){
                 loading.start();
+                paginate.filterState = filterParameters
             },
             data: JSON.stringify(filterParameters),
             dataType: 'json',
@@ -273,10 +274,10 @@ var entries = {
         paginate.display.next(paginate.current < Math.ceil(entries.total/50)-1);
         loading.end();
     },
-    reload: function(pageNumber){
+    reload: function(pageNumber, filterParameters){
         pageNumber = paginate.processPageNumber(pageNumber);
-        if(filterModal.active){
-            entries.filter(filterModal.parameters, pageNumber);
+        if(filterParameters){
+            entries.filter(filterParameters, pageNumber);
         } else {
             entries.load(pageNumber);
         }

--- a/public/js/institutions-pane.js
+++ b/public/js/institutions-pane.js
@@ -36,7 +36,8 @@ var institutionsPane = {
 
                 // display account related entries on click
                 $('#account-id-'+accountObject.id).click(function(){
-                    filterModal.active = false;
+                    filterModal.active = false; // no longer filtering
+                    paginate.current = 0;   // reset current "page number"
                     var accountFilterParameters = $.extend(true, {}, defaultFilterParameters);
                     accountFilterParameters.account = accountObject.id;
                     entries.filter(accountFilterParameters);
@@ -103,6 +104,7 @@ $(document).ready(function(){
         });
 
     $("#entry-overview").click(function(){
+        paginate.current = 0;
         entries.load();
         institutionsPane.clearActiveState();
         $('#entry-overview').addClass('active');

--- a/public/js/paginate.js
+++ b/public/js/paginate.js
@@ -1,12 +1,13 @@
 var paginate = {
     current: 0,
+    filterState: {},
     init: function(){
         $("#next").click(paginate.next);
         $("#prev").click(paginate.previous);
     },
     next: function(){
         paginate.current++;
-        entries.reload(paginate.current);
+        entries.reload(paginate.current, paginate.filterState);
     },
     previous: function(){
         paginate.current--;
@@ -14,7 +15,7 @@ var paginate = {
             paginate.current = 0;
         }
 
-        entries.reload(paginate.current);
+        entries.reload(paginate.current, paginate.filterState);
     },
     processPageNumber: function(pageNumber){
         pageNumber = parseInt(pageNumber);

--- a/resources/views/modal/filter.blade.php
+++ b/resources/views/modal/filter.blade.php
@@ -74,7 +74,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal" id="filter-close">Close</button>
-                <button type="button" class="btn btn-warning" data-dismiss="modal" id="filter-reset"><span class="glyphicon glyphicon-repeat"></span> Reset</button>
+                <button type="button" class="btn btn-warning" id="filter-reset"><span class="glyphicon glyphicon-repeat"></span> Reset</button>
                 <button type="button" class="btn btn-primary" data-dismiss="modal" id="filter-set"><span class="glyphicon glyphicon-search"></span> Set Filter</button>
             </div>
         </div>


### PR DESCRIPTION
- Filter modal no longer closes when clicking on the reset button
- Pagination now has a filter state. Used for storing state while clicking "next" & "previous".
- Fixed some bugs when resetting filter modal inputs: 
  - min/max inputs were not being cleared
  - tag button checkboxes were not being cleared. just the active state
  - account/account-type select wasn't being cleared. It wasn't updated when the select was changed in commit 5543337
- Current page number is now reset when clicking on an account element in the institutions pane.