### PR TITLE
Feature/response-assert-status-failure-text

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,8 @@ after_script:
   - mysql -u root -e "DROP USER 'jdenoc'@'localhost';"
   - mysql -u root -e "DROP DATABASE money_tracker;"
 
-# make sure ONLY updates to the master branch cause a build
+# make sure ONLY updates to the master & develop branches cause a build
 branch:
   only:
     - master
+    - develop

--- a/app/Http/Controllers/Api/EntryController.php
+++ b/app/Http/Controllers/Api/EntryController.php
@@ -196,22 +196,31 @@ class EntryController extends Controller {
         );
     }
 
-    public static function get_filter_details(){
-        $tags = Tag::all();
-        $tag_ids = $tags->pluck('id')->toArray();
-        return [
+    /**
+     * @param bool $include_tag_ids
+     * @return array
+     */
+    public static function get_filter_details($include_tag_ids = true){
+        $filter_details = [
             'start_date'=>'date_format:Y-m-d',
             'end_date'=>'date_format:Y-m-d',
             'account'=>'integer',
             'account_type'=>'integer',
             'tags'=>'array',
-            'tags.*'=>'in:'.implode(',', $tag_ids),
             'expense'=>'boolean',
             'attachments'=>'boolean',
             'min_value'=>'numeric',
             'max_value'=>'numeric',
             'unconfirmed'=>'boolean'
         ];
+
+        if($include_tag_ids){
+            $tags = Tag::all();
+            $tag_ids = $tags->pluck('id')->toArray();
+            $filter_details['tags.*'] = 'in:'.implode(',', $tag_ids);
+        }
+
+        return $filter_details;
     }
 
     /**

--- a/tests/Feature/Api/DeleteEntryTest.php
+++ b/tests/Feature/Api/DeleteEntryTest.php
@@ -5,11 +5,11 @@ namespace Tests\Feature\Api;
 use App\Account;
 use App\AccountType;
 use App\Entry;
+use Faker\Factory as FakerFactory;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class DeleteEntryTest extends TestCase {
 
@@ -29,22 +29,30 @@ class DeleteEntryTest extends TestCase {
         $get_response2 = $this->get($this->_base_uri.$entry->id);
 
         // THEN
-        $get_response1->assertStatus(HttpStatus::HTTP_OK);
-        $delete_response->assertStatus(HttpStatus::HTTP_NO_CONTENT);
-        $get_response2->assertStatus(HttpStatus::HTTP_NOT_FOUND);
+        $this->assertResponseStatus($get_response1, HttpStatus::HTTP_OK);
+        $this->assertResponseStatus($delete_response, HttpStatus::HTTP_NO_CONTENT);
+        $this->assertResponseStatus($get_response2, HttpStatus::HTTP_NOT_FOUND);
+
+        $this->assertEmpty($delete_response->getContent());
+        $this->assertTrue(is_array($get_response2->json()));
+        $this->assertEmpty($get_response2->json());
     }
 
     public function testMarkingEntryDeletedWhenEntryDoesNotExist(){
+        $faker = FakerFactory::create();
         // GIVEN
-        $entry_id = 99999;
+        $entry_id = $faker->randomNumber();
 
         // WHEN
         $get_response = $this->get($this->_base_uri.$entry_id);
         $delete_response = $this->delete($this->_base_uri.$entry_id);
 
         // THEN
-        $get_response->assertStatus(HttpStatus::HTTP_NOT_FOUND);
-        $delete_response->assertStatus(HttpStatus::HTTP_NOT_FOUND);
+        $this->assertResponseStatus($get_response, HttpStatus::HTTP_NOT_FOUND);
+        $this->assertResponseStatus($delete_response, HttpStatus::HTTP_NOT_FOUND);
+        $this->assertTrue(is_array($get_response->json()));
+        $this->assertEmpty($get_response->json());
+        $this->assertEmpty($delete_response->getContent());
     }
 
 }

--- a/tests/Feature/Api/ListEntriesBase.php
+++ b/tests/Feature/Api/ListEntriesBase.php
@@ -7,7 +7,7 @@ use App\Attachment;
 use App\Entry;
 use App\Tag;
 use Carbon\Carbon;
-use Faker\Factory;
+use Faker\Factory as FakerFactory;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
@@ -38,9 +38,13 @@ class ListEntriesBase extends TestCase {
      */
     protected $_uri = '/api/entries';
 
-    public function setUp(){
+    public function __construct($name = null, array $data = [], $dataName = ''){
+        parent::__construct($name, $data, $dataName);
+        $this->_faker = FakerFactory::create();
+    }
+
+    protected function setUp(){
         parent::setUp();
-        $this->_faker = Factory::create();
         $this->_generated_account = factory(Account::class)->create();
         $this->_generated_tags = factory(Tag::class, $this->_faker->randomDigitNotNull)->create();
     }

--- a/tests/Feature/Api/PostEntriesTest.php
+++ b/tests/Feature/Api/PostEntriesTest.php
@@ -12,7 +12,11 @@ class PostEntriesTest extends ListEntriesBase {
     public function providerPostEntriesFilter(){
         // need to call setUp() before running through a data provider method
         // environment needs setting up and isn't until setUp() is called
-        $this->setUp();
+        //$this->setUp();
+        // We can no longer call setUp() as a work around
+        // it caused the database to populate and in doing so we caused some tests to fail.
+        // Said tests failed because they were testing the absence of database values.
+        $this->initialiseApplication();
 
         $filter = [];
         $filter['no filter'] = [[]];
@@ -41,11 +45,8 @@ class PostEntriesTest extends ListEntriesBase {
         ];
 
         // confirm all filters in EntryController are listed here
-        $current_filters = EntryController::get_filter_details();
+        $current_filters = EntryController::get_filter_details(false);
         foreach(array_keys($current_filters) as $existing_filter){
-            if(strpos('.*', $existing_filter) === false){
-                continue;
-            }
             $this->assertArrayHasKey($existing_filter, $filter_details);
         }
 

--- a/tests/Feature/Api/PostEntryTest.php
+++ b/tests/Feature/Api/PostEntryTest.php
@@ -8,7 +8,7 @@ use App\Attachment;
 use App\Entry;
 use App\Http\Controllers\Api\EntryController;
 use App\Tag;
-use Faker\Factory;
+use Faker\Factory as FakerFactory;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
@@ -37,7 +37,11 @@ class PostEntryTest extends TestCase {
     public function providerCreateEntryWithMissingData(){
         // PHPUnit data providers are called before setUp() and setUpBeforeClass() are called.
         // With that piece of information, we need to call setUp() earlier than we normally would so that we can use model factories
-        $this->setUp();
+        //$this->setUp();
+        // We can no longer call setUp() as a work around
+        // it caused the database to populate and in doing so we caused some tests to fail.
+        // Said tests failed because they were testing the absence of database values.
+        $this->initialiseApplication();
 
         $required_entry_fields = Entry::get_fields_required_for_creation();
 
@@ -154,7 +158,7 @@ class PostEntryTest extends TestCase {
     }
 
     public function testCreateEntryButTagDoesNotExist(){
-        $faker = Factory::create();
+        $faker = FakerFactory::create();
         // GIVEN
         do{
             $generate_tag_count = $faker->randomDigitNotNull;
@@ -207,7 +211,7 @@ class PostEntryTest extends TestCase {
     }
 
     public function testCreateEntryWithAttachments(){
-        $faker = Factory::create();
+        $faker = FakerFactory::create();
         // GIVEN
         do{
             $generated_attachment_count = $faker->randomDigitNotNull;

--- a/tests/Feature/Api/PutEntryTest.php
+++ b/tests/Feature/Api/PutEntryTest.php
@@ -8,8 +8,8 @@ use App\Attachment;
 use App\Entry;
 use App\Http\Controllers\Api\EntryController;
 use App\Tag;
-use Faker\Factory;
-use Symfony\Component\HttpFoundation\Response;
+use Faker\Factory as FakerFactory;
+use Symfony\Component\HttpFoundation\Response as HttpStatus;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
@@ -39,14 +39,14 @@ class PutEntryTest extends TestCase {
         $response = $this->json("PUT", $this->_base_uri.$this->_generated_entry->id, $update_data);
 
         // THEN
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
+        $response->assertStatus(HttpStatus::HTTP_BAD_REQUEST);
         $response_as_array = $this->getResponseAsArray($response);
         $this->assertPutResponseHasCorrectKeys($response_as_array);
         $this->assertFailedPutResponse($response_as_array, EntryController::ERROR_MSG_SAVE_ENTRY_NO_DATA);
     }
 
     public function testUpdateEntryButNewAccountTypeDoesNotExist(){
-        $faker = Factory::create();
+        $faker = FakerFactory::create();
         // GIVEN - see setUp()
 
         $entry_data = factory(Entry::class)->make();
@@ -60,14 +60,14 @@ class PutEntryTest extends TestCase {
         $response = $this->json('PUT', $this->_base_uri.$this->_generated_entry->id, $entry_data);
 
         // THEN
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
+        $response->assertStatus(HttpStatus::HTTP_BAD_REQUEST);
         $response_as_array = $this->getResponseAsArray($response);
         $this->assertPutResponseHasCorrectKeys($response_as_array);
         $this->assertFailedPutResponse($response_as_array, EntryController::ERROR_MSG_SAVE_ENTRY_INVALID_ACCOUNT_TYPE);
     }
 
     public function testUpdateEntryButEntryDoesNotExist(){
-        $faker = Factory::create();
+        $faker = FakerFactory::create();
         // GIVEN - entry does not exist
         $entry_id = $faker->randomDigitNotNull;
         $entry_data = factory(Entry::class)->make();
@@ -77,8 +77,8 @@ class PutEntryTest extends TestCase {
         $response = $this->json('PUT', $this->_base_uri.$entry_id, $entry_data);
 
         // THEN
-        $response->assertStatus(Response::HTTP_NOT_FOUND);
-        $response_as_array = $this->getResponseAsArray($response);
+        $this->assertResponseStatus($response, HttpStatus::HTTP_NOT_FOUND);
+        $response_as_array = $response->json();
         $this->assertPutResponseHasCorrectKeys($response_as_array);
         $this->assertFailedPutResponse($response_as_array, EntryController::ERROR_MSG_SAVE_ENTRY_DOES_NOT_EXIST);
     }
@@ -93,7 +93,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $get_account_response1 = $this->get('/api/account/'.$this->_generated_account->id);
         // THEN
-        $get_account_response1->assertStatus(Response::HTTP_OK);
+        $get_account_response1->assertStatus(HttpStatus::HTTP_OK);
         $get_account_response1_as_array = $this->getResponseAsArray($get_account_response1);
         $this->assertArrayHasKey('total', $get_account_response1_as_array);
         $original_total = $get_account_response1_as_array['total'];
@@ -101,7 +101,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $put_response = $this->json("PUT", $this->_base_uri.$this->_generated_entry->id, $entry_data);
         // THEN
-        $put_response->assertStatus(Response::HTTP_OK);
+        $put_response->assertStatus(HttpStatus::HTTP_OK);
         $put_response_as_array = $this->getResponseAsArray($put_response);
         $this->assertPutResponseHasCorrectKeys($put_response_as_array);
         $this->assertSuccessPutResponse($put_response_as_array);
@@ -109,7 +109,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $get_entry_response = $this->get($this->_base_uri.$this->_generated_entry->id);
         // THEN
-        $get_entry_response->assertStatus(Response::HTTP_OK);
+        $get_entry_response->assertStatus(HttpStatus::HTTP_OK);
         $get_entry_response_as_array = $this->getResponseAsArray($get_entry_response);
         $this->assertArrayHasKey('entry_value', $get_entry_response_as_array);
         $this->assertEquals($entry_data['entry_value'], $get_entry_response_as_array['entry_value']);
@@ -117,7 +117,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $get_account_response2 = $this->get('/api/account/'.$this->_generated_account->id);
         // THEN
-        $get_account_response2->assertStatus(Response::HTTP_OK);
+        $get_account_response2->assertStatus(HttpStatus::HTTP_OK);
         $get_account_response2_as_array = $this->getResponseAsArray($get_account_response2);
         $this->assertArrayHasKey('total', $get_account_response2_as_array);
         $updated_total = $get_account_response2_as_array['total'];
@@ -140,7 +140,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $get_account_response1 = $this->get('/api/account/'.$this->_generated_account->id);
         // THEN
-        $get_account_response1->assertStatus(Response::HTTP_OK);
+        $get_account_response1->assertStatus(HttpStatus::HTTP_OK);
         $get_account_response1_as_array = $this->getResponseAsArray($get_account_response1);
         $this->assertArrayHasKey('total', $get_account_response1_as_array);
         $original_total = $get_account_response1_as_array['total'];
@@ -148,7 +148,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $put_response = $this->json("PUT", $this->_base_uri.$this->_generated_entry->id, $entry_data);
         // THEN
-        $put_response->assertStatus(Response::HTTP_OK);
+        $put_response->assertStatus(HttpStatus::HTTP_OK);
         $put_response_as_array = $this->getResponseAsArray($put_response);
         $this->assertPutResponseHasCorrectKeys($put_response_as_array);
         $this->assertEmpty($put_response_as_array[EntryController::RESPONSE_SAVE_KEY_ERROR]);
@@ -157,7 +157,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $get_entry_response = $this->get($this->_base_uri.$this->_generated_entry->id);
         // THEN
-        $get_entry_response->assertStatus(Response::HTTP_NOT_FOUND);
+        $get_entry_response->assertStatus(HttpStatus::HTTP_NOT_FOUND);
         $get_entry_response_as_array = $this->getResponseAsArray($get_entry_response);
         $this->assertTrue(is_array($get_entry_response_as_array));
         $this->assertEmpty($get_entry_response_as_array);
@@ -165,7 +165,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $get_account_response2 = $this->get('/api/account/'.$this->_generated_account->id);
         // THEN
-        $get_account_response2->assertStatus(Response::HTTP_OK);
+        $get_account_response2->assertStatus(HttpStatus::HTTP_OK);
         $get_account_response2_as_array = $this->getResponseAsArray($get_account_response2);
         $this->assertArrayHasKey('total', $get_account_response2_as_array);
         $updated_total = $get_account_response2_as_array['total'];
@@ -181,7 +181,11 @@ class PutEntryTest extends TestCase {
     public function providerUpdateEntryWithCertainProperties(){
         // PHPUnit data providers are called before setUp() and setUpBeforeClass() are called.
         // With that piece of information, we need to call setUp() earlier than we normally would so that we can use model factories
-        $this->setUp();
+        //$this->setUp();
+        // We can no longer call setUp() as a work around
+        // it caused the database to populate and in doing so we caused some tests to fail.
+        // Said tests failed because they were testing the absence of database values.
+        $this->initialiseApplication();
 
         $required_entry_fields = Entry::get_fields_required_for_update();
         unset($required_entry_fields[array_search('disabled', $required_entry_fields)]);
@@ -219,7 +223,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $put_response = $this->json("PUT", $this->_base_uri.$this->_generated_entry->id, $entry_data);
         // THEN
-        $put_response->assertStatus(Response::HTTP_OK);
+        $put_response->assertStatus(HttpStatus::HTTP_OK);
         $put_response_as_array = $this->getResponseAsArray($put_response);
         $this->assertPutResponseHasCorrectKeys($put_response_as_array);
         $this->assertSuccessPutResponse($put_response_as_array);
@@ -227,7 +231,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $get_response = $this->get($this->_base_uri.$this->_generated_entry->id);
         // THEN
-        $get_response->assertStatus(Response::HTTP_OK);
+        $get_response->assertStatus(HttpStatus::HTTP_OK);
         $get_response_as_array = $this->getResponseAsArray($get_response);
         foreach($entry_data as $property=>$value){
             $this->assertEquals($value, $get_response_as_array[$property], "Entry data:".json_encode($entry_data)."\nGet Request:".$get_response->getContent());
@@ -236,7 +240,7 @@ class PutEntryTest extends TestCase {
 
     public function testUpdateEntryWithTagThatDoesNotExist(){
         // GIVEN - see setUp()
-        $faker = Factory::create();
+        $faker = FakerFactory::create();
         $generate_tag_count = $faker->numberBetween(2, 5);
         factory(Tag::class, $generate_tag_count)->create();
         $put_entry_data = ['tags'=>Tag::all()->pluck('id')->toArray()];
@@ -248,7 +252,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $put_response = $this->json('PUT', $this->_base_uri.$this->_generated_entry->id, $put_entry_data);
         // THEN
-        $put_response->assertStatus(Response::HTTP_OK);
+        $put_response->assertStatus(HttpStatus::HTTP_OK);
         $put_response_as_array = $this->getResponseAsArray($put_response);
         $this->assertPutResponseHasCorrectKeys($put_response_as_array);
         $this->assertSuccessPutResponse($put_response_as_array);
@@ -256,7 +260,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $get_response = $this->get($this->_base_uri.$this->_generated_entry->id);
         // THEN
-        $get_response->assertStatus(Response::HTTP_OK);
+        $get_response->assertStatus(HttpStatus::HTTP_OK);
         $get_response_as_array = $this->getResponseAsArray($get_response);
         $this->assertArrayHasKey('tags', $get_response_as_array);
         $this->assertTrue(is_array($get_response_as_array['tags']));
@@ -279,7 +283,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $put_response = $this->json("PUT", $this->_base_uri.$this->_generated_entry->id, $put_entry_data);
         // THEN
-        $put_response->assertStatus(Response::HTTP_OK);
+        $put_response->assertStatus(HttpStatus::HTTP_OK);
         $put_response_as_array = $this->getResponseAsArray($put_response);
         $this->assertPutResponseHasCorrectKeys($put_response_as_array);
         $this->assertSuccessPutResponse($put_response_as_array);
@@ -287,7 +291,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $get_response = $this->get($this->_base_uri.$this->_generated_entry->id);
         // THEN
-        $get_response->assertStatus(Response::HTTP_OK);
+        $get_response->assertStatus(HttpStatus::HTTP_OK);
         $get_response_as_array = $this->getResponseAsArray($get_response);
         $this->assertArrayHasKey('attachments', $get_response_as_array);
         $this->assertTrue(is_array($get_response_as_array['attachments']));
@@ -316,7 +320,7 @@ class PutEntryTest extends TestCase {
         $put_response = $this->json("PUT", $this->_base_uri.$this->_generated_entry->id, $put_entry_data);
 
         // THEN
-        $put_response->assertStatus(Response::HTTP_OK);
+        $put_response->assertStatus(HttpStatus::HTTP_OK);
         $put_response_as_array = $this->getResponseAsArray($put_response);
         $this->assertPutResponseHasCorrectKeys($put_response_as_array);
         $this->assertSuccessPutResponse($put_response_as_array);
@@ -325,7 +329,7 @@ class PutEntryTest extends TestCase {
         $get_response = $this->get($this->_base_uri.$this->_generated_entry->id);
 
         // THEN
-        $get_response->assertStatus(Response::HTTP_OK);
+        $get_response->assertStatus(HttpStatus::HTTP_OK);
         $get_response_as_array = $this->getResponseAsArray($get_response);
         $this->assertArrayHasKey('attachments', $get_response_as_array);
         $this->assertTrue(is_array($get_response_as_array['attachments']));
@@ -347,7 +351,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $put_response = $this->json('PUT', $this->_base_uri.$this->_generated_entry->id, $put_entry_data);
         // THEN
-        $put_response->assertStatus(Response::HTTP_OK);
+        $put_response->assertStatus(HttpStatus::HTTP_OK);
         $put_response_as_array = $this->getResponseAsArray($put_response);
         $this->assertPutResponseHasCorrectKeys($put_response_as_array);
         $this->assertSuccessPutResponse($put_response_as_array);
@@ -355,7 +359,7 @@ class PutEntryTest extends TestCase {
         // WHEN
         $get_response = $this->get($this->_base_uri.$this->_generated_entry->id);
         // THEN
-        $get_response->assertStatus(Response::HTTP_OK);
+        $get_response->assertStatus(HttpStatus::HTTP_OK);
         $get_response_as_array = $this->getResponseAsArray($get_response);
         $this->assertEquals($put_entry_data['entry_date'], $get_response_as_array['entry_date'], $get_response->getContent());
         $this->assertEquals($put_entry_data['entry_value'], $get_response_as_array['entry_value'], $get_response->getContent());

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,16 @@ abstract class TestCase extends BaseTestCase {
 
     use CreatesApplication;
 
+    public function initialiseApplication(){
+        $this->app = $this->createApplication();
+    }
+
+    public function refreshApplication(){
+        if(!$this->app){
+            $this->initialiseApplication();
+        }
+    }
+
     public function tearDown(){
         $this->truncateDatabaseTables();
         parent::tearDown();
@@ -44,6 +54,16 @@ abstract class TestCase extends BaseTestCase {
         $expected_timestamp = strtotime($expected_datetime);
         $actual_timestamp = strtotime($actual_datetime);
         $this->assertTrue(abs($expected_timestamp - $actual_timestamp) <= 1, $assert_failure_message);
+    }
+
+    /**
+     * @param TestResponse|Response $response
+     * @param int $expected_status
+     */
+    protected function assertResponseStatus($response, $expected_status){
+        $actual_status = $response->getStatusCode();
+        $failure_message = "Expected status code ".$expected_status." but received ".$actual_status.". Response content: ".$response->getContent();
+        $this->assertTrue($actual_status === $expected_status, $failure_message);
     }
 
     /**


### PR DESCRIPTION
- travis-ci should only run builds on the `develop` and `master` branches
- Because the `testResponse->assertStatus()` doesn't tell us what response content we got, we've created a custom method to do just that: `assertResponseStatus()`.
- Can't call `setUp()` from within dataProviders anymore. It resulted in database being populated prematurely and causing tests to fail. Instead we must "initialise the application".
- A bunch of asserts were added to Api\DeleteAccountTypeTest and Api\DeleteEntryTest to account for appropriate responses.

Resolves #32 
Resolves #33 