### PR TITLE
Feature/database-snapshots-on-test-failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,6 @@ before_script:
 
 script: vendor/bin/phpunit --coverage-text
 
-after_failure:
-  # give us a snapshot of the database after a failure
-  - mysqldump -u root -e money_tracker;
-
 after_script:
   # SHOW DATABASES is here for piece of mind, to confirm that the database is deleted when it is supposed to be deleted
   - mysql -u root -e "SHOW DATABASES;"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,10 @@ before_script:
 
 script: vendor/bin/phpunit --coverage-text
 
+after_failure:
+  # give us a snapshot of the database after a failure
+  - mysqldump -u root -e money_tracker;
+
 after_script:
   # SHOW DATABASES is here for piece of mind, to confirm that the database is deleted when it is supposed to be deleted
   - mysql -u root -e "SHOW DATABASES;"

--- a/app/Http/Controllers/Api/EntryController.php
+++ b/app/Http/Controllers/Api/EntryController.php
@@ -273,7 +273,7 @@ class EntryController extends Controller {
     }
 
     /**
-     * @param $filters
+     * @param array $filters
      * @param int $page_number
      * @return \Illuminate\Contracts\Routing\ResponseFactory
      */

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -4,19 +4,26 @@ namespace Tests;
 
 use Illuminate\Contracts\Console\Kernel;
 
-trait CreatesApplication
-{
+trait CreatesApplication {
+
     /**
      * Creates the application.
      *
      * @return \Illuminate\Foundation\Application
      */
-    public function createApplication()
-    {
+    public function createApplication(){
         $app = require __DIR__.'/../bootstrap/app.php';
-
         $app->make(Kernel::class)->bootstrap();
-
         return $app;
+    }
+
+    public function initialiseApplication(){
+        $this->app = $this->createApplication();
+    }
+
+    public function refreshApplication(){
+        if(!$this->app){
+            $this->initialiseApplication();
+        }
     }
 }

--- a/tests/Feature/Api/DeleteAccountTypeTest.php
+++ b/tests/Feature/Api/DeleteAccountTypeTest.php
@@ -48,7 +48,8 @@ class DeleteAccountTypeTest extends TestCase {
         // THEN
         $this->assertResponseStatus($account_response1, HttpStatus::HTTP_OK);
         $this->assertResponseStatus($disabled_response, HttpStatus::HTTP_NO_CONTENT);
-        $this->assertResponseStatus($account_response2, HttpStatus::HTTP_OK);
+        // $this->assertResponseStatus($account_response2, HttpStatus::HTTP_OK); // temperately disabling this so we can effectively test failure output
+        $this->assertResponseStatus($account_response2, HttpStatus::HTTP_BAD_GATEWAY);  // TODO: remove this line and reactivate the line above
 
         $account_response1_as_array = $account_response1->json();
         $this->assertNotEmpty($account_response1_as_array, $account_response1->getContent());

--- a/tests/Feature/Api/DeleteAccountTypeTest.php
+++ b/tests/Feature/Api/DeleteAccountTypeTest.php
@@ -53,8 +53,7 @@ class DeleteAccountTypeTest extends TestCase {
         // THEN
         $this->assertResponseStatus($account_response1, HttpStatus::HTTP_OK);
         $this->assertResponseStatus($disabled_response, HttpStatus::HTTP_NO_CONTENT);
-        // $this->assertResponseStatus($account_response2, HttpStatus::HTTP_OK); // temperately disabling this so we can effectively test failure output
-        $this->assertResponseStatus($account_response2, HttpStatus::HTTP_BAD_GATEWAY);  // TODO: remove this line and reactivate the line above
+        $this->assertResponseStatus($account_response2, HttpStatus::HTTP_OK);
 
         $account_response1_as_array = $account_response1->json();
         $this->assertNotEmpty($account_response1_as_array, $account_response1->getContent());

--- a/tests/Feature/Api/DeleteAccountTypeTest.php
+++ b/tests/Feature/Api/DeleteAccountTypeTest.php
@@ -8,11 +8,8 @@ use Faker\Factory as FakerFactory;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class DeleteAccountTypeTest extends TestCase {
-
-    use DatabaseMigrations;
 
     private $_disable_account_type_uri = '/api/account-type/';
     private $_get_account_uri = '/api/account/';

--- a/tests/Feature/Api/DeleteAccountTypeTest.php
+++ b/tests/Feature/Api/DeleteAccountTypeTest.php
@@ -17,6 +17,11 @@ class DeleteAccountTypeTest extends TestCase {
     private $_disable_account_type_uri = '/api/account-type/';
     private $_get_account_uri = '/api/account/';
 
+    public function setUp(){
+        $this->setDatabaseStateInjectionPermission(self::$ALLOW_INJECT_DATABASE_STATE_ON_EXCEPTION);
+        parent::setUp();
+    }
+
     public function testDisableAccountTypeThatDoesNotExist(){
         $faker = FakerFactory::create();
         // GIVEN - account_type does not exist

--- a/tests/Feature/Api/DeleteAttachmentTest.php
+++ b/tests/Feature/Api/DeleteAttachmentTest.php
@@ -9,13 +9,9 @@ use App\Entry;
 use Tests\TestCase;
 use Faker;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Symfony\Component\HttpFoundation\Response;
 
 class DeleteAttachmentTest extends TestCase {
-
-    use DatabaseMigrations;
 
     private $_attachment_base_uri = '/api/attachment/';
     private $_entry_base_uri = '/api/entry/';

--- a/tests/Feature/Api/DeleteEntryTest.php
+++ b/tests/Feature/Api/DeleteEntryTest.php
@@ -9,11 +9,8 @@ use Faker\Factory as FakerFactory;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class DeleteEntryTest extends TestCase {
-
-    use DatabaseMigrations;
 
     private $_base_uri = '/api/entry/';
 

--- a/tests/Feature/Api/GetAccountTest.php
+++ b/tests/Feature/Api/GetAccountTest.php
@@ -5,15 +5,12 @@ namespace Tests\Feature\Api;
 use Faker;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Symfony\Component\HttpFoundation\Response;
 
 use App\Account;
 use App\AccountType;
 
 class GetAccountTest extends TestCase {
-
-    use DatabaseMigrations;
 
     /**
      * @var string

--- a/tests/Feature/Api/GetAccountTypesTest.php
+++ b/tests/Feature/Api/GetAccountTypesTest.php
@@ -7,11 +7,8 @@ use Faker\Factory;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class GetAccountTypesTest extends TestCase {
-
-    use DatabaseMigrations;
 
     private $_uri = '/api/account-types';
 

--- a/tests/Feature/Api/GetAccountsTest.php
+++ b/tests/Feature/Api/GetAccountsTest.php
@@ -5,14 +5,11 @@ namespace Tests\Feature\Api;
 use Faker\Factory;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Symfony\Component\HttpFoundation\Response;
 
 use App\Account;
 
 class GetAccountsTest extends TestCase {
-
-    use DatabaseMigrations;
 
     private $_uri = '/api/accounts';
 

--- a/tests/Feature/Api/GetEntryTest.php
+++ b/tests/Feature/Api/GetEntryTest.php
@@ -6,7 +6,6 @@ use App\Account;
 use Carbon\Carbon;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 use Faker;
 
@@ -16,8 +15,6 @@ use App\Entry;
 use App\Tag;
 
 class GetEntryTest extends TestCase {
-
-    use DatabaseMigrations;
 
     private $_generate_tag_count;
     private $_generate_attachment_count;

--- a/tests/Feature/Api/GetInstitutionTest.php
+++ b/tests/Feature/Api/GetInstitutionTest.php
@@ -9,11 +9,8 @@ use Faker;
 use Tests\TestCase;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class GetInstitutionTest extends TestCase {
-
-    use DatabaseMigrations;
 
     /**
      * @var string

--- a/tests/Feature/Api/GetInstitutionsTest.php
+++ b/tests/Feature/Api/GetInstitutionsTest.php
@@ -6,12 +6,9 @@ use App\Institution;
 use Faker\Factory;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 
 class GetInstitutionsTest extends TestCase {
-
-    use DatabaseMigrations;
 
     protected $_base_uri = '/api/institutions';
 

--- a/tests/Feature/Api/GetTagsTest.php
+++ b/tests/Feature/Api/GetTagsTest.php
@@ -4,14 +4,11 @@ namespace Tests\Feature\Api;
 
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Symfony\Component\HttpFoundation\Response;
 
 Use App\Tag;
 
 class GetTagsTest extends TestCase {
-
-    use DatabaseMigrations;
 
     private $_uri = '/api/tags';
 

--- a/tests/Feature/Api/ListEntriesBase.php
+++ b/tests/Feature/Api/ListEntriesBase.php
@@ -10,13 +10,10 @@ use Carbon\Carbon;
 use Faker\Factory as FakerFactory;
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Tests\TestCase;
 
 class ListEntriesBase extends TestCase {
-
-    use DatabaseMigrations;
 
     /**
      * @var Generator

--- a/tests/Feature/Api/PostEntriesTest.php
+++ b/tests/Feature/Api/PostEntriesTest.php
@@ -9,6 +9,11 @@ use Symfony\Component\HttpFoundation\Response as HttpStatus;
 
 class PostEntriesTest extends ListEntriesBase {
 
+    public function setUp(){
+        parent::setUp();
+        $this->setDatabaseStateInjectionPermission(self::$ALLOW_INJECT_DATABASE_STATE_ON_EXCEPTION);
+    }
+
     public function providerPostEntriesFilter(){
         // need to call setUp() before running through a data provider method
         // environment needs setting up and isn't until setUp() is called

--- a/tests/Feature/Api/PostEntryTest.php
+++ b/tests/Feature/Api/PostEntryTest.php
@@ -12,11 +12,8 @@ use Faker\Factory as FakerFactory;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class PostEntryTest extends TestCase {
-
-    use DatabaseMigrations;
 
     private $_base_uri = '/api/entry';
 

--- a/tests/Feature/Api/PutEntryTest.php
+++ b/tests/Feature/Api/PutEntryTest.php
@@ -12,11 +12,8 @@ use Faker\Factory as FakerFactory;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class PutEntryTest extends TestCase {
-
-    use DatabaseMigrations;
 
     private $_base_uri = '/api/entry/';
     private $_generated_account;

--- a/tests/InjectDatabaseStateIntoException.php
+++ b/tests/InjectDatabaseStateIntoException.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests;
+
+use App\Account;
+use App\AccountType;
+use App\Attachment;
+use App\Entry;
+use App\Institution;
+use App\Tag;
+use App\User;
+
+trait InjectDatabaseStateIntoException {
+
+    public static $ALLOW_INJECT_DATABASE_STATE_ON_EXCEPTION = true;
+    public static $DENY_INJECT_DATABASE_STATE_ON_EXCEPTION = false;
+
+    private $can_inject_database_state = false;
+
+    /**
+     * @return bool
+     */
+    public function isDatabaseStateInjectionAllowed(){
+        return $this->can_inject_database_state;
+    }
+
+    /**
+     * @param bool $can_inject_database_state
+     */
+    public function setDatabaseStateInjectionPermission($can_inject_database_state){
+        if($can_inject_database_state !== self::$ALLOW_INJECT_DATABASE_STATE_ON_EXCEPTION && $can_inject_database_state !== self::$DENY_INJECT_DATABASE_STATE_ON_EXCEPTION){
+            throw new \UnexpectedValueException("Attempted to set a value other than those permitted when setting database state injection permission");
+        }
+        $this->can_inject_database_state = $can_inject_database_state;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDatabaseState(){
+        $database_collection = collect();
+        $database_collection->put('tags', Tag::all());
+        $database_collection->put('users', User::all());
+        $database_collection->put('institutions', Institution::all());
+        $database_collection->put('accounts', Account::all());
+        $database_collection->put('account_types', AccountType::all());
+        $database_collection->put('entries+entry_tags', Entry::with('tags')->get());   // get a collection of entries with their tags
+        $database_collection->put('attachments', Attachment::all());
+        return $database_collection->toJson();
+    }
+
+    /**
+     * @param \Exception $exception
+     * @param string $injectable_message
+     * @return \Exception
+     */
+    public function injectMessageIntoException($exception, $injectable_message){
+        if($this->isDatabaseStateInjectionAllowed()){
+            $exception_message = $exception->getMessage()."\n".$injectable_message;
+            $exception_name = get_class($exception);
+            return new $exception_name($exception_message);
+        } else {
+            return $exception;
+        }
+    }
+
+
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,12 +4,14 @@ namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Foundation\Testing\TestResponse;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
 
 abstract class TestCase extends BaseTestCase {
 
     use CreatesApplication;
+    use DatabaseMigrations;
     use InjectDatabaseStateIntoException;
 
     private $_database_state = '';

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,7 +12,12 @@ abstract class TestCase extends BaseTestCase {
     use CreatesApplication;
     use InjectDatabaseStateIntoException;
 
+    private $_database_state = '';
+
     public function tearDown(){
+        if($this->isDatabaseStateInjectionAllowed()){
+            $this->_database_state = $this->getDatabaseState();
+        }
         $this->truncateDatabaseTables();
         parent::tearDown();
     }
@@ -78,11 +83,8 @@ abstract class TestCase extends BaseTestCase {
      * @throws \Throwable
      */
     public function onNotSuccessfulTest($unsuccessful_test_exception){
-        if($this->isDatabaseStateInjectionAllowed()){
-            $database_state = $this->getDatabaseState();
-            $exception_message_to_inject = "Database state on failure:\n".$database_state;
-            $unsuccessful_test_exception = $this->injectMessageIntoException($unsuccessful_test_exception, $exception_message_to_inject);
-        }
+        $exception_message_to_inject = "Database state on failure:\n".$this->_database_state;
+        $unsuccessful_test_exception = $this->injectMessageIntoException($unsuccessful_test_exception, $exception_message_to_inject);
 
         parent::onNotSuccessfulTest($unsuccessful_test_exception); // this needs to occur at the end of the method, or things won't get output.
     }

--- a/tests/Unit/InjectDatabaseStateIntoExceptionTest.php
+++ b/tests/Unit/InjectDatabaseStateIntoExceptionTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Denis
+ * Date: 2017-12-07
+ * Time: 09:41
+ */
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class InjectDatabaseStateIntoExceptionTest extends TestCase {
+
+    use DatabaseMigrations;
+    // NOTE: InjectDatabaseStateIntoException trait has already been included by the TestCase class
+
+    public function testSettingValidInjectionPermission(){
+        $current_state = $this->isDatabaseStateInjectionAllowed();
+        $this->assertEquals(self::$DENY_INJECT_DATABASE_STATE_ON_EXCEPTION, $current_state, "by default, we should NOT be able to inject a database state into an exception");
+
+        $this->setDatabaseStateInjectionPermission(self::$ALLOW_INJECT_DATABASE_STATE_ON_EXCEPTION);
+        $current_state = $this->isDatabaseStateInjectionAllowed();
+        $this->assertEquals(self::$ALLOW_INJECT_DATABASE_STATE_ON_EXCEPTION, $current_state);
+
+        $this->setDatabaseStateInjectionPermission(self::$DENY_INJECT_DATABASE_STATE_ON_EXCEPTION);
+        $current_state = $this->isDatabaseStateInjectionAllowed();
+        $this->assertEquals(self::$DENY_INJECT_DATABASE_STATE_ON_EXCEPTION, $current_state);
+    }
+
+    /**
+     * @expectedException \UnexpectedValueException
+     */
+    public function testSettingInvalidInjectionPermission(){
+        $current_state = $this->isDatabaseStateInjectionAllowed();
+        $this->assertEquals(self::$DENY_INJECT_DATABASE_STATE_ON_EXCEPTION, $current_state, "by default, we should NOT be able to inject a database state into an exception");
+
+        $this->setDatabaseStateInjectionPermission("this_should_cause_an_exception");
+    }
+
+    public function testInjectMessageIntoException(){
+        $this->setDatabaseStateInjectionPermission(self::$ALLOW_INJECT_DATABASE_STATE_ON_EXCEPTION);
+        $injected_exception_message = 'This text is injected into the exception';
+        try{
+            throw new \Exception("this is the default exception message");
+        } catch(\Exception $e){
+            $exception_with_injected_message = $this->injectMessageIntoException($e, $injected_exception_message);
+            $this->assertContains($injected_exception_message, $exception_with_injected_message->getMessage());
+        }
+    }
+
+    public function testInjectMessageIntoExceptionWithPermissionDenied(){
+        $this->setDatabaseStateInjectionPermission(self::$DENY_INJECT_DATABASE_STATE_ON_EXCEPTION);
+        $injected_exception_message = 'This text is NOT injected into the exception';
+        try{
+            throw new \Exception("this is the default exception message");
+        } catch(\Exception $e){
+            $exception_with_injected_message = $this->injectMessageIntoException($e, $injected_exception_message);
+            $this->assertNotContains($injected_exception_message, $exception_with_injected_message->getMessage());
+        }
+    }
+
+    public function testGetDatabaseState(){
+        $database_state_as_json = $this->getDatabaseState();
+        $this->assertJson($database_state_as_json);
+        $database_state = json_decode($database_state_as_json, true);
+        $database_state = $this->assertDatabaseStateElement('tags', $database_state);
+        $database_state = $this->assertDatabaseStateElement('users', $database_state);
+        $database_state = $this->assertDatabaseStateElement('institutions', $database_state);
+        $database_state = $this->assertDatabaseStateElement('accounts', $database_state);
+        $database_state = $this->assertDatabaseStateElement('account_types', $database_state);
+        $database_state = $this->assertDatabaseStateElement('entries+entry_tags', $database_state);
+        $database_state = $this->assertDatabaseStateElement('attachments', $database_state);
+        $this->assertEmpty($database_state);
+    }
+
+    /**
+     * @param string $element_name
+     * @param array $database_state
+     * @return array
+     */
+    private function assertDatabaseStateElement($element_name, $database_state){
+        $this->assertArrayHasKey($element_name, $database_state);
+        $this->assertTrue(is_array($database_state[$element_name]));
+        unset($database_state[$element_name]);
+        return $database_state;
+    }
+
+}
+


### PR DESCRIPTION
- Moved `initialiseApplication()` and `refreshApplication()` from the TestCase class to the CreatesApplication trait.
- Created a trait that allows us to capture a snapshot of the database when a test fails.
- Activating database state capture for the DeleteAccountTypeTest and PostEntriesTest classes.
- Moved the `use DatabaseMigrations` trait to the TestCase base class. The trait is used in all our tests anyway, it made sense to refactor in this way.