### PR TITLE
feature/rename-entries.account_type

### DIFF
--- a/app/AccountType.php
+++ b/app/AccountType.php
@@ -26,7 +26,7 @@ class AccountType extends BaseModel {
     }
 
     public function entries(){
-        return $this->hasMany('App\Entry', 'account_type');
+        return $this->hasMany('App\Entry', 'account_type_id');
     }
 
 }

--- a/app/Entry.php
+++ b/app/Entry.php
@@ -11,7 +11,7 @@ class Entry extends BaseModel {
 
     protected $table = 'entries';
     protected $fillable = [
-        'entry_date', 'account_type', 'entry_value', 'memo', 'expense', 'confirm', 'disabled', 'disabled_stamp'
+        'entry_date', 'account_type_id', 'entry_value', 'memo', 'expense', 'confirm', 'disabled', 'disabled_stamp'
     ];
     protected $guarded = [
         'id', 'create_stamp', 'modified_stamp'
@@ -26,7 +26,7 @@ class Entry extends BaseModel {
     ];
 
     private static $required_entry_fields = [
-        'account_type',
+        'account_type_id',
         'confirm',
         'disabled',
         'entry_date',
@@ -36,10 +36,10 @@ class Entry extends BaseModel {
     ];
 
     /**
-     * entries.account_type = account_types.id
+     * entries.account_type_id = account_types.id
      */
     public function account_type(){
-        return $this->belongsTo('App\AccountType', 'account_type');
+        return $this->belongsTo('App\AccountType', 'account_type_id');
     }
 
     /**
@@ -127,7 +127,7 @@ class Entry extends BaseModel {
                     $entries_query->where('entries.entry_value', '<=', $filter_constraint);
                     break;
                 case EntryController::FILTER_KEY_ACCOUNT_TYPE:
-                    $entries_query->where('entries.account_type', $filter_constraint);
+                    $entries_query->where('entries.account_type_id', $filter_constraint);
                     break;
                 case EntryController::FILTER_KEY_EXPENSE:
                     if($filter_constraint == true){
@@ -144,7 +144,7 @@ class Entry extends BaseModel {
                     break;
                 case EntryController::FILTER_KEY_ACCOUNT:
                     $entries_query->join('account_types', function($join) use ($filter_constraint){
-                        $join->on('entries.account_type', '=', 'account_types.id')
+                        $join->on('entries.account_type_id', '=', 'account_types.id')
                             ->where('account_types.account_id', $filter_constraint);
                     });
                     break;

--- a/app/Http/Controllers/Api/EntryController.php
+++ b/app/Http/Controllers/Api/EntryController.php
@@ -126,8 +126,8 @@ class EntryController extends Controller {
             );
         }
 
-        // check validity of account_type value
-        $account_type = AccountType::find($entry_data['account_type']);
+        // check validity of account_type_id value
+        $account_type = AccountType::find($entry_data['account_type_id']);
         if(empty($account_type)){
             return response(
                 [self::RESPONSE_SAVE_KEY_ERROR=>self::ERROR_MSG_SAVE_ENTRY_INVALID_ACCOUNT_TYPE, self::RESPONSE_SAVE_KEY_ID=>self::ERROR_ENTRY_ID],
@@ -178,9 +178,9 @@ class EntryController extends Controller {
             );
         }
 
-        // check validity of account_type value
-        if(isset($entry_data['account_type'])){
-            $account_type = AccountType::find($entry_data['account_type']);
+        // check validity of account_type_id value
+        if(isset($entry_data['account_type_id'])){
+            $account_type = AccountType::find($entry_data['account_type_id']);
             if(empty($account_type)){
                 return response(
                     [self::RESPONSE_SAVE_KEY_ERROR => self::ERROR_MSG_SAVE_ENTRY_INVALID_ACCOUNT_TYPE, self::RESPONSE_SAVE_KEY_ID => self::ERROR_ENTRY_ID],

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -60,7 +60,7 @@ $factory->define(App\AccountType::class, function(Faker\Generator $faker){
 $factory->define(App\Entry::class, function(Faker\Generator $faker){
     return [
         'entry_date'=>$faker->date(),
-        'account_type'=>$faker->randomNumber(),
+        'account_type_id'=>$faker->randomNumber(),
         'entry_value'=>$faker->randomFloat(2, 0, 100),  // 0.00 < entry_value < 100.00
         'memo'=>$faker->words(3, true),
         'expense'=>$faker->boolean,

--- a/database/migrations/2017_12_14_062223_rename_account_types_type_name_column_to_name.php
+++ b/database/migrations/2017_12_14_062223_rename_account_types_type_name_column_to_name.php
@@ -1,11 +1,9 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class RenameAccountTypesTypeNameColumnToName extends Migration
-{
+class RenameAccountTypesTypeNameColumnToName extends Migration {
+
     /**
      * Rename account_types.type_name to account_types.name
      *

--- a/database/migrations/2017_12_19_073314_rename_entries_account_type_column_to_account_type_id.php
+++ b/database/migrations/2017_12_19_073314_rename_entries_account_type_column_to_account_type_id.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RenameEntriesAccountTypeColumnToAccountTypeId extends Migration {
+
+    /**
+     * Rename entries.account_type to entries.account_type_id
+     *
+     * @return void
+     */
+    public function up(){
+        Schema::table('entries', function (Blueprint $table) {
+            $table->renameColumn('account_type', 'account_type_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(){
+        Schema::table('entries', function (Blueprint $table) {
+            $table->renameColumn('account_type_id', 'account_type');
+        });
+    }
+
+}

--- a/database/seeds/UiSampleDatabaseSeeder.php
+++ b/database/seeds/UiSampleDatabaseSeeder.php
@@ -43,7 +43,7 @@ class UiSampleDatabaseSeeder extends Seeder {
 
         $entries = collect();
         for($entry_i=0; $entry_i<self::COUNT_ENTRY; $entry_i++){
-            $entry = factory(App\Entry::class)->create(['account_type'=>$faker->randomElement($account_type_ids)]);
+            $entry = factory(App\Entry::class)->create(['account_type_id'=>$faker->randomElement($account_type_ids)]);
             if($faker->boolean){    // randomly assign tags to entries
                 $entry_tag_ids = $faker->randomElements($tag_ids, $faker->numberBetween(1, self::COUNT_TAG));
                 $entry->tags()->attach($entry_tag_ids);

--- a/features/GET_API_ENTRIES.md
+++ b/features/GET_API_ENTRIES.md
@@ -24,7 +24,7 @@ _example output:_
 > **THEN:** receive a 200 status  
 > **AND:** get a json response containing a list of entries  
 > **AND:** in the json is a count of the entries  
-> **AND:** in the entry nodes there are entry details, including "has_attachments", "tags" and "account_type" nodes  
+> **AND:** in the entry nodes there are entry details, including "has_attachments", "tags" and "account_type_id" nodes  
 > **AND:** entry tags node is an array  
 > **AND:** entries marked as "deleted" do not appear
 
@@ -41,7 +41,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 2,
+    "account_type_id": 2,
     "tags": [1, 2, 3]
   },
   "1": {
@@ -54,7 +54,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": false,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 2]
   },
   "2": {
@@ -67,7 +67,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 2,
+    "account_type_id": 2,
     "tags": []
   },
   "3": {
@@ -80,7 +80,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": false,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": []
   },
   "count": 4
@@ -98,7 +98,7 @@ _example output:_
 > **THEN:** receive a 200 status  
 > **AND:** get a json response containing a list of entries  
 > **AND:** in the json is a count of the total non-deleted entries in the database  
-> **AND:** in the entry nodes there are entry details, including "has_attachments", "tags" and "account_type" nodes  
+> **AND:** in the entry nodes there are entry details, including "has_attachments", "tags" and "account_type_id" nodes  
 > **AND:** entry tags node is an array  
 
 _GET /api/entries/ example output:_
@@ -114,7 +114,7 @@ _GET /api/entries/ example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 2,
+    "account_type_id": 2,
     "tags": []
   },
   "1": {
@@ -127,7 +127,7 @@ _GET /api/entries/ example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": false,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 3]
   },
   ...
@@ -141,7 +141,7 @@ _GET /api/entries/ example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 3]
   },
   "count": 127
@@ -161,7 +161,7 @@ _GET /api/entries/1 example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 2,
+    "account_type_id": 2,
     "tags": []
   },
   "51": {
@@ -174,7 +174,7 @@ _GET /api/entries/1 example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": false,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 3]
   },
   ...
@@ -188,7 +188,7 @@ _GET /api/entries/1 example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 3]
   },
   "count": 127
@@ -208,7 +208,7 @@ _GET /api/entries/2 example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 2,
+    "account_type_id": 2,
     "tags": []
   },
   "101": {
@@ -221,7 +221,7 @@ _GET /api/entries/2 example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": false,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 3]
   },
   ...
@@ -235,7 +235,7 @@ _GET /api/entries/2 example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 3]
   },
   "count": 127

--- a/features/GET_API_ENTRY_ENTRYID.md
+++ b/features/GET_API_ENTRY_ENTRYID.md
@@ -34,7 +34,7 @@ _example output:_
   "memo": "entry test",
   "expense": "1",
   "confirm": 0,
-  "account_type": 1,
+  "account_type_id": 1,
   "tags": [
     {"id": 1, "tag": "xxx"},
     {"id": 2, "tag": "yyy"},
@@ -72,7 +72,7 @@ _example output:_
   "memo": "entry test",
   "expense": "1",
   "confirm": 0,
-  "account_type": 1,
+  "account_type_id": 1,
   "tags": [],
   "attachments": [
     {"attachment": "test1.txt", "uuid": "baa9302e-6ebc-437b-b5c7-32075e7a3ddd"},
@@ -106,7 +106,7 @@ _example output:_
   "memo": "entry test",
   "expense": "1",
   "confirm": 0,
-  "account_type": 1,
+  "account_type_id": 1,
   "tags": [
     {"id": 1, "tag": "xxx"},
     {"id": 2, "tag": "yyy"},
@@ -142,7 +142,7 @@ _example output:_
   "memo": "entry test",
   "expense": "1",
   "confirm": 0,
-  "account_type": 1,
+  "account_type_id": 1,
   "tags": [],
   "attachments": [],
   "create_stamp": "1970-01-01T00:00:00+00:00",

--- a/features/POST_API_ENTRIES.md
+++ b/features/POST_API_ENTRIES.md
@@ -45,7 +45,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 2,
+    "account_type_id": 2,
     "tags": [1, 2, 3]
   },
   "1": {
@@ -58,7 +58,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": false,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 2]
   },
   "3": {
@@ -71,7 +71,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 2,
+    "account_type_id": 2,
     "tags": []
   },
   "5": {
@@ -84,7 +84,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": false,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": []
   },
   "count": 4
@@ -124,7 +124,7 @@ _POST /api/entries/0 example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 2,
+    "account_type_id": 2,
     "tags": []
   },
   "1": {
@@ -137,7 +137,7 @@ _POST /api/entries/0 example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": false,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 3]
   },
   ...
@@ -151,7 +151,7 @@ _POST /api/entries/0 example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 3]
   },
   "count": 127
@@ -171,7 +171,7 @@ _POST /api/entries/1 example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 2,
+    "account_type_id": 2,
     "tags": []
   },
   "51": {
@@ -184,7 +184,7 @@ _POST /api/entries/1 example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": false,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 3]
   },
   ...
@@ -198,7 +198,7 @@ _POST /api/entries/1 example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 3]
   },
   "count": 127
@@ -218,7 +218,7 @@ _POST /api/entries/2 example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 2,
+    "account_type_id": 2,
     "tags": []
   },
   "101": {
@@ -231,7 +231,7 @@ _POST /api/entries/2 example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": false,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 3]
   },
   ...
@@ -245,7 +245,7 @@ _POST /api/entries/2 example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 3]
   },
   "count": 127
@@ -314,7 +314,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 2,
+    "account_type_id": 2,
     "tags": [1, 3]
   },
   "count": 1
@@ -351,7 +351,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 2,
+    "account_type_id": 2,
     "tags": [1, 2, 3]
   },
   "1": {
@@ -364,7 +364,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": false,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 2]
   },
   "3": {
@@ -377,7 +377,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 2,
+    "account_type_id": 2,
     "tags": []
   },
   "5": {
@@ -390,7 +390,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": false,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": []
   },
   "count": 4
@@ -427,7 +427,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 2,
+    "account_type_id": 2,
     "tags": [1, 2, 3]
   },
   "1": {
@@ -440,7 +440,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": false,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": [1, 2]
   },
   "3": {
@@ -453,7 +453,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": true,
-    "account_type": 2,
+    "account_type_id": 2,
     "tags": []
   },
   "5": {
@@ -466,7 +466,7 @@ _example output:_
     "create_stamp": "1970-01-01 00:00:00",
     "modified_stamp": "1970-01-01 00:00:00",
     "has_attachments": false,
-    "account_type": 1,
+    "account_type_id": 1,
     "tags": []
   },
   "count": 4

--- a/features/POST_API_ENTRY.md
+++ b/features/POST_API_ENTRY.md
@@ -101,7 +101,7 @@ example output:
   "memo": "entry test",
   "expense": 1,
   "confirm": 0,
-  "account_type": 3,
+  "account_type_id": 3,
   "tags": [],
   "attachments": [],
   "create_stamp": "1970-01-01T00:00:00+00:00",
@@ -158,12 +158,8 @@ example output:
   "memo": "entry test",
   "expense": 1,
   "confirm": 0,
-  "account_type": 3,
-  "tags": [
-    1,
-    2,
-    3
-  ],
+  "account_type_id": 3,
+  "tags": [1, 2, 3],
   "attachments": [],
   "create_stamp": "1970-01-01T00:00:00+00:00",
   "modified_stamp": "1970-01-01T00:00:01+00:00"
@@ -200,7 +196,7 @@ example output:
   "memo": "entry test",
   "expense": 1,
   "confirm": 0,
-  "account_type": 1,
+  "account_type_id": 1,
   "tags": [],
   "attachments": [
     {"attachment": "test1.txt", "uuid": "baa9302e-6ebc-437b-b5c7-32075e7a3ddd"},

--- a/features/PUT_API_ENTRY_ENTRYID.md
+++ b/features/PUT_API_ENTRY_ENTRYID.md
@@ -23,7 +23,7 @@ example output:
 > **GIVEN:** you wish to update an entry  
 > **AND:** you have an existing entry  
 > **AND:** you have an entry ID  
-> **AND:** you have entry data that includes a new account_type value  
+> **AND:** you have entry data that includes a new account_type_id value  
 > **AND:** account_type does not exist  
 > **WHEN:** sending a PUT request to /api/entry  
 > **AND:** you send the data as json in the put body  
@@ -109,7 +109,7 @@ example output:
   "memo": "entry test",
   "expense": 1,
   "confirm": 0,
-  "account_type": 3,
+  "account_type_id": 3,
   "tags": [],
   "attachments": [],
   "create_stamp": "1970-01-01T00:00:00+00:00",
@@ -226,7 +226,7 @@ _example output:_
   "memo": "entry test",
   "expense": 1,
   "confirm": 0,
-  "account_type": 3,
+  "account_type_id": 3,
   "tags": [],
   "attachments": [],
   "create_stamp": "1970-01-01T00:00:00+00:00",
@@ -270,12 +270,8 @@ example output:
   "memo": "entry test",
   "expense": 1,
   "confirm": 0,
-  "account_type": 3,
-  "tags": [
-    1,
-    2,
-    3
-  ],
+  "account_type_id": 3,
+  "tags": [1, 2, 3],
   "attachments": [],
   "create_stamp": "1970-01-01T00:00:00+00:00",
   "modified_stamp": "1970-01-01T00:00:01+00:00"
@@ -314,7 +310,7 @@ example output:
   "memo": "entry test",
   "expense": 1,
   "confirm": 0,
-  "account_type": 1,
+  "account_type_id": 1,
   "tags": [],
   "attachments": [
     {"attachment": "test1.txt", "uuid": "baa9302e-6ebc-437b-b5c7-32075e7a3ddd"},
@@ -354,7 +350,7 @@ example output:
   "memo": "entry test",
   "expense": 1,
   "confirm": 0,
-  "account_type": 1,
+  "account_type_id": 1,
   "tags": [],
   "attachments": [],
   "create_stamp": "1970-01-01T00:00:00+00:00",

--- a/public/js/entry-modal.js
+++ b/public/js/entry-modal.js
@@ -150,7 +150,7 @@ var entryModal = {
         $("#entry-date").val(entry.value.entry_date);
         $("#entry-value").val(entry.value.entry_value);
         $("#entry-memo").val(entry.value.memo);
-        $("#entry-account-type").val(entry.value.account_type)
+        $("#entry-account-type").val(entry.value.account_type_id)
             .trigger('change'); // show/update account name in modal
         $("input[name='expense-switch']")
             .prop('checked', entry.value.expense)
@@ -229,7 +229,7 @@ var entryModal = {
             id: $('#entry-id').val(),
             entry_date: $('#entry-date').val(),
             entry_value: $('#entry-value').val(),
-            account_type: parseInt($('#entry-account-type').val()),
+            account_type_id: parseInt($('#entry-account-type').val()),
             memo: $('#entry-memo').val(),
             expense: $('input[name="expense-switch"]').prop('checked'),
             confirm: $('#entry-confirm').prop('checked'),

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -269,7 +269,7 @@ var entries = {
                 '<td>'+entryObject.memo+'</td>' +
                 '<td class="value-col">'+(entryObject.expense ? '' : '$'+entryObject.entry_value)+'</td>' +
                 '<td class="value-col">'+(entryObject.expense ? '$'+entryObject.entry_value : '')+'</td>' +
-                '<td>'+accountTypes.getNameById(entryObject.account_type)+'</td>' +
+                '<td>'+accountTypes.getNameById(entryObject.account_type_id)+'</td>' +
                 '<td><span class="glyphicon glyphicon-'+(entryObject.has_attachments ? 'check' : 'unchecked')+'" aria-hidden="true"></span></td>' +
                 '<td>'+displayTags+'</td>' +
                 '</tr>'

--- a/tests/Feature/Api/DeleteAttachmentTest.php
+++ b/tests/Feature/Api/DeleteAttachmentTest.php
@@ -32,7 +32,7 @@ class DeleteAttachmentTest extends TestCase {
         // GIVEN
         $generated_account = factory(Account::class)->create();
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$generated_account->id]);
-        $generated_entry = factory(Entry::class)->create(['account_type'=>$generated_account_type->id]);
+        $generated_entry = factory(Entry::class)->create(['account_type_id'=>$generated_account_type->id]);
         $generated_attachment = factory(Attachment::class)->create(['entry_id'=>$generated_entry->id]);
 
         // WHEN

--- a/tests/Feature/Api/DeleteEntryTest.php
+++ b/tests/Feature/Api/DeleteEntryTest.php
@@ -18,7 +18,7 @@ class DeleteEntryTest extends TestCase {
         // GIVEN
         $generated_account = factory(Account::class)->create();
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$generated_account->id]);
-        $entry = factory(Entry::class)->create(['account_type'=>$generated_account_type->id]);
+        $entry = factory(Entry::class)->create(['account_type_id'=>$generated_account_type->id]);
 
         // WHEN
         $get_response1 = $this->get($this->_base_uri.$entry->id);

--- a/tests/Feature/Api/GetEntriesTest.php
+++ b/tests/Feature/Api/GetEntriesTest.php
@@ -102,7 +102,7 @@ class GetEntriesTest extends ListEntriesBase {
         // GIVEN
         $table = with(new Entry)->getTable();
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
-        $generated_entries = factory(Entry::class, EntryController::MAX_ENTRIES_IN_RESPONSE)->make(['account_type'=>$generated_account_type->id]);
+        $generated_entries = factory(Entry::class, EntryController::MAX_ENTRIES_IN_RESPONSE)->make(['account_type_id'=>$generated_account_type->id]);
         // generating entries in batches and using database insert methods because it's faster
         for($i=0; $i<($entry_count/EntryController::MAX_ENTRIES_IN_RESPONSE); $i++){
             DB::table($table)->insert($generated_entries->toArray());

--- a/tests/Feature/Api/GetEntryTest.php
+++ b/tests/Feature/Api/GetEntryTest.php
@@ -46,7 +46,7 @@ class GetEntryTest extends TestCase {
         // GIVEN
         $generated_account = factory(Account::class)->create();
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$generated_account->id]);
-        $generated_entry = factory(Entry::class)->create(['account_type'=>$generated_account_type->id]);
+        $generated_entry = factory(Entry::class)->create(['account_type_id'=>$generated_account_type->id]);
         $generated_tags_as_array = $this->generateTagsAndOutputAsArray($generated_entry);
         $generated_attachments_as_array = $this->generateAttachmentsAndOutputAsArray($generated_entry->id);
 
@@ -67,7 +67,7 @@ class GetEntryTest extends TestCase {
         // GIVEN
         $generated_account = factory(Account::class)->create();
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$generated_account->id]);
-        $generated_entry = factory(Entry::class)->create(['account_type'=>$generated_account_type->id]);
+        $generated_entry = factory(Entry::class)->create(['account_type_id'=>$generated_account_type->id]);
         $generated_attachments_as_array = $this->generateAttachmentsAndOutputAsArray($generated_entry->id);
 
         // WHEN
@@ -88,7 +88,7 @@ class GetEntryTest extends TestCase {
         // GIVEN
         $generated_account = factory(Account::class)->create();
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$generated_account->id]);
-        $generated_entry = factory(Entry::class)->create(['account_type'=>$generated_account_type->id]);
+        $generated_entry = factory(Entry::class)->create(['account_type_id'=>$generated_account_type->id]);
         $generated_tags_as_array = $this->generateTagsAndOutputAsArray($generated_entry);
 
         // WHEN
@@ -109,7 +109,7 @@ class GetEntryTest extends TestCase {
         // GIVEN
         $generated_account = factory(Account::class)->create();
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$generated_account->id]);
-        $generated_entry = factory(Entry::class)->create(['account_type'=>$generated_account_type->id]);
+        $generated_entry = factory(Entry::class)->create(['account_type_id'=>$generated_account_type->id]);
 
         // WHEN
         $response = $this->get($this->_base_uri.$generated_entry->id);
@@ -129,7 +129,7 @@ class GetEntryTest extends TestCase {
         // GIVEN
         $generated_account = factory(Account::class)->create();
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$generated_account->id]);
-        $generated_entry = factory(Entry::class)->create(['disabled'=>1, 'account_type'=>$generated_account_type->id]);
+        $generated_entry = factory(Entry::class)->create(['disabled'=>1, 'account_type_id'=>$generated_account_type->id]);
 
         // WHEN
         $response = $this->get($this->_base_uri.$generated_entry->id);
@@ -185,7 +185,7 @@ class GetEntryTest extends TestCase {
         $this->assertArrayHasKey('memo', $entry_nodes);
         $this->assertArrayHasKey('expense', $entry_nodes);
         $this->assertArrayHasKey('confirm', $entry_nodes);
-        $this->assertArrayHasKey('account_type', $entry_nodes);
+        $this->assertArrayHasKey('account_type_id', $entry_nodes);
         $this->assertArrayHasKey('create_stamp', $entry_nodes);
         $this->assertArrayHasKey('modified_stamp', $entry_nodes);
         $this->assertArrayHasKey('tags', $entry_nodes);
@@ -204,7 +204,7 @@ class GetEntryTest extends TestCase {
         $this->assertEquals($generated_entry->memo, $response_body_as_array['memo'], $failure_message);
         $this->assertEquals($generated_entry->expense, $response_body_as_array['expense'], $failure_message);
         $this->assertEquals($generated_entry->confirm, $response_body_as_array['confirm'], $failure_message);
-        $this->assertEquals($generated_entry->account_type, $response_body_as_array['account_type'], $failure_message);
+        $this->assertEquals($generated_entry->account_type_id, $response_body_as_array['account_type_id'], $failure_message);
         $this->assertDateFormat($response_body_as_array['create_stamp'], Carbon::ATOM, $failure_message."\nfor these value to equal, PHP & MySQL timestamps must be the same");
         $this->assertDateFormat($response_body_as_array['modified_stamp'], Carbon::ATOM, $failure_message."\nfor these value to equal, PHP & MySQL timestamps must be the same");
         $this->assertDatetimeWithinOneSecond($generated_entry->create_stamp, $response_body_as_array['create_stamp'], $failure_message."\nfor these value to equal, PHP & MySQL timestamps must be the same");

--- a/tests/Feature/Api/ListEntriesBase.php
+++ b/tests/Feature/Api/ListEntriesBase.php
@@ -53,7 +53,7 @@ class ListEntriesBase extends TestCase {
      * @return Entry
      */
     protected function generate_entry_record($account_type_id, $entry_disabled, $override_entry_components=[]){
-        $default_entry_data = ['account_type'=>$account_type_id, 'disabled'=>$entry_disabled];
+        $default_entry_data = ['account_type_id'=>$account_type_id, 'disabled'=>$entry_disabled];
         $new_entry_data = array_merge($default_entry_data, $override_entry_components);
         unset($new_entry_data['tags']);
         unset($new_entry_data['has_attachments']);
@@ -113,7 +113,7 @@ class ListEntriesBase extends TestCase {
         $this->assertArrayHasKey('entry_date', $entry_nodes);
         $this->assertArrayHasKey('entry_value', $entry_nodes);
         $this->assertArrayHasKey('memo', $entry_nodes);
-        $this->assertArrayHasKey('account_type', $entry_nodes);
+        $this->assertArrayHasKey('account_type_id', $entry_nodes);
         $this->assertArrayHasKey('expense', $entry_nodes);
         $this->assertArrayHasKey('confirm', $entry_nodes);
         $this->assertArrayHasKey('create_stamp', $entry_nodes);
@@ -131,7 +131,7 @@ class ListEntriesBase extends TestCase {
         $this->assertEquals($generated_entry->entry_date, $entry_nodes['entry_date'], $failure_msg);
         $this->assertEquals($generated_entry->entry_value, $entry_nodes['entry_value'], $failure_msg);
         $this->assertEquals($generated_entry->memo, $entry_nodes['memo'], $failure_msg);
-        $this->assertEquals($generated_entry->account_type, $entry_nodes['account_type'], $failure_msg);
+        $this->assertEquals($generated_entry->account_type_id, $entry_nodes['account_type_id'], $failure_msg);
         $this->assertEquals($generated_entry->expense, $entry_nodes['expense'], $failure_msg);
         $this->assertEquals($generated_entry->confirm, $entry_nodes['confirm'], $failure_msg);
         $this->assertDateFormat($entry_nodes['create_stamp'], Carbon::ATOM, $failure_msg);

--- a/tests/Feature/Api/PostEntriesTest.php
+++ b/tests/Feature/Api/PostEntriesTest.php
@@ -11,7 +11,7 @@ class PostEntriesTest extends ListEntriesBase {
 
     public function setUp(){
         parent::setUp();
-        $this->setDatabaseStateInjectionPermission(self::$ALLOW_INJECT_DATABASE_STATE_ON_EXCEPTION);
+        $this->setDatabaseStateInjectionPermission(self::$DENY_INJECT_DATABASE_STATE_ON_EXCEPTION);
     }
 
     public function providerPostEntriesFilter(){
@@ -330,7 +330,7 @@ class PostEntriesTest extends ListEntriesBase {
                     $entry_components['entry_value'] = $constraint;
                     break;
                 case EntryController::FILTER_KEY_ACCOUNT_TYPE:
-                    $entry_components[$filter_name] = $constraint;
+                    $entry_components['account_type_id'] = $constraint;
                     break;
                 case EntryController::FILTER_KEY_EXPENSE:
                     if($constraint == true){

--- a/tests/Feature/Api/PostEntriesTest.php
+++ b/tests/Feature/Api/PostEntriesTest.php
@@ -11,7 +11,7 @@ class PostEntriesTest extends ListEntriesBase {
 
     public function setUp(){
         parent::setUp();
-        $this->setDatabaseStateInjectionPermission(self::$DENY_INJECT_DATABASE_STATE_ON_EXCEPTION);
+        $this->setDatabaseStateInjectionPermission(self::$ALLOW_INJECT_DATABASE_STATE_ON_EXCEPTION);
     }
 
     public function providerPostEntriesFilter(){

--- a/tests/Feature/Api/PostEntryTest.php
+++ b/tests/Feature/Api/PostEntryTest.php
@@ -107,7 +107,7 @@ class PostEntryTest extends TestCase {
         $generated_account = factory(Account::class)->create();
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$generated_account->id]);
         $generated_entry_data = $this->generateEntryData();
-        $generated_entry_data['account_type'] = $generated_account_type->id;
+        $generated_entry_data['account_type_id'] = $generated_account_type->id;
 
         // WHEN
         $get_account_response1 = $this->get('/api/account/'.$generated_account->id);
@@ -140,7 +140,7 @@ class PostEntryTest extends TestCase {
         $this->assertEquals($generated_entry_data['memo'], $get_entry_response_as_array['memo']);
         $this->assertEquals($generated_entry_data['expense'], $get_entry_response_as_array['expense']);
         $this->assertEquals($generated_entry_data['confirm'], $get_entry_response_as_array['confirm']);
-        $this->assertEquals($generated_entry_data['account_type'], $get_entry_response_as_array['account_type']);
+        $this->assertEquals($generated_entry_data['account_type_id'], $get_entry_response_as_array['account_type_id']);
 
         // WHEN
         $get_account_response2 = $this->get('/api/account/'.$generated_account->id);
@@ -169,7 +169,7 @@ class PostEntryTest extends TestCase {
         $generated_entry_data = $this->generateEntryData();
         $generated_entry_data['tags'] = [$non_existent_tag_id];
         $generated_entry_data['tags'] = array_merge($generated_entry_data['tags'], $generated_tag_ids);
-        $generated_entry_data['account_type'] = $generated_account_type->id;
+        $generated_entry_data['account_type_id'] = $generated_account_type->id;
 
         // WHEN
         $post_response = $this->json('POST', $this->_base_uri, $generated_entry_data);
@@ -192,7 +192,7 @@ class PostEntryTest extends TestCase {
         $this->assertEquals($generated_entry_data['memo'], $get_response_as_array['memo'], $entry_failure_message);
         $this->assertEquals($generated_entry_data['expense'], $get_response_as_array['expense'], $entry_failure_message);
         $this->assertEquals($generated_entry_data['confirm'], $get_response_as_array['confirm'], $entry_failure_message);
-        $this->assertEquals($generated_entry_data['account_type'], $get_response_as_array['account_type'], $entry_failure_message);
+        $this->assertEquals($generated_entry_data['account_type_id'], $get_response_as_array['account_type_id'], $entry_failure_message);
         $this->assertTrue(is_array($get_response_as_array['tags']), $entry_failure_message);
         $this->assertNotEmpty($get_response_as_array['tags'], $entry_failure_message);
         $this->assertFalse(in_array($non_existent_tag_id, $get_response_as_array['tags']), $entry_failure_message);
@@ -212,7 +212,7 @@ class PostEntryTest extends TestCase {
         $generated_account = factory(Account::class)->create();
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$generated_account->id]);
         $generated_entry_data = $this->generateEntryData();
-        $generated_entry_data['account_type'] = $generated_account_type->id;
+        $generated_entry_data['account_type_id'] = $generated_account_type->id;
         $generated_entry_data['attachments'] = [];
         foreach($generated_attachments as $generated_attachment){
             $generated_entry_data['attachments'][] = [
@@ -243,7 +243,7 @@ class PostEntryTest extends TestCase {
         $this->assertEquals($generated_entry_data['memo'], $get_response_as_array['memo']);
         $this->assertEquals($generated_entry_data['expense'], $get_response_as_array['expense']);
         $this->assertEquals($generated_entry_data['confirm'], $get_response_as_array['confirm']);
-        $this->assertEquals($generated_entry_data['account_type'], $get_response_as_array['account_type']);
+        $this->assertEquals($generated_entry_data['account_type_id'], $get_response_as_array['account_type_id']);
         $this->assertArrayHasKey('attachments', $get_response_as_array);
         $this->assertTrue(is_array($get_response_as_array['attachments']));
         $this->assertNotEmpty($get_response_as_array['attachments']);
@@ -259,7 +259,7 @@ class PostEntryTest extends TestCase {
     private function generateEntryData(){
         $entry_data = factory(Entry::class)->make();
         return [
-            'account_type'=>$entry_data->account_type,
+            'account_type_id'=>$entry_data->account_type,
             'confirm'=>$entry_data->confirm,
             'entry_date'=>$entry_data->entry_date,
             'entry_value'=>$entry_data->entry_value,

--- a/tests/Feature/Api/PostEntryTest.php
+++ b/tests/Feature/Api/PostEntryTest.php
@@ -259,7 +259,7 @@ class PostEntryTest extends TestCase {
     private function generateEntryData(){
         $entry_data = factory(Entry::class)->make();
         return [
-            'account_type_id'=>$entry_data->account_type,
+            'account_type_id'=>$entry_data->account_type_id,
             'confirm'=>$entry_data->confirm,
             'entry_date'=>$entry_data->entry_date,
             'entry_value'=>$entry_data->entry_value,

--- a/tests/Feature/Api/PutEntryTest.php
+++ b/tests/Feature/Api/PutEntryTest.php
@@ -25,7 +25,7 @@ class PutEntryTest extends TestCase {
         // GIVEN - for all tests
         $this->_generated_account = factory(Account::class)->create();
         $this->_generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
-        $this->_generated_entry = factory(Entry::class)->create(['account_type'=>$this->_generated_account_type->id]);
+        $this->_generated_entry = factory(Entry::class)->create(['account_type_id'=>$this->_generated_account_type->id]);
     }
 
     public function testUpdateEntryWithoutProvidingData(){
@@ -48,9 +48,9 @@ class PutEntryTest extends TestCase {
 
         $entry_data = factory(Entry::class)->make();
         $entry_data = $entry_data->toArray();
-        // make sure account_type value that does not exist
-        while($entry_data['account_type'] == $this->_generated_account_type->id){
-            $entry_data['account_type'] = $faker->randomDigitNotNull;
+        // make sure account_type_id value that does not exist
+        while($entry_data['account_type_id'] == $this->_generated_account_type->id){
+            $entry_data['account_type_id'] = $faker->randomDigitNotNull;
         }
 
         // WHEN
@@ -71,7 +71,7 @@ class PutEntryTest extends TestCase {
             // with the pre-generated entry
             $entry_id = $faker->randomNumber();
         }while($entry_id == $this->_generated_entry->id);
-        $entry_data = factory(Entry::class)->make(['account_type'=>$this->_generated_account_type->id]);
+        $entry_data = factory(Entry::class)->make(['account_type_id'=>$this->_generated_account_type->id]);
         $entry_data = $entry_data->toArray();
 
         // WHEN
@@ -191,7 +191,7 @@ class PutEntryTest extends TestCase {
         $required_entry_fields = Entry::get_fields_required_for_update();
         unset($required_entry_fields[array_search('disabled', $required_entry_fields)]);
         unset($required_entry_fields[array_search('entry_value', $required_entry_fields)]);
-        unset($required_entry_fields[array_search('account_type', $required_entry_fields)]);
+        unset($required_entry_fields[array_search('account_type_id', $required_entry_fields)]);
         $required_entry_fields = array_values($required_entry_fields);  // do this to reset array index after unset
         $generated_entry_data1 = factory(Entry::class)->make();
         $generated_entry_data2 = factory(Entry::class)->make();
@@ -367,7 +367,7 @@ class PutEntryTest extends TestCase {
         $this->assertEquals($put_entry_data['memo'], $get_response_as_array['memo'], $get_response->getContent());
         $this->assertEquals($put_entry_data['expense'], $get_response_as_array['expense'], $get_response->getContent());
         $this->assertEquals($put_entry_data['confirm'], $get_response_as_array['confirm'], $get_response->getContent());
-        $this->assertEquals($put_entry_data['account_type'], $get_response_as_array['account_type'], $get_response->getContent());
+        $this->assertEquals($put_entry_data['account_type_id'], $get_response_as_array['account_type_id'], $get_response->getContent());
     }
 
     /**


### PR DESCRIPTION
Renamed `entries.account_type` to `entries.account_type_id`

Resolves #65 