### PR TITLE
feature/update-attachment-upload-messages

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,7 +4,9 @@ namespace App\Exceptions;
 
 use Exception;
 use Illuminate\Auth\AuthenticationException;
+use Illuminate\Session\TokenMismatchException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use \Symfony\Component\HttpFoundation\Response as HttpStatus;
 
 class Handler extends ExceptionHandler
 {
@@ -42,9 +44,13 @@ class Handler extends ExceptionHandler
      * @param  \Exception  $exception
      * @return \Illuminate\Http\Response
      */
-    public function render($request, Exception $exception)
-    {
-        return parent::render($request, $exception);
+    public function render($request, Exception $exception){
+        if ($exception instanceof TokenMismatchException || $request->is('attachment/upload')){
+            // handle TokenMismatchException's for attachment/upload
+            return response(['error'=>"token mis-match"],HttpStatus::HTTP_UNAUTHORIZED);
+        } else {
+            return parent::render($request, $exception);
+        }
     }
 
     /**

--- a/app/Http/Controllers/Api/AttachmentController.php
+++ b/app/Http/Controllers/Api/AttachmentController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Api;
 
-use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 
 use App\Attachment;

--- a/app/Http/Controllers/Web/AttachmentController.php
+++ b/app/Http/Controllers/Web/AttachmentController.php
@@ -3,9 +3,9 @@
 namespace App\Http\Controllers\Web;
 
 use App\Attachment;
-use Response;
-use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 use Ramsey\Uuid\Uuid;
@@ -82,10 +82,11 @@ class AttachmentController extends Controller {
     }
 
     public function deleteUpload(Request $request){
-        if(empty($request->input('filename'))){
+        if(empty($request->input('filename')) || empty($request->input('uuid'))){
             return response('', HttpStatus::HTTP_BAD_REQUEST);
         } else {
             $attachment = new Attachment();
+            $attachment->uuid = $request->input('uuid');
             $attachment->name = $request->input('filename');
             if($attachment->storage_exists(true)){
                 $attachment->storage_delete(true);

--- a/public/js/entry-modal.js
+++ b/public/js/entry-modal.js
@@ -47,7 +47,8 @@ $('#attachment-uploader').uploadFile({
             method: 'delete',
             data: {
                 _token: uploadToken,
-                filename: attachment.tmp_filename
+                uuid: attachment.uuid,
+                filename: attachment.name
             },
             dataType: "json",
             statusCode: {
@@ -57,6 +58,9 @@ $('#attachment-uploader').uploadFile({
                 400: function(){
                     notice.display(notice.typeWarning, "Error occurred while attempting to delete attachment");
                     return false;
+                },
+                401: function(){
+                    notice.display(notice.typeError, "Failed to delete attachment due to expired session. Refresh page.")
                 },
                 404: function(){
                     notice.display(notice.typeInfo, "Attachment not found");


### PR DESCRIPTION
- Fixed bug with `DELETE /attachment/upload`.
- Handling token mis-match errors for the `attachment/upload` path.

Resolves #81 