### PR TITLE
support/reset-current-page-number-on-fresh-filtering

### DIFF
--- a/public/js/filter-modal.js
+++ b/public/js/filter-modal.js
@@ -110,7 +110,8 @@ var filterModal = {
         if(attachmentInputValue === 1){ filterModalFilterParameters.attachments = true;                   } // has attachments
         if(unconfirmed){                filterModalFilterParameters.unconfirmed = true;                   }
 
-        entries.filter(filterModalFilterParameters);
+        paginate.current = 0;   // reset current page number
+        entries.filter(filterModalFilterParameters, paginate.current);
     }
 };
 


### PR DESCRIPTION
now resetting current "page number" when performing a filtering request

Resolves #127 