### PR TITLE
Release/1.8.3

### DIFF
--- a/database/migrations/2018_09_25_011033_update_account_types_column_type.php
+++ b/database/migrations/2018_09_25_011033_update_account_types_column_type.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateAccountTypesColumnType extends Migration {
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(){
+        // Because there is a column of type ENUM in the account_types, we can't modify any columns using ORM
+        DB::statement("ALTER TABLE account_types CHANGE type type ENUM('checking','savings','credit card','debit card','loan')");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(){
+        // Because there is a column of type ENUM in the account_types, we can't modify any columns using ORM
+        DB::statement("ALTER TABLE account_types CHANGE type type ENUM('checking','savings','credit card','debit card')");
+    }
+
+}

--- a/public/js/filter-modal.js
+++ b/public/js/filter-modal.js
@@ -27,10 +27,11 @@ var filterModal = {
             }
             filterModal.updateRangeCurrency(account.currency);
         });
-        filterModal.toggleAccountOrAccountTypeSelect();
+        filterModal.clearAccountOrAccountTypeSelect();
+        filterModal.initAccountSelect();
     },
     toggleAccountOrAccountTypeSelect: function(){
-        $('#filter-account-or-account-type .generated').remove();
+        filterModal.clearAccountOrAccountTypeSelect();
         var currentState = $('#filter-toggle-account-or-account-type').bootstrapSwitch('state');
         // on/true = account_type; off/false = account; see bootstrapSwitchAccountOrAccountTypeObject
         if(currentState){
@@ -53,6 +54,9 @@ var filterModal = {
                 $("#filter-account-or-account-type").append('<option value="'+accountOrAccountTypeObject.id+'" class="generated">'+accountOrAccountTypeObject.name+'</option>');
             }
         });
+    },
+    clearAccountOrAccountTypeSelect: function(){
+        $('#filter-account-or-account-type .generated').remove();
     },
     initTagsInput: function(){
         var filterTags = $('#filter-tags');

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -177,13 +177,11 @@ var accounts = {
                 }
             },
             complete: function(){
-                accounts.display();
+                institutionsPane.displayAccounts();
+                filterModal.clearAccountOrAccountTypeSelect();
+                filterModal.initAccountSelect();
             }
         });
-    },
-    display: function(){
-        institutionsPane.displayAccounts();
-        filterModal.initAccountSelect();
     },
     valuesSortedBy: function(property){
         return accounts.value.slice().sort(function(a, b){


### PR DESCRIPTION
Clearing filter-modal account select options before adding options after making a `GET /api/accounts` request.

Resolves #164 