### PR TITLE
Feature/show-account-from-account_type-in-entry-modal

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -77,3 +77,11 @@ $factory->define(App\Attachment::class, function(Faker\Generator $faker){
         'stamp'=>date('Y-m-d H:i:s')
     ];
 });
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+$factory->define(App\User::class, function (Faker\Generator $faker) {
+    return [
+        'name' => $faker->name,
+        'email' => $faker->safeEmail,
+    ];
+});

--- a/public/css/entry-modal.css
+++ b/public/css/entry-modal.css
@@ -27,6 +27,19 @@
     padding: 6px;
 }
 
+#entry-account-name{
+    font-weight: normal;
+    font-size: 11px;
+    line-height: 11px;
+    margin: 3px auto 5px;
+    padding-left: 87px;
+    width: 310px;
+}
+
+#entry-account-name span{
+    padding-left: 2px;
+}
+
 #entry-memo-label {
     vertical-align: top;
 }

--- a/public/js/entry-modal.js
+++ b/public/js/entry-modal.js
@@ -95,12 +95,19 @@ var entryModal = {
         $('#entry-account-type').change(function(){
             var accountTypeId = $(this).val();
             var account = accountTypes.getAccount(accountTypeId);
+            var accountNameParentElement = $('#entry-account-name');
             if(account.hasOwnProperty('name')){
-                $('#entry-account-name').removeClass('hidden');
+                accountNameParentElement.removeClass('hidden');
                 $('#entry-account-name span').text(account.name);
             } else {
-                $('#entry-account-name').addClass('hidden');
+                accountNameParentElement.addClass('hidden');
                 $('#entry-account-name span').text('');
+            }
+
+            if(account.hasOwnProperty('disabled') && account.disabled){
+                accountNameParentElement.removeClass('text-info').addClass('text-muted');
+            } else {
+                accountNameParentElement.removeClass('text-muted').addClass('text-info');
             }
         });
     },

--- a/public/js/entry-modal.js
+++ b/public/js/entry-modal.js
@@ -92,6 +92,17 @@ var entryModal = {
             var value = $(this).val().replace(/[^0-9.]/g, '');
             $(this).val( parseFloat(value).toFixed(2) );
         });
+        $('#entry-account-type').change(function(){
+            var accountTypeId = $(this).val();
+            var account = accountTypes.getAccount(accountTypeId);
+            if(account.hasOwnProperty('name')){
+                $('#entry-account-name').removeClass('hidden');
+                $('#entry-account-name span').text(account.name);
+            } else {
+                $('#entry-account-name').addClass('hidden');
+                $('#entry-account-name span').text('');
+            }
+        });
     },
     initEntryDate: function(){
         var today = new Date();
@@ -132,7 +143,8 @@ var entryModal = {
         $("#entry-date").val(entry.value.entry_date);
         $("#entry-value").val(entry.value.entry_value);
         $("#entry-memo").val(entry.value.memo);
-        $("#entry-account-type").val(entry.value.account_type);
+        $("#entry-account-type").val(entry.value.account_type)
+            .trigger('change'); // show/update account name in modal
         $("input[name='expense-switch']")
             .prop('checked', entry.value.expense)
             .bootstrapSwitch('state', entry.value.expense);
@@ -167,7 +179,8 @@ var entryModal = {
         entryModal.initEntryDate();
         $("#entry-value").val('');
         $("#entry-memo").val('');
-        $("#entry-account-type").val('');
+        $("#entry-account-type").val('')
+            .trigger('change'); // hide/clear account name from display
         $("input[name='expense-switch']").prop('checked', true)
             .bootstrapSwitch('state', true);
         // clear tags input

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -29,6 +29,15 @@ function responseToData(response, responseType){
 var tags = {
     uri: "/api/tags",
     value: [],
+    find: function(id){
+        id = parseInt(id);
+        var foundTags = $.grep(tags.value, function(tag){ return tag.id === id });
+        if(foundTags.length > 0){
+            return foundTags[0];
+        } else {
+            return {};  // could not find a tag associated with the provided ID
+        }
+    },
     load: function(){
         $.ajax({
             url: tags.uri,
@@ -60,14 +69,9 @@ var tags = {
             return element.name;
         });
     },
-    getNamesById: function(tagIds){
-        var tagNames = [];
-        for(i=0; i<tags.value.length; i++){
-            if($.inArray(tags.value[i]['id'], tagIds) !== -1){
-                tagNames.push(tags.value[i]['name']);
-            }
-        }
-        return tagNames;
+    getNameById: function(id){
+        var tag = tags.find(id);
+        return (tag.hasOwnProperty('name')) ? tag.name : '';
     },
     getIdByName: function(tagName){
         var tagObjects = $.grep(tags.value, function(element){
@@ -117,7 +121,8 @@ var accounts = {
     uri: "/api/accounts",
     value: [],
     find: function(id){
-        var foundAccounts = $.grep(accounts.value, function(account){ return account.id == id });
+        id = parseInt(id);
+        var foundAccounts = $.grep(accounts.value, function(account){ return account.id === id });
         if(foundAccounts.length > 0){
             return foundAccounts[0];
         } else {
@@ -156,7 +161,8 @@ var accountTypes = {
     uri: "/api/account-types",
     value: [],
     find: function(id){
-        var foundAccountTypes = $.grep(accountTypes.value, function(accountType){ return accountType.id == id });
+        id = parseInt(id);
+        var foundAccountTypes = $.grep(accountTypes.value, function(accountType){ return accountType.id === id });
         if(foundAccountTypes.length > 0){
             return foundAccountTypes[0];
         } else {
@@ -251,8 +257,8 @@ var entries = {
         entries.clearDisplay();
         $.each(entries.value, function(index, entryObject){
             var displayTags = '';
-            $.each(tags.getNamesById(entryObject.tags), function(id, tagName){
-                displayTags += '<span class="label label-default entry-tag">'+tagName+'</span>';
+            $.each(entryObject.tags, function(id){
+                displayTags += '<span class="label label-default entry-tag">'+tags.getNameById(id)+'</span>';
             });
             $('#entries-display-pane tbody').append(
                 '<tr class="'+(!entryObject.confirm ? 'warning' : (entryObject.expense ? '' : 'success'))+'">' +

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -257,8 +257,8 @@ var entries = {
         entries.clearDisplay();
         $.each(entries.value, function(index, entryObject){
             var displayTags = '';
-            $.each(entryObject.tags, function(id){
-                displayTags += '<span class="label label-default entry-tag">'+tags.getNameById(id)+'</span>';
+            $.each(entryObject.tags, function(id, tagId){
+                displayTags += '<span class="label label-default entry-tag">'+tags.getNameById(tagId)+'</span>';
             });
             $('#entries-display-pane tbody').append(
                 '<tr class="'+(!entryObject.confirm ? 'warning' : (entryObject.expense ? '' : 'success'))+'">' +

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -116,6 +116,14 @@ var institutions = {
 var accounts = {
     uri: "/api/accounts",
     value: [],
+    find: function(id){
+        var foundAccounts = $.grep(accounts.value, function(account){ return account.id == id });
+        if(foundAccounts.length > 0){
+            return foundAccounts[0];
+        } else {
+            return {};  // couldn't find the account associated with the provided ID
+        }
+    },
     load: function(){
         $.ajax({
             url: accounts.uri,
@@ -147,6 +155,14 @@ var accounts = {
 var accountTypes = {
     uri: "/api/account-types",
     value: [],
+    find: function(id){
+        var foundAccountTypes = $.grep(accountTypes.value, function(accountType){ return accountType.id == id });
+        if(foundAccountTypes.length > 0){
+            return foundAccountTypes[0];
+        } else {
+            return {};
+        }
+    },
     load: function(){
         $.ajax({
             url: accountTypes.uri,
@@ -176,14 +192,19 @@ var accountTypes = {
         institutionsPane.displayAccountTypes();
     },
     getNameById: function (accountTypeId) {
-        var accountTypeObjects = $.grep(accountTypes.value, function(element){
-            return element.id === accountTypeId;
-        });
-
-        if(accountTypeObjects.length > 0){
-            return accountTypeObjects[0].type_name;
+        var accountType = accountTypes.find(accountTypeId);
+        if(accountType.hasOwnProperty('type_name')){
+            return accountType.type_name;
         } else {
             return '';
+        }
+    },
+    getAccount: function(accountTypeId){
+        var accountType = accountTypes.find(accountTypeId);
+        if(accountType.hasOwnProperty('account_id')){
+            return accounts.find(accountType.account_id);
+        } else {
+            return {};  // couldn't find the account_type associated with the provided ID
         }
     }
 };

--- a/resources/views/modal/entry.blade.php
+++ b/resources/views/modal/entry.blade.php
@@ -38,6 +38,10 @@
                     <select id="entry-account-type" name="entry-account-type" class="form-control">
                         <option></option>
                     </select>
+                    <div id="entry-account-name" class="text-info hidden text-right">
+                        <strong>Account Name:</strong>
+                        <span></span>
+                    </div>
                 </label>
 
                 <label><span id="entry-memo-label">Memo:</span><textarea id="entry-memo" name="entry-memo" class="form-control"></textarea></label>

--- a/tests/Feature/Api/ListEntriesBase.php
+++ b/tests/Feature/Api/ListEntriesBase.php
@@ -161,7 +161,7 @@ class ListEntriesBase extends TestCase {
                 $generated_disabled_entries,
                 'entry ID:'.$entry_in_response['id']."\ndisabled entries:".json_encode($generated_disabled_entries)."\nresponse entries:".json_encode($entries_in_response)
             );
-            $generated_entry = $generated_entries->where('id', $entry_in_response['id'])->pop();
+            $generated_entry = $generated_entries->where('id', $entry_in_response['id'])->first();
             $this->assertNotEmpty($generated_entry, "Entry in response: ".json_encode($entry_in_response)." not found in generated set: ".$generated_entries->toJson());
             $this->assertInstanceOf(Entry::class, $generated_entry);
             $this->assertEntryNodesExist($entry_in_response);

--- a/tests/Feature/Api/PostEntriesTest.php
+++ b/tests/Feature/Api/PostEntriesTest.php
@@ -75,7 +75,7 @@ class PostEntriesTest extends ListEntriesBase {
         }
 
         // batch of filter requests
-        $batched_filter_details = array_rand($filter_details, 3);
+        $batched_filter_details = $this->_faker->randomElements($filter_details, 3);
         $filter["filtering [".implode(",", $batched_filter_details).']'] = [array_intersect_key($filter_details, array_flip($batched_filter_details))];
 
         // all filter requests
@@ -284,6 +284,7 @@ class PostEntriesTest extends ListEntriesBase {
     /**
      * Because the data provider method is called before the test, we are unlikely to have the same tags setup
      * This method is called at the start of each test and gathers the tags that are available, then assigns them to the "filter" array
+     * account_type and account IDs are also randomly selected and assigned to the "filter" array.
      * @param array $filter_details
      * @return array
      */

--- a/tests/Feature/Api/PostEntriesTest.php
+++ b/tests/Feature/Api/PostEntriesTest.php
@@ -75,7 +75,7 @@ class PostEntriesTest extends ListEntriesBase {
         }
 
         // batch of filter requests
-        $batched_filter_details = $this->_faker->randomElements($filter_details, 3);
+        $batched_filter_details = array_rand($filter_details, 3);   // NOTE: this can't use the faker method. It will cause warnings in tests to occur.
         $filter["filtering [".implode(",", $batched_filter_details).']'] = [array_intersect_key($filter_details, array_flip($batched_filter_details))];
 
         // all filter requests

--- a/tests/InjectDatabaseStateIntoException.php
+++ b/tests/InjectDatabaseStateIntoException.php
@@ -50,17 +50,17 @@ trait InjectDatabaseStateIntoException {
     }
 
     /**
-     * @param \Exception $exception
+     * @param \Exception $original_exception
      * @param string $injectable_message
      * @return \Exception
      */
-    public function injectMessageIntoException($exception, $injectable_message){
+    public function injectMessageIntoException($original_exception, $injectable_message){
         if($this->isDatabaseStateInjectionAllowed()){
-            $exception_message = $exception->getMessage()."\n".$injectable_message;
-            $exception_name = get_class($exception);
-            return new $exception_name($exception_message, 0, $exception);
+            $exception_message = $original_exception->getMessage()."\n".$injectable_message;
+            $exception_name = get_class($original_exception);
+            return new $exception_name($exception_message, null, $original_exception);
         } else {
-            return $exception;
+            return $original_exception;
         }
     }
 


### PR DESCRIPTION
- Fixed bug in the Tests/Feature/Api/ListEntriesBase class where when we perform entry list assertions, we are not slowly erasing the original source of our comparisons.
- Added feature to display account name when an account_type is selected in the entry-modal
- Added `find()` methods to the `tags`, `accounts` and `accountTypes`JavaScript objects in home.js. These allow us to find a tag/account/accountType object base on a provided ID.
- Replaced `tags.getNamesById()` with `tags.getNameById()`, which utilises the new `tags.find()` method. Previous usage of `tags.getNamesById()` has been replaced/updated accordingly.
- Re-adding and updated the factory for the Users model. It seems to have been removed for some reason in the d024cc9 commit.