### PR TITLE
support/fix_entries_overview_display_after_save

### DIFF
--- a/public/js/home.js
+++ b/public/js/home.js
@@ -409,11 +409,7 @@ var entry = {
         });
     },
     completeEntryUpdate: function(){
-        if(filterModal.active){
-            filterModal.submit();
-        } else {
-            entries.reload(paginate.current);
-        }
+        entries.reload(paginate.current, paginate.filterState);
         institutions.load();
         accounts.load();
         institutionsPane.displayAccountTypes();


### PR DESCRIPTION
Fixed a bug where saving an entry results in the entries being displayed reverts to the overview listings. Regardless of filtered state.