### PR TITLE
support/filter-account-dropdown-fix

### DIFF
--- a/public/js/filter-modal.js
+++ b/public/js/filter-modal.js
@@ -27,10 +27,11 @@ var filterModal = {
             }
             filterModal.updateRangeCurrency(account.currency);
         });
-        filterModal.toggleAccountOrAccountTypeSelect();
+        filterModal.clearAccountOrAccountTypeSelect();
+        filterModal.initAccountSelect();
     },
     toggleAccountOrAccountTypeSelect: function(){
-        $('#filter-account-or-account-type .generated').remove();
+        filterModal.clearAccountOrAccountTypeSelect();
         var currentState = $('#filter-toggle-account-or-account-type').bootstrapSwitch('state');
         // on/true = account_type; off/false = account; see bootstrapSwitchAccountOrAccountTypeObject
         if(currentState){
@@ -53,6 +54,9 @@ var filterModal = {
                 $("#filter-account-or-account-type").append('<option value="'+accountOrAccountTypeObject.id+'" class="generated">'+accountOrAccountTypeObject.name+'</option>');
             }
         });
+    },
+    clearAccountOrAccountTypeSelect: function(){
+        $('#filter-account-or-account-type .generated').remove();
     },
     initTagsInput: function(){
         var filterTags = $('#filter-tags');

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -177,13 +177,11 @@ var accounts = {
                 }
             },
             complete: function(){
-                accounts.display();
+                institutionsPane.displayAccounts();
+                filterModal.clearAccountOrAccountTypeSelect();
+                filterModal.initAccountSelect();
             }
         });
-    },
-    display: function(){
-        institutionsPane.displayAccounts();
-        filterModal.initAccountSelect();
     },
     valuesSortedBy: function(property){
         return accounts.value.slice().sort(function(a, b){


### PR DESCRIPTION
Clearing filter-modal account select options before adding options after making a `GET /api/accounts` request.

Resolves #164 