### PR TITLE
Support/account types in institue pane disappear after saving an entry

### DIFF
--- a/public/js/home.js
+++ b/public/js/home.js
@@ -410,7 +410,8 @@ var entry = {
     },
     completeEntryUpdate: function(){
         entries.reload(paginate.current, paginate.filterState);
-        institutions.load();
+        institutionsPane.clear();
+        institutionsPane.displayInstitutions();
         accounts.load();
         institutionsPane.displayAccountTypes();
     }

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -409,11 +409,22 @@ var entry = {
         });
     },
     completeEntryUpdate: function(){
+        // re-display entries
         entries.reload(paginate.current, paginate.filterState);
+        // re-display institutes-pane contents
         institutionsPane.clear();
         institutionsPane.displayInstitutions();
         accounts.load();
         institutionsPane.displayAccountTypes();
+
+        var intervalSetAccountActive = setInterval(function(){
+            // need to wait for the accounts to be re-displayed
+            if(institutionsPane.accountsDisplayed){
+                var accountId = ($.isEmptyObject(paginate.filterState)) ? '' : paginate.filterState.account;
+                institutionsPane.setActiveState(accountId);
+                clearInterval(intervalSetAccountActive);    // stops interval from running again
+            }
+        }, 50);
     }
 };
 

--- a/public/js/institutions-pane.js
+++ b/public/js/institutions-pane.js
@@ -36,14 +36,13 @@ var institutionsPane = {
 
                 // display account related entries on click
                 $('#account-id-'+accountObject.id).click(function(){
-                    filterModal.active = false; // no longer filtering
                     paginate.current = 0;   // reset current "page number"
                     var accountFilterParameters = $.extend(true, {}, defaultFilterParameters);
                     accountFilterParameters.account = accountObject.id;
                     entries.filter(accountFilterParameters);
                     // assign active class after click event occurs
                     institutionsPane.clearActiveState();
-                    $(this).addClass('active');
+                    institutionsPane.setActiveState(accountFilterParameters.account);
                 });
             });
             institutionsPane.accountsDisplayed = true;
@@ -81,12 +80,22 @@ var institutionsPane = {
         institutionsPane.institutionsDisplayed = false;
         institutionsPane.accountsDisplayed = false;
         institutionsPane.closedAccountsDisplayed = false;
-        $('.institutions-pane-institution').remove();
         $('.institutions-pane-account').remove();
+        $('.institutions-pane-institution').remove();
     },
     clearActiveState: function(){
         $('#entry-overview').removeClass('active');
         $('.institutions-pane-account').removeClass('active');
+    },
+    setActiveState: function(accountId){
+        if(!$.isNumeric(accountId)){
+            $('#entry-overview').addClass('active');
+        } else {
+            $('#account-id-'+accountId)
+                .addClass('active')
+                .parents('.institutions-pane-collapse')
+                .collapse('show');
+        }
     }
 };
 
@@ -107,7 +116,7 @@ $(document).ready(function(){
         paginate.current = 0;
         entries.load();
         institutionsPane.clearActiveState();
-        $('#entry-overview').addClass('active');
+        institutionsPane.setActiveState();
         $('.institutions-pane-collapse.in').collapse('hide');
     });
 });

--- a/public/js/paginate.js
+++ b/public/js/paginate.js
@@ -1,6 +1,6 @@
 var paginate = {
     current: 0,
-    filterState: {},
+    filterState: {},    // see filter-modal.js:defaultFilterParameters for expected nodes
     init: function(){
         $("#next").click(paginate.next);
         $("#prev").click(paginate.previous);


### PR DESCRIPTION
- When saving an entry, we already have the institutions in memory. Just like account-types, there is no need to re-fetch them. Only accounts are updated and so only they should be fetched. So now we're clearing the institutions-pane and reloading everything (except accounts) from memory.
- After saving an entry and the institutions-pane is reloaded, we want to be able to continue to show which account (if any) was selected prior to saving said entry.

Resolves #86 