### PR TITLE
hotfix/null_entry_in_post_entries_test_response

### DIFF
--- a/tests/Feature/Api/PostEntriesTest.php
+++ b/tests/Feature/Api/PostEntriesTest.php
@@ -108,9 +108,11 @@ class PostEntriesTest extends ListEntriesBase {
 
         $generated_entries = $this->batch_generate_entries($generate_entry_count, $generated_account_type->id, $this->convert_filters_to_entry_components($filter_details), true);
         $generated_disabled_entries = $generated_entries->where('disabled', 1);
-        $generated_entries = $generated_entries->sortByDesc('disabled') // sorting so disabled entries are at the start of the collection
-            ->splice($generated_disabled_entries->count()-1);
-        $generate_entry_count -= $generated_disabled_entries->count();
+        if($generated_disabled_entries->count() > 0){   // if there are no disabled entries, then there is no need to do any fancy filtering
+            $generated_entries = $generated_entries->sortByDesc('disabled') // sorting so disabled entries are at the start of the collection
+                ->splice($generated_disabled_entries->count()-1);
+            $generate_entry_count -= $generated_disabled_entries->count();
+        }
 
         if($generate_entry_count < 1){
             // if we only generate entries that have been marked "disabled"


### PR DESCRIPTION
Fixed bug in the `PostEntriesTest::testPostEntries` test. If none of the generated entries were marked as "disabled", then we were slicing to an index of `-1`, which translated to an index of `1`. Fix involves checking if there are any "disabled" entries. If there are, then we can splice, otherwise continue as normal.

Fixes #68 
Fixes #64 