### PR TITLE
support/mysql-output-test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,20 @@ install:
   - php artisan travis-ci --display-env
 
 before_script:
+  - mysql -u root -e "SHOW DATABASES;"
   - mysql -u root -e "CREATE DATABASE money_tracker;"
   - mysql -u root -e "CREATE USER 'jdenoc'@'localhost' IDENTIFIED BY 'password';"
   - mysql -u root -e "GRANT ALL ON money_tracker.* TO 'jdenoc'@'localhost';"
+  - mysql -u root -e "SHOW DATABASES;"
 
 # Some tests take over 10 minutes to run. Using travis_wait to work around that.
 script: travis_wait vendor/bin/phpunit --coverage-text
 
 after_script:
+  - mysql -u root -e "SHOW DATABASES;"
   - mysql -u root -e "DROP USER 'jdenoc'@'localhost';"
   - mysql -u root -e "DROP DATABASE money_tracker;"
+  - mysql -u root -e "SHOW DATABASES;"
 
 # make sure ONLY updates to the master branch cause a build
 branch:


### PR DESCRIPTION
Added `mysql -u root -e "SHOW DATABASES;"` before and after MySQL commands are run. To make sure that databases have been created/deleted appropriately.