### PR TITLE
feature/fix-timezone-entry-list-muting

### DIFF
--- a/public/js/home.js
+++ b/public/js/home.js
@@ -282,13 +282,19 @@ var entries = {
     },
     display: function(){
         entries.clearDisplay();
+        var isEntryInFuture = function(entryDate){
+            var millisecondsPerMinute = 60000;
+            var timezoneOffset = new Date().getTimezoneOffset()*millisecondsPerMinute;
+            return Date.parse(entryDate)+timezoneOffset > Date.now();
+        };
         $.each(entries.value, function(index, entryObject){
+            entryObject.isEntryInFuture = isEntryInFuture(entryObject.entry_date);
             var displayTags = '';
             $.each(entryObject.tags, function(id, tagId){
                 displayTags += '<span class="label label-default entry-tag">'+tags.getNameById(tagId)+'</span>';
             });
             $('#entries-display-pane tbody').append(
-                '<tr class="'+(!entryObject.confirm ? 'warning' : (entryObject.expense ? '' : 'success'))+(new Date(entryObject.entry_date) > new Date() ? ' text-muted':'')+'">' +
+                '<tr class="'+(!entryObject.confirm ? 'warning' : (entryObject.expense ? '' : 'success'))+(entryObject.isEntryInFuture ? ' text-muted':'')+'">' +
                 '<td class="check-col" data-toggle="modal" data-target="#entry-modal" onclick="entry.load('+entryObject.id+');">' +
                 "\t"+'<span class="glyphicon glyphicon-pencil"></span>' +
                 '</td>' +


### PR DESCRIPTION
Corrected bug where entries.entry_value is considered a UTC date when parsing it in Javascript by adding a timezone offset value to the parsed value.