### PR TITLE
feature/schedule-clear-tmp_uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ MOST_RECENT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
 git checkout -q tags/$MOST_RECENT_TAG
 php artisan app:version $MOST_RECENT_TAG
 
-
 # should it be required, i.e. new packages
 # development
 composer update
@@ -98,6 +97,15 @@ That being said, there are certainly variables that should be modified at this p
 - `DB_DATABASE`
 - `DB_USERNAME`
 - `DB_PASSWORD`
+
+### Scheduled tasks Setup
+You will need to add the following Cron entry to your server.
+```bash
+* * * * * php /path-to-your-project/artisan schedule:run >> /dev/null 2>&1
+```
+This Cron will call the Laravel command scheduler every minute. When the `schedule:run` command is executed, Laravel will evaluate your scheduled tasks and runs the tasks that are due.  
+Here is a list of commands that will _scheduled_ as part of this setup:  
+- `artisan storage:clear-tmp-uploads`
 
 ## Testing
 This project has been setup to use [travis-ci](https://travis-ci.org/jdenoc/money-tracker) for continuous integration testing. If you wish to test locally, here are some steps to follow:

--- a/app/Console/Commands/AppVersion.php
+++ b/app/Console/Commands/AppVersion.php
@@ -29,15 +29,6 @@ class AppVersion extends Command {
     protected $description = 'Get/Set application version';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct(){
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/ClearTmpUploads.php
+++ b/app/Console/Commands/ClearTmpUploads.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Attachment;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class ClearTmpUploads extends Command {
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'storage:clear-tmp-uploads';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clears the files from the storage/app/tmp_uploads directory';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle(){
+        $tmp_upload_file_count = 0;
+        $tmp_upload_files = Storage::files(Attachment::STORAGE_TMP_UPLOAD);
+        foreach($tmp_upload_files as $tmp_upload_file){
+            if(strpos($tmp_upload_file, 'gitignore') !== false){
+                continue;   // don't delete .gitignore file
+            }
+            $deleted = Storage::delete($tmp_upload_file);
+            if($deleted){
+                $tmp_upload_file_count++;
+            }
+        }
+
+        $this->info($tmp_upload_file_count." files deleted from ".Attachment::STORAGE_TMP_UPLOAD);
+    }
+
+}

--- a/app/Console/Commands/TravisCi.php
+++ b/app/Console/Commands/TravisCi.php
@@ -23,13 +23,6 @@ class TravisCi extends Command {
     protected $description = 'Outputs details needed for travis-ci builds';
 
     /**
-     * Create a new command instance.
-     */
-    public function __construct(){
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      */
     public function handle(){

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -14,7 +14,8 @@ class Kernel extends ConsoleKernel {
      */
     protected $commands = [
         Commands\TravisCi::class,
-        Commands\AppVersion::class
+        Commands\AppVersion::class,
+        Commands\ClearTmpUploads::class,
     ];
 
     /**
@@ -24,8 +25,8 @@ class Kernel extends ConsoleKernel {
      * @return void
      */
     protected function schedule(Schedule $schedule){
-        // $schedule->command('inspire')
-        //          ->hourly();
+        // $schedule->command('inspire')->hourly();
+        $schedule->command('storage:clear-tmp-uploads')->daily();
     }
 
     /**


### PR DESCRIPTION
Created a new artisan command `storage:clear-tmp-uploads` to clear the `storage/app/tmp_uploads` directory. It has been scheduled to run daily.

Resolves #77 