### PR TITLE
Feature/account-type-number-in-entry-modal

### DIFF
--- a/public/css/custom-bootstrap.css
+++ b/public/css/custom-bootstrap.css
@@ -9,7 +9,7 @@
 }
 .value-col{
     width: 80px;
-    text-align: center;
+    text-align: right;
 }
 .type-col span{
     font-size: 24px;

--- a/public/css/entry-modal.css
+++ b/public/css/entry-modal.css
@@ -27,7 +27,7 @@
     padding: 6px;
 }
 
-#entry-account-name{
+.account-type-meta{
     font-weight: normal;
     font-size: 11px;
     line-height: 11px;
@@ -36,7 +36,7 @@
     width: 310px;
 }
 
-#entry-account-name span{
+.account-type-meta span{
     padding-left: 2px;
 }
 

--- a/public/js/entry-modal.js
+++ b/public/js/entry-modal.js
@@ -98,20 +98,23 @@ var entryModal = {
         });
         $('#entry-account-type').change(function(){
             var accountTypeId = $(this).val();
+            var accountType = accountTypes.find(accountTypeId);
             var account = accountTypes.getAccount(accountTypeId);
-            var accountNameParentElement = $('#entry-account-name');
+            var accountTypeMetaParentElement = $('.account-type-meta');
             if(account.hasOwnProperty('name')){
-                accountNameParentElement.removeClass('hidden');
+                accountTypeMetaParentElement.removeClass('hidden');
                 $('#entry-account-name span').text(account.name);
+                $('#entry-account-type-last-digits span').text(accountType.last_digits);
             } else {
-                accountNameParentElement.addClass('hidden');
+                accountTypeMetaParentElement.addClass('hidden');
                 $('#entry-account-name span').text('');
+                $('#entry-account-type-last-digits span').text('');
             }
 
             if(account.hasOwnProperty('disabled') && account.disabled){
-                accountNameParentElement.removeClass('text-info').addClass('text-muted');
+                accountTypeMetaParentElement.removeClass('text-info').addClass('text-muted');
             } else {
-                accountNameParentElement.removeClass('text-muted').addClass('text-info');
+                accountTypeMetaParentElement.removeClass('text-muted').addClass('text-info');
             }
         });
     },

--- a/public/js/filter-modal.js
+++ b/public/js/filter-modal.js
@@ -46,7 +46,7 @@ var filterModal = {
     initTagsInput: function(){
         var filterTags = $('#filter-tags');
         var tagValues = tags.value.sort(function(a, b){
-            return a.name.length-b.name.length
+            return (a.name < b.name) ? -1 : (a.name > b.name) ? 1 : 0;
         });
 
         $.each(tagValues, function(idx, tagObj){

--- a/resources/views/modal/entry.blade.php
+++ b/resources/views/modal/entry.blade.php
@@ -38,8 +38,12 @@
                     <select id="entry-account-type" name="entry-account-type" class="form-control">
                         <option></option>
                     </select>
-                    <div id="entry-account-name" class="text-info hidden text-right">
+                    <div id="entry-account-name" class="text-info hidden text-right account-type-meta">
                         <strong>Account Name:</strong>
+                        <span></span>
+                    </div>
+                    <div id="entry-account-type-last-digits" class="text-info hidden text-right account-type-meta">
+                        <strong>Last 4 Digits:</strong>
                         <span></span>
                     </div>
                 </label>


### PR DESCRIPTION
- Added `account_types.last_digits` display to the entry-modal when an `account-type` is selected.
- Making value columns (i.e.: the income/expense columns on the home page) right aligned.
- corrected sorting of tags for the filter modal