### PR TITLE
feature/vue-ext/loading-modal

### DIFF
--- a/database/seeds/UiSampleDatabaseSeeder.php
+++ b/database/seeds/UiSampleDatabaseSeeder.php
@@ -6,7 +6,7 @@ class UiSampleDatabaseSeeder extends Seeder {
 
     const COUNT_ACCOUNT = 2;
     const COUNT_ACCOUNT_TYPE = 3;
-    const COUNT_ATTACHMENT = 3;
+    const COUNT_ATTACHMENT = 6;
     const COUNT_ENTRY = 5;
     const COUNT_INSTITUTION = 2;
     const COUNT_MIN = 1;

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "vuex": "^3.0.1"
   },
   "scripts": {
-    "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "dev-watch": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "production": "cross-env NODE_ENV=production  node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "build-dev": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "build-dev-watch": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "build-prod": "cross-env NODE_ENV=production  node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.1.0",
@@ -22,7 +22,9 @@
     "bulma-badge": "^1.0.1",
     "bulma-checkradio": "^2.1.0",
     "bulma-tooltip": "^1.0.4",
+    "randomcolor": "^0.5.3",
     "vue-js-toggle-button": "^1.2.3",
+    "vue-spinner-component": "^1.0.5",
     "vue2-dropzone": "^3.2.2"
   }
 }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -4,6 +4,7 @@ import Store from './store';
 import EntryModal from './components/entry-modal';
 import EntriesTable from './components/entries-table';
 import InstitutionsPanel from './components/institutions-panel';
+import LoadingModal from './components/loading-modal';
 import Navbar from './components/navbar';
 
 import { Accounts } from './accounts';
@@ -15,6 +16,14 @@ import { Version } from './version';
 
 Vue.prototype.$eventHub = new Vue({
     computed: {
+        /**
+         * @returns {string}
+         */
+        EVENT_SHOW_LOADING: function(){ return "loading-true"; },
+        /**
+         * @returns {string}
+         */
+        EVENT_STOP_LOADING: function(){ return "loading-false"; },
         /**
          * @returns {string}
          */
@@ -40,10 +49,14 @@ new Vue({
         EntryModal,
         EntriesTable,
         InstitutionsPanel,
+        LoadingModal,
         Navbar
     },
     store: Store,
     mounted: function(){
+        // TODO: probably going to remove this...
+        this.$eventHub.broadcast(this.$eventHub.EVENT_SHOW_LOADING);
+
         let accounts = new Accounts();
         accounts.fetch();
 
@@ -51,7 +64,9 @@ new Vue({
         accountTypes.fetch();
 
         let entries = new Entries();
-        entries.fetch();
+        entries.fetch().then(function(){
+            this.$eventHub.broadcast(this.$eventHub.EVENT_STOP_LOADING);
+        }.bind(this));
 
         let institutions = new Institutions();
         institutions.fetch();

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -14,10 +14,15 @@ import { Tags } from './tags';
 import { Version } from './version';
 
 Vue.prototype.$eventHub = new Vue({
-    data: function(){
-        return {
-            EVENT_OPEN_ENTRY_MODAL: "open-entry-modal",
-        }
+    computed: {
+        /**
+         * @returns {string}
+         */
+        EVENT_OPEN_ENTRY_MODAL: function(){ return "open-entry-modal";},
+        /**
+         * @returns {string}
+         */
+        EVENT_UPDATE_ENTRY_MODAL_DATA: function(){ return "update-data-in-entry-modal"; }
     },
     methods: {
         broadcast(event, data = null){

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -19,19 +19,19 @@ Vue.prototype.$eventHub = new Vue({
         /**
          * @returns {string}
          */
-        EVENT_SHOW_LOADING: function(){ return "loading-true"; },
+        EVENT_LOADING_SHOW: function(){ return "loading-true"; },
         /**
          * @returns {string}
          */
-        EVENT_STOP_LOADING: function(){ return "loading-false"; },
+        EVENT_LOADING_HIDE: function(){ return "loading-false"; },
         /**
          * @returns {string}
          */
-        EVENT_OPEN_ENTRY_MODAL: function(){ return "open-entry-modal";},
+        EVENT_ENTRY_MODAL_OPEN: function(){ return "open-entry-modal";},
         /**
          * @returns {string}
          */
-        EVENT_UPDATE_ENTRY_MODAL_DATA: function(){ return "update-data-in-entry-modal"; }
+        EVENT_ENTRY_MODAL_UPDATE_DATA: function(){ return "update-data-in-entry-modal"; }
     },
     methods: {
         broadcast(event, data = null){
@@ -55,7 +55,7 @@ new Vue({
     store: Store,
     mounted: function(){
         // TODO: probably going to remove this...
-        this.$eventHub.broadcast(this.$eventHub.EVENT_SHOW_LOADING);
+        this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_SHOW);
 
         let accounts = new Accounts();
         accounts.fetch();
@@ -65,7 +65,7 @@ new Vue({
 
         let entries = new Entries();
         entries.fetch().then(function(){
-            this.$eventHub.broadcast(this.$eventHub.EVENT_STOP_LOADING);
+            this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_HIDE);
         }.bind(this));
 
         let institutions = new Institutions();

--- a/resources/assets/js/components/entries-table-entry-row.vue
+++ b/resources/assets/js/components/entries-table-entry-row.vue
@@ -55,7 +55,7 @@
                 return new Tags().getNameById(tagId);
             },
             openEditEntryModal: function(entryId){
-                this.$eventHub.broadcast(this.$eventHub.EVENT_OPEN_ENTRY_MODAL, entryId);
+                this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_MODAL_OPEN, entryId);
             },
             modalNotAvailable: function(entryId){
                 alert("Modal not currently available\nEntry "+entryId+" can't be modified at this time");

--- a/resources/assets/js/components/entry-modal-attachment.vue
+++ b/resources/assets/js/components/entry-modal-attachment.vue
@@ -11,9 +11,16 @@
 </template>
 
 <script>
+    import {Entry} from "../entry"
+
     export default {
         name: "entry-modal-attachment",
-        props: [ 'uuid','name'],
+        props: [ 'uuid','name', 'entryId'],
+        data: function(){
+            return {
+                entryObject: new Entry()
+            }
+        },
         methods: {
             viewEntryAttachment: function(){
                 window.open("/attachment/"+this.uuid, "_blank");

--- a/resources/assets/js/components/entry-modal.vue
+++ b/resources/assets/js/components/entry-modal.vue
@@ -387,6 +387,7 @@
             saveEntry: function(){
                 // TODO: save an entry
                 this.notAvailable();
+                // TODO: on entry-modal save, update entries-table component display
             },
             deleteEntry: function(){
                 // TODO: delete entry, but ONLY if entry does not already exist

--- a/resources/assets/js/components/entry-modal.vue
+++ b/resources/assets/js/components/entry-modal.vue
@@ -329,6 +329,7 @@
                 }
                 this.isVisible = true;
                 this.updateAccountTypeMeta();
+                this.$eventHub.broadcast(this.$eventHub.EVENT_STOP_LOADING);
             },
             closeModal: function(){
                 this.isDeletable = false;
@@ -338,6 +339,7 @@
                 this.updateAccountTypeMeta();
             },
             primeDataForModal: function(entryId = null){
+                this.$eventHub.broadcast(this.$eventHub.EVENT_SHOW_LOADING);
                 if(!_.isEmpty(entryId) || _.isNumber(entryId)){ // isNumber is used to handle isEmpty() reading numbers as empty
                     if(_.isObject(entryId)){
                         // entryId was passed as part of an event payload

--- a/resources/assets/js/components/entry-modal.vue
+++ b/resources/assets/js/components/entry-modal.vue
@@ -134,6 +134,7 @@
                         v-bind:key="entryAttachment.uuid"
                         v-bind:uuid="entryAttachment.uuid"
                         v-bind:name="entryAttachment.name"
+                        v-bind:entryId="entryData.id"
                     ></entry-modal-attachment>
                 </div>
             </section>
@@ -423,6 +424,7 @@
         },
         created: function(){
             this.$eventHub.listen(this.$eventHub.EVENT_OPEN_ENTRY_MODAL, this.primeDataForModal);
+            this.$eventHub.listen(this.$eventHub.EVENT_UPDATE_ENTRY_MODAL_DATA, this.openModal);
         },
         mounted: function(){
             this.resetEntryData();

--- a/resources/assets/js/components/entry-modal.vue
+++ b/resources/assets/js/components/entry-modal.vue
@@ -329,7 +329,7 @@
                 }
                 this.isVisible = true;
                 this.updateAccountTypeMeta();
-                this.$eventHub.broadcast(this.$eventHub.EVENT_STOP_LOADING);
+                this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_HIDE);
             },
             closeModal: function(){
                 this.isDeletable = false;
@@ -339,7 +339,7 @@
                 this.updateAccountTypeMeta();
             },
             primeDataForModal: function(entryId = null){
-                this.$eventHub.broadcast(this.$eventHub.EVENT_SHOW_LOADING);
+                this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_SHOW);
                 if(!_.isEmpty(entryId) || _.isNumber(entryId)){ // isNumber is used to handle isEmpty() reading numbers as empty
                     if(_.isObject(entryId)){
                         // entryId was passed as part of an event payload
@@ -426,8 +426,8 @@
             }
         },
         created: function(){
-            this.$eventHub.listen(this.$eventHub.EVENT_OPEN_ENTRY_MODAL, this.primeDataForModal);
-            this.$eventHub.listen(this.$eventHub.EVENT_UPDATE_ENTRY_MODAL_DATA, this.openModal);
+            this.$eventHub.listen(this.$eventHub.EVENT_ENTRY_MODAL_OPEN, this.primeDataForModal);
+            this.$eventHub.listen(this.$eventHub.EVENT_ENTRY_MODAL_UPDATE_DATA, this.openModal);
         },
         mounted: function(){
             this.resetEntryData();

--- a/resources/assets/js/components/loading-modal.vue
+++ b/resources/assets/js/components/loading-modal.vue
@@ -1,0 +1,60 @@
+<template>
+    <div id="loading-modal" class="modal" v-bind:class="{'is-active' : isLoading}">
+        <div class="modal-background"></div>
+        <div class="modal-content">
+            <div class="container">
+                <spinner
+                    v-bind:depth="spinner.depth"
+                    v-bind:size="spinner.size"
+                    v-bind:speed="spinner.speed"
+                    v-bind:color="spinner.color"
+                ></spinner>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+    import randomColor from 'randomColor';
+    import Spinner from 'vue-spinner-component/src/Spinner.vue';
+
+    export default {
+        name: "loading-modal",
+        components: {
+            Spinner
+        },
+        data: function(){
+            return {
+                isLoading: false,
+                spinner: {
+                    depth: 5,
+                    size: 175,
+                    speed: 0.5,
+                    color: ""
+                },
+            };
+        },
+        methods: {
+            showLoading: function(){
+                this.generateRandomColor();
+                this.isLoading = true;
+            },
+            stopLoading: function(){
+                this.isLoading = false;
+            },
+            generateRandomColor: function(){
+                this.spinner.color = randomColor();
+            }
+        },
+        created: function(){
+            this.$eventHub.listen(this.$eventHub.EVENT_SHOW_LOADING, this.showLoading);
+            this.$eventHub.listen(this.$eventHub.EVENT_STOP_LOADING, this.stopLoading);
+        },
+    }
+</script>
+
+<style scoped>
+    .container {
+        width: 100px;
+    }
+</style>

--- a/resources/assets/js/components/loading-modal.vue
+++ b/resources/assets/js/components/loading-modal.vue
@@ -47,8 +47,8 @@
             }
         },
         created: function(){
-            this.$eventHub.listen(this.$eventHub.EVENT_SHOW_LOADING, this.showLoading);
-            this.$eventHub.listen(this.$eventHub.EVENT_STOP_LOADING, this.stopLoading);
+            this.$eventHub.listen(this.$eventHub.EVENT_LOADING_SHOW, this.showLoading);
+            this.$eventHub.listen(this.$eventHub.EVENT_LOADING_HIDE, this.stopLoading);
         },
     }
 </script>

--- a/resources/assets/js/components/navbar.vue
+++ b/resources/assets/js/components/navbar.vue
@@ -53,7 +53,7 @@
         },
         methods: {
             openAddEntryModal: function(){
-                this.$eventHub.broadcast(this.$eventHub.EVENT_OPEN_ENTRY_MODAL);
+                this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_MODAL_OPEN);
             },
             openFilterModal: function(){
                 this.modalNotAvailable();

--- a/resources/assets/js/entries.js
+++ b/resources/assets/js/entries.js
@@ -35,7 +35,7 @@ export class Entries extends ObjectBaseClass {
 //         });
 
         console.log("URL:"+this.uri+'/'+pageNumber+";\nfilter:"+requestParameters);
-        Axios.post(this.uri+'/'+pageNumber, requestParameters)
+        return Axios.post(this.uri+'/'+pageNumber, requestParameters)
             .then(this.axiosSuccess.bind(this))
             .catch(this.axiosFailure);
     }

--- a/resources/assets/js/entry.js
+++ b/resources/assets/js/entry.js
@@ -58,7 +58,7 @@ export class Entry extends ObjectBaseClass {
 
     processSuccessfulResponseData(responseData){
         if(!_.isEmpty(responseData)){
-            responseData.fetchStamp = new Date().getTime();
+            responseData = this.updateEntryFetchStamp(responseData)
         }
         return responseData;
     }
@@ -70,6 +70,11 @@ export class Entry extends ObjectBaseClass {
         } else {
             return false;
         }
+    }
+
+    updateEntryFetchStamp(entryData){
+        entryData.fetchStamp = new Date().getTime();
+        return entryData;
     }
 
 }

--- a/resources/assets/js/objectBaseClass.js
+++ b/resources/assets/js/objectBaseClass.js
@@ -10,7 +10,7 @@ export class ObjectBaseClass {
 
     fetch(){
         console.log(this.uri);
-        Axios.get(this.uri)
+        return Axios.get(this.uri)
             .then(this.axiosSuccess.bind(this))
             .catch(this.axiosFailure);
     }

--- a/resources/views/vue.blade.php
+++ b/resources/views/vue.blade.php
@@ -30,8 +30,13 @@
                 <entries-table></entries-table>
             </div>
         </div>
-        <loading-modal></loading-modal>
         <entry-modal></entry-modal>
+        <!--
+        loading-modal must ALWAYS be on the bottom.
+        This way if the loading-modal is active and another modal is active,
+        then it will look like the loading-modal is still active.
+        -->
+        <loading-modal></loading-modal>
     </div>
     <script type="text/javascript" src="{{asset('vue/js/app.js')}}"></script>
     <script type="text/javascript" src="{{asset('vue/js/bulma-accordion.js')}}"></script>

--- a/resources/views/vue.blade.php
+++ b/resources/views/vue.blade.php
@@ -30,6 +30,7 @@
                 <entries-table></entries-table>
             </div>
         </div>
+        <loading-modal></loading-modal>
         <entry-modal></entry-modal>
     </div>
     <script type="text/javascript" src="{{asset('vue/js/app.js')}}"></script>

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -80,6 +80,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
     public function testClickingOnEntryTableEditButtonOfUnconfirmedEntry($data_entry_selector, $data_expense_switch_label){
         $this->browse(function(Browser $browser) use ($data_entry_selector, $data_expense_switch_label){
             $browser->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openExistingEntryModal($data_entry_selector)
                 ->with($this->_selector_entry_modal, function($entry_modal) use ($data_expense_switch_label){
                     $entry_id = $entry_modal->value($this->_selector_field_entry_id);
@@ -139,6 +140,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
     public function testClickingOnEntryTableEditButtonOfConfirmedEntry($data_entry_selector, $data_expense_switch_label){
         $this->browse(function(Browser $browser) use ($data_entry_selector, $data_expense_switch_label){
             $browser->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openExistingEntryModal($data_entry_selector)
                 ->with($this->_selector_entry_modal, function($entry_modal) use ($data_expense_switch_label){
                     $entry_id = $entry_modal->value($this->_selector_field_entry_id);
@@ -201,6 +203,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $confirmed_entry_selector = $this->randomConfirmedEntrySelector();
             $browser->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openExistingEntryModal($confirmed_entry_selector)
                 ->click($this->_selector_btn_lock)
                 ->with($this->_selector_modal_head, function($modal_head){
@@ -251,6 +254,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $entry_selector = $this->randomEntrySelector().'.'.$this->_class_has_attachments;
             $browser->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openExistingEntryModal($entry_selector)
                 ->with($this->_selector_entry_modal, function($entry_modal){
                     $entry_modal->assertVisible($this->_selector_existing_attachments);
@@ -279,6 +283,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
     public function testClickingOnEntryTableEditButtonOfEntryWithTags($data_entry_selector, $data_tags_container_selector, $data_tag_selector){
         $this->browse(function(Browser $browser) use ($data_entry_selector, $data_tags_container_selector, $data_tag_selector){
             $browser->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openExistingEntryModal($data_entry_selector)
                 ->with($this->_selector_entry_modal, function($entry_modal) use ($data_entry_selector, $data_tags_container_selector, $data_tag_selector){
                     $entry_modal->assertVisible($data_tags_container_selector);
@@ -293,6 +298,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $entry_selector = $this->randomEntrySelector().'.'.$this->_class_has_attachments;
             $browser->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openExistingEntryModal($entry_selector)
                 ->with($this->_selector_entry_modal, function($entry_modal){
                     $entry_modal
@@ -321,6 +327,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $entry_selector = $this->randomEntrySelector();
             $browser->visit(new HomePage())
+                ->waitForLoadingToStop()
                 // open existing entry in modal and confirm fields are filled
                 ->openExistingEntryModal($entry_selector)
                 ->with($this->_selector_entry_modal, function($entry_modal){

--- a/tests/Browser/EntryModalNewEntryTest.php
+++ b/tests/Browser/EntryModalNewEntryTest.php
@@ -51,6 +51,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $this->browse(function (Browser $browser) {
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->assertMissing($this->_selector_modal);
         });
     }
@@ -59,6 +60,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openNewEntryModal()
                 ->assertVisible($this->_selector_modal);
         });
@@ -68,6 +70,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openNewEntryModal()
                 ->with($this->_selector_modal_head, function($entry_modal_head){
                     $entry_modal_head
@@ -86,6 +89,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openNewEntryModal()
                 ->with($this->_selector_modal_head, function($entry_modal_head){
                     $entry_modal_head->click($this->_selector_modal_head_close_btn);
@@ -98,6 +102,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openNewEntryModal()
                 ->with($this->_selector_modal_head, function($entry_modal_head){
                     $entry_modal_head
@@ -116,6 +121,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openNewEntryModal()
                 ->with($this->_selector_modal_body, function($entry_modal_body){
                     $entry_modal_body
@@ -169,6 +175,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openNewEntryModal()
                 ->with($this->_selector_modal_foot, function($entry_modal_foot){
                     $entry_modal_foot
@@ -193,6 +200,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openNewEntryModal()
                 ->with($this->_selector_modal_foot, function($entry_modal_foot){
                     $entry_modal_foot->click($this->_selector_modal_foot_cancel_btn);
@@ -205,6 +213,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openNewEntryModal()
                 ->with($this->_selector_modal_body, function($entry_modal_body){
                     $entry_modal_body
@@ -223,10 +232,10 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser) use ($account_type){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openNewEntryModal()
                 ->with($this->_selector_modal_body, function($entry_modal_body){
                     $entry_modal_body
-                        ->assertVisible($this->_selector_modal_body_account_type_is_loading)
                         ->assertDontSee($this->_label_account_type_meta_account_name)
                         ->assertDontSee($this->_label_account_type_meta_last_digits);
                         // TODO: currency icon in input#entry-value is "$"
@@ -255,6 +264,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openNewEntryModal()
                 ->with($this->_selector_modal_body, function($entry_modal_body){
                     $entry_modal_body
@@ -273,6 +283,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser) use ($account_type){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openNewEntryModal()
 
                 ->with($this->_selector_modal_body, function($entry_modal_body){
@@ -318,6 +329,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openNewEntryModal()
                 ->with($this->_selector_modal_body, function($entry_modal_body){
                     $upload_file_path = storage_path(parent::TEST_STORAGE_FILE_PATH);
@@ -351,6 +363,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser) use ($tag){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->openNewEntryModal()
                 ->with($this->_selector_modal_body, function ($entry_modal_body) use ($tag){
                     $first_char = substr($tag, 0, 1);

--- a/tests/Browser/NavbarTest.php
+++ b/tests/Browser/NavbarTest.php
@@ -24,6 +24,7 @@ class NavbarTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->with($this->_selector_navbar, function($navbar){
                     $navbar->assertVisible($this->_selector_navbar_brand);
                 });
@@ -34,6 +35,7 @@ class NavbarTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->with($this->_selector_navbar, function($navbar){
                     $navbar->assertSee($this->_label_add_entry);
                 });
@@ -44,6 +46,7 @@ class NavbarTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->with($this->_selector_navbar, function($navbar){
                     $navbar->assertSee($this->_label_filter);
                 });
@@ -54,6 +57,7 @@ class NavbarTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $browser
                 ->visit(new HomePage())
+                ->waitForLoadingToStop()
                 ->with($this->_selector_navbar, function($navbar){
                     $navbar_dropdown_selector = $this->_selector_navbar_dropdown;
                     $navbar

--- a/tests/Browser/Pages/HomePage.php
+++ b/tests/Browser/Pages/HomePage.php
@@ -37,10 +37,17 @@ class HomePage extends Page {
         return [
             '@navbar'=>'.navbar',
             '@new-entry-modal-btn'=>'#nav-entry-modal',
+            '@loading'=>'#loading-modal',
             '@entry-modal'=>'#entry-modal',
             '@entry-modal-save-btn'=>"#entry-modal button#entry-save-btn",
             '@edit-existing-entry-modal-btn'=>"button.button.edit-entry-button"
         ];
+    }
+
+    public function waitForLoadingToStop(Browser $browser){
+        $browser
+            ->assertVisible('@loading')
+            ->waitUntilMissing('@loading', self::WAIT_SECONDS);
     }
 
     public function openNewEntryModal(Browser $browser){
@@ -53,8 +60,10 @@ class HomePage extends Page {
         $browser
             ->waitFor($entry_table_selector, self::WAIT_SECONDS)
             ->with($entry_table_selector, function($table_body){
-            $table_body->click('@edit-existing-entry-modal-btn');
-        })->waitFor('@entry-modal', self::WAIT_SECONDS);
+                $table_body->click('@edit-existing-entry-modal-btn');
+            })
+            ->waitForLoadingToStop()
+            ->waitFor('@entry-modal', self::WAIT_SECONDS);
     }
 
     public function assertEntryModalSaveButtonIsDisabled(Browser $browser){


### PR DESCRIPTION

- Renamed scripts in `package.json` to better define what they're supposed to do.
- Doubled number of attachment records generated by `UiSampleDatabaseSeeder`.
- Created a `loading-modal` component to show a loading "spinner" when intensive tasks are being performed.
- Moved event names back from `$eventHub.data` to `$eventHub.computed`.
- Created new event names and updated others in `$eventHub`.
- Added logic to existing dusk tests to take into account the use of the `loading-modal`.
- Passing and `entryId` from the entry-modal component to the entry-modal-attachment component as a property.

Related to #28 