### PR TITLE
Feature/vue-ext/notification-snotify

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - dockerhost:$DOCKER_HOST_IP
     dns_search:
       - money-tracker.docker
+    networks:
+      - net.money-tracker
 
   database:
     build:
@@ -31,14 +33,21 @@ services:
       - MYSQL_DATABASE=money_tracker
       - MYSQL_USER=jdenoc
       - MYSQL_PASSWORD=password
+    networks:
+      - net.money-tracker
 
   selenium: # needed for e2e (End-to-End) testing
     image: selenium/standalone-chrome:latest
     container_name: "selenium.money-tracker"
     links:
-    - application:money-tracker.docker
+      - application:money-tracker.docker
     volumes:
-    - /dev/shm:/dev/shm
+      - /dev/shm:/dev/shm
+    networks:
+      - net.money-tracker
 
 volumes:
   db.money-tracker:
+
+networks:
+  net.money-tracker:

--- a/package.json
+++ b/package.json
@@ -1,14 +1,5 @@
 {
   "private": true,
-  "devDependencies": {
-    "axios": "^0.16.2",
-    "cross-env": "^5.0.1",
-    "laravel-mix": "^1.0",
-    "lodash": "^4.17.4",
-    "toastr": "^2.1.4",
-    "vue": "^2.1.10",
-    "vuex": "^3.0.1"
-  },
   "scripts": {
     "build-dev": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
     "build-dev-watch": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
@@ -17,13 +8,21 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.1.0",
     "@voerro/vue-tagsinput": "^1.8.0",
+    "axios": "^0.16.2",
     "bulma": "^0.6.2",
     "bulma-accordion": "^1.0.1",
     "bulma-badge": "^1.0.1",
     "bulma-checkradio": "^2.1.0",
     "bulma-tooltip": "^1.0.4",
+    "cross-env": "^5.0.1",
     "randomcolor": "^0.5.3",
+    "laravel-mix": "^1.0",
+    "lodash": "^4.17.4",
+    "toastr": "^2.1.4",
+    "vue": "^2.1.10",
+    "vuex": "^3.0.1",
     "vue-js-toggle-button": "^1.2.3",
+    "vue-snotify": "^3.2.1",
     "vue-spinner-component": "^1.0.5",
     "vue2-dropzone": "^3.2.2"
   }

--- a/resources/assets/js/account-types.js
+++ b/resources/assets/js/account-types.js
@@ -1,6 +1,7 @@
-import Store from './store';
-import {ObjectBaseClass} from "./objectBaseClass";
 import {Accounts} from "./accounts";
+import {ObjectBaseClass} from "./objectBaseClass";
+import {SnotifyStyle} from "vue-snotify";
+import Store from './store';
 
 export class AccountTypes extends ObjectBaseClass {
 
@@ -15,14 +16,10 @@ export class AccountTypes extends ObjectBaseClass {
             switch(error.response.status){
                 case 404:
                     this.assign = [];
-                    // TODO: inform user
-                    // notice.display(notice.typeInfo, "No account types available");
-                    break;
+                    return {type: SnotifyStyle.info, message: "No account types currently available"};
                 case 500:
                 default:
-                    // TODO: inform user of issue
-                    // notice.display(notice.typeDanger, 'Error occurred while attempting to retrieve account types');
-                    break;
+                    return {type: SnotifyStyle.error, message: "An error occurred while attempting to retrieve account types"};
             }
         }
     }

--- a/resources/assets/js/accounts.js
+++ b/resources/assets/js/accounts.js
@@ -1,7 +1,8 @@
-import Store from './store';
-import { ObjectBaseClass } from './objectBaseClass';
-import { Institutions } from "./institutions";
 import { AccountTypes } from "./account-types";
+import { Institutions } from "./institutions";
+import { ObjectBaseClass } from './objectBaseClass';
+import { SnotifyStyle } from 'vue-snotify';
+import Store from './store';
 
 export class Accounts extends ObjectBaseClass {
 
@@ -16,14 +17,10 @@ export class Accounts extends ObjectBaseClass {
             switch(error.response.status){
                 case 404:
                     this.assign = [];
-                    // TODO: notify user
-                    // notice.display(notice.typeInfo, "No accounts currently available");
-                    break;
+                    return {type: SnotifyStyle.info, message: "No accounts currently available"};
                 case 500:
                 default:
-                    // TODO: notify user of issue
-                    // notice.display(notice.typeDanger, "Error occurred when attempting to retrieve accounts");
-                    break;
+                    return {type: SnotifyStyle.error, message: "An error occurred while attempting to retrieve accounts"};
             }
         }
     }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import Store from './store';
 
-import Snotify, { SnotifyStyle } from 'vue-snotify';
+import Snotify from 'vue-snotify';
 Vue.use(Snotify, {toast: {timeout: 5000}});
 
 import EntryModal from './components/entry-modal';
@@ -9,6 +9,7 @@ import EntriesTable from './components/entries-table';
 import InstitutionsPanel from './components/institutions-panel';
 import LoadingModal from './components/loading-modal';
 import Navbar from './components/navbar';
+import Notification from './components/notification';
 
 import { Accounts } from './accounts';
 import { AccountTypes } from './account-types';
@@ -62,32 +63,14 @@ new Vue({
         EntriesTable,
         InstitutionsPanel,
         LoadingModal,
-        Navbar
+        Navbar,
+        Notification
     },
     store: Store,
     methods: {
         displayNotification: function(notification){
-            if(!_.isEmpty(notification)){
-                switch(notification.type){
-                    case SnotifyStyle.error:
-                        this.$snotify.error(notification.message);
-                        break;
-                    case SnotifyStyle.info:
-                    default:
-                        this.$snotify.info(notification.message);
-                        break;
-                    case SnotifyStyle.success:
-                        this.$snotify.success(notification.message);
-                        break;
-                    case SnotifyStyle.warning:
-                        this.$snotify.warning(notification.message);
-                        break;
-                }
-            }
+            this.$eventHub.broadcast(this.$eventHub.EVENT_NOTIFICATION, notification);
         }
-    },
-    created: function(){
-        this.$eventHub.listen(this.$eventHub.EVENT_NOTIFICATION, this.displayNotification);
     },
     mounted: function(){
         this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_SHOW);

--- a/resources/assets/js/attachment.js
+++ b/resources/assets/js/attachment.js
@@ -4,6 +4,7 @@
 
 import { Entry } from './entry';
 import { ObjectBaseClass } from './objectBaseClass';
+import { SnotifyStyle } from 'vue-snotify';
 import Axios from "axios";
 
 export class Attachment extends ObjectBaseClass {
@@ -35,8 +36,8 @@ export class Attachment extends ObjectBaseClass {
         entry = this.entryObject.updateEntryFetchStamp(entry);
         this.entryObject.assign = entry;
 
-        // TODO: inform user of attachment deletion
-        // notice.display(notice.typeInfo, "Attachment has been deleted");
+        // inform user of attachment deletion
+        entry.notification = {type: SnotifyStyle.info, message: "Attachment has been deleted"};
         return entry;
     }
 
@@ -44,14 +45,10 @@ export class Attachment extends ObjectBaseClass {
         if(error.response){
             switch(error.response.status){
                 case 404:
-                    // TODO: inform user of error
-                    // notice.display(notice.typeDanger, 'Could not delete attachment');
-                    break;
+                    return {notification: {type: SnotifyStyle.warning, message: "Could not delete attachment"}};
                 case 500:
                 default:
-                    // TODO: send a notice - delete entry
-                    // notice.display(notice.typeError, "An error occurred while attempting to delete entry attachment ["+entryId+"]");
-                    break;
+                    return {notification: {type: SnotifyStyle.error, message: "An error occurred while attempting to delete entry attachment [%s]"}};
             }
         }
     }

--- a/resources/assets/js/components/entries-table.vue
+++ b/resources/assets/js/components/entries-table.vue
@@ -50,9 +50,13 @@
         },
         methods: {
             updateEntriesTable: function(){
-                this.entries.fetch().finally(function(){
-                    this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_HIDE);
-                }.bind(this));
+                this.entries.fetch()
+                    .then(function(notification){
+                        this.$eventHub.broadcast(this.$eventHub.EVENT_NOTIFICATION, notification);
+                    }.bind(this))
+                    .finally(function(){
+                        this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_HIDE);
+                    }.bind(this));
             }
         },
         created: function(){

--- a/resources/assets/js/components/entry-modal-attachment.vue
+++ b/resources/assets/js/components/entry-modal-attachment.vue
@@ -34,11 +34,9 @@
                     this.attachmentObject
                         .delete(this.uuid, this.entryId)
                         .then(function(newEntryData){
-                            if(!_.isEmpty(newEntryData.notification) && _.isObject(newEntryData.notification)){
-                                // inform user of attachment deletion
-                                this.$eventHub.broadcast(this.$eventHub.EVENT_NOTIFICATION, {type: newEntryData.notification.type, message: newEntryData.notification.message.replace("%s", this.entryId)});
-                                delete newEntryData.notification;
-                            }
+                            // inform user of attachment deletion
+                            this.$eventHub.broadcast(this.$eventHub.EVENT_NOTIFICATION, {type: newEntryData.notification.type, message: newEntryData.notification.message.replace("%s", this.entryId)});
+                            delete newEntryData.notification;
                             if(!_.isEmpty(newEntryData)){
                                 // update entryData in entry-modal component
                                 this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_MODAL_UPDATE_DATA, newEntryData);

--- a/resources/assets/js/components/entry-modal-attachment.vue
+++ b/resources/assets/js/components/entry-modal-attachment.vue
@@ -34,6 +34,11 @@
                     this.attachmentObject
                         .delete(this.uuid, this.entryId)
                         .then(function(newEntryData){
+                            if(!_.isEmpty(newEntryData.notification) && _.isObject(newEntryData.notification)){
+                                // inform user of attachment deletion
+                                this.$eventHub.broadcast(this.$eventHub.EVENT_NOTIFICATION, {type: newEntryData.notification.type, message: newEntryData.notification.message.replace("%s", this.entryId)});
+                                delete newEntryData.notification;
+                            }
                             if(!_.isEmpty(newEntryData)){
                                 // update entryData in entry-modal component
                                 this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_MODAL_UPDATE_DATA, newEntryData);

--- a/resources/assets/js/components/entry-modal.vue
+++ b/resources/assets/js/components/entry-modal.vue
@@ -112,25 +112,12 @@
                             v-bind:typeahead="true"
                             v-bind:typeahead-max-results="5"
                         ></voerro-tags-input>
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Rather than an input for "readonly" tags within the entry-modal, we're going to use `.box` and `.tag` class elements.
                         <div class="box" v-show="isLocked"><div class="tags">
                             <span class="tag"
                                 v-for="tag in displayReadOnlyTags"
                                 v-text="tag"
                             ></span>
                         </div></div>
-<<<<<<< HEAD
-=======
-                        <input type="text" class="input has-text-grey-dark" readonly
-                           v-model="displayReadOnlyTags"
-                           v-show="isLocked"
-                        />
->>>>>>> Applied a toggled locking feature to the entry-modal for previously saved & confirmed entries.
-=======
->>>>>>> Rather than an input for "readonly" tags within the entry-modal, we're going to use `.box` and `.tag` class elements.
                     </div></div></div>
                 </div>
 

--- a/resources/assets/js/components/entry-modal.vue
+++ b/resources/assets/js/components/entry-modal.vue
@@ -10,7 +10,7 @@
                     <input class="is-checkradio is-block is-success" id="entry-confirm" type="checkbox" name="entry-confirm"
                         v-model="entryData.confirm"
                         v-bind:disabled="isLocked"
-                    >
+                    />
                     <label for="entry-confirm"
                         v-bind:class="{'has-text-grey-light': !entryData.confirm, 'has-text-white': entryData.confirm}"
                         >Confirmed</label>
@@ -125,6 +125,7 @@
                     <vue-dropzone ref="entryModalFileUpload" id="entry-modal-file-upload"
                         v-bind:options="dropzoneOptions"
                         v-on:vdropzone-success="dropzoneSuccessfulUpload"
+                        v-on:vdropzone-error="dropzoneUploadError"
                         v-on:vdropzone-removed-file="dropzoneRemoveUpload"
                         v-show="!isLocked"
                     ></vue-dropzone>
@@ -181,6 +182,7 @@
     import {AccountTypes} from "../account-types";
     import {Entries} from "../entries";
     import {Entry} from "../entry";
+    import {SnotifyStyle} from 'vue-snotify';
     import {Tags} from '../tags';
     import EntryModalAttachment from "./entry-modal-attachment";
     import ToggleButton from 'vue-js-toggle-button/src/Button'
@@ -518,7 +520,13 @@
                 this.entryData = _.clone(this.defaultData);
             },
             dropzoneSuccessfulUpload(file, response){
+                // response: {'uuid', 'name', 'tmp_filename'}
                 this.entryData.attachments.push(response);
+                this.$eventHub.broadcast(this.$eventHub.EVENT_NOTIFICATION, {type: SnotifyStyle.info, message: "uploaded: "+response.name});
+            },
+            dropzoneUploadError(file, message, xhr){
+                // response: {'error'}
+                this.$eventHub.broadcast(this.$eventHub.EVENT_NOTIFICATION, {type: SnotifyStyle.warning, message: "file upload failure: "+message.error});
             },
             dropzoneRemoveUpload(file){
                 let removedAttachmentObject = JSON.parse(file.xhr.response);

--- a/resources/assets/js/components/entry-modal.vue
+++ b/resources/assets/js/components/entry-modal.vue
@@ -179,8 +179,8 @@
 <script>
     import _ from 'lodash';
     import {AccountTypes} from "../account-types";
-    import {Entries} from "../entries"
-    import {Entry} from "../entry"
+    import {Entries} from "../entries";
+    import {Entry} from "../entry";
     import {Tags} from '../tags';
     import EntryModalAttachment from "./entry-modal-attachment";
     import ToggleButton from 'vue-js-toggle-button/src/Button'
@@ -356,16 +356,21 @@
                             reject(entryId);
                         }
                     }.bind(this))
-                        .then(this.openModal)
-                        .catch(function(entryId){
+                        .then(this.openModal)       // resolve
+                        .catch(function(entryId){   // reject
                             this.entryObject.fetch(entryId)
-                                .then(function(){
-                                    let entryData = this.entryObject.find(entryId);
-                                    this.openModal(entryData);
-                                }.bind(this))
-                                .catch(function(){
-                                    // TODO: display notification error
-                                    this.openModal({});
+                                .then(function(fetchResult){
+                                    let freshlyFetchedEntryData = {};
+                                    if(fetchResult.fetched){
+                                        freshlyFetchedEntryData = this.entryObject.find(entryId);
+                                    }
+                                    this.openModal(freshlyFetchedEntryData);
+                                    if(!_.isEmpty(fetchResult.notification)){
+                                        this.$eventHub.broadcast(
+                                            this.$eventHub.EVENT_NOTIFICATION,
+                                            {type: fetchResult.notification.type, message: fetchResult.notification.message}
+                                        );
+                                    }
                                 }.bind(this));
                         }.bind(this));
                 } else {
@@ -387,21 +392,6 @@
                 this.isLocked = false;
                 this.dropzoneRef.enable();
                 this.updateAccountTypeMeta();
-            },
-            toggleLockState: function(){
-                if(this.isLocked){
-                    this.unlockModal();
-                } else {
-                    this.lockModal();
-                }
-            },
-            lockModal: function(){
-                this.isLocked = true;
-                this.dropzoneRef.disable();
-            },
-            unlockModal: function(){
-                this.isLocked = false;
-                this.dropzoneRef.enable();
             },
             saveEntry: function(){
                 this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_SHOW);
@@ -462,16 +452,37 @@
                         }
                     });
                 }
-
-                this.entryObject.save(newEntryData).finally(function(){
+                this.entryObject.save(newEntryData).then(function(notification){
+                    if(!_.isEmpty(notification)){
+                        this.$eventHub.broadcast(
+                            this.$eventHub.EVENT_NOTIFICATION,
+                            {type: notification.type, message: notification.message.replace('%s', this.entryData.id)}
+                        );
+                    }
                     this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_TABLE_UPDATE);
                     this.closeModal();
                 }.bind(this));
             },
             deleteEntry: function(){
+                this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_SHOW);
                 this.entryObject
                     .delete(this.entryData.id)
-                    .then(this.closeModal.bind(this));
+                    .then(function(deleteResult){
+                        if(!_.isEmpty(deleteResult.notification)){
+                            this.$eventHub.broadcast(
+                                this.$eventHub.EVENT_NOTIFICATION,
+                                {type: deleteResult.notification.type, message: deleteResult.notification.message.replace('%s', this.entryData.id)}
+                            );
+                        }
+                        this.closeModal();
+                        if(deleteResult.deleted){
+                            this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_TABLE_UPDATE);
+                            // don't need to broadcast an event to hide the loading modal here
+                            // already taken care of at the end of the entry-table update event process
+                        } else {
+                            this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_HIDE);
+                        }
+                    }.bind(this));
             },
             notAvailable: function(){
                 alert("This feature is not currently available");
@@ -510,9 +521,9 @@
                 this.entryData.attachments.push(response);
             },
             dropzoneRemoveUpload(file){
-                let removedeAttachmentObject = JSON.parse(file.xhr.response);
+                let removedAttachmentObject = JSON.parse(file.xhr.response);
                 this.entryData.attachments = this.entryData.attachments.filter(function(attachment){
-                    return attachment.uuid !== removedeAttachmentObject.uuid;
+                    return attachment.uuid !== removedAttachmentObject.uuid;
                 });
             }
         },

--- a/resources/assets/js/components/institutions-panel.vue
+++ b/resources/assets/js/components/institutions-panel.vue
@@ -13,7 +13,6 @@
                 v-bind:key="institution.id"
                 v-bind:id="institution.id"
                 v-bind:name="institution.name"
-                v-bind:total="account.total"
             ></institutions-panel-institution>
 
             <div class="accordion" v-show="inactiveAccountsAreAvailable">

--- a/resources/assets/js/components/notification.vue
+++ b/resources/assets/js/components/notification.vue
@@ -1,0 +1,44 @@
+<template>
+    <vue-snotify></vue-snotify>
+</template>
+
+<script>
+    import { SnotifyStyle } from 'vue-snotify';
+
+    export default {
+        name: "notification",
+        methods: {
+            displayNotification: function(notification){
+                if(!_.isEmpty(notification)){
+                    switch(notification.type){
+                        case SnotifyStyle.error:
+                            this.$snotify.error(notification.message);
+                            break;
+                        case SnotifyStyle.info:
+                        default:
+                            this.$snotify.info(notification.message);
+                            break;
+                        case SnotifyStyle.success:
+                            this.$snotify.success(notification.message);
+                            break;
+                        case SnotifyStyle.warning:
+                            this.$snotify.warning(notification.message);
+                            break;
+                    }
+                }
+            }
+        },
+        created: function(){
+            this.$eventHub.listen(this.$eventHub.EVENT_NOTIFICATION, this.displayNotification);
+        },
+    }
+</script>
+
+<style scoped>
+    .snotifyToast__body{
+        font-size: 1.1em;
+    }
+    .snotify-success .snotifyToast__body{
+        color: #e1f1e1;
+    }
+</style>

--- a/resources/assets/js/entries.js
+++ b/resources/assets/js/entries.js
@@ -1,4 +1,5 @@
 import { ObjectBaseClass } from './objectBaseClass';
+import { SnotifyStyle } from 'vue-snotify';
 import Axios from "axios";
 import Store from './store';
 
@@ -7,7 +8,7 @@ export class Entries extends ObjectBaseClass {
     constructor(){
         super();
         this.storeType = Store.getters.STORE_TYPE_ENTRIES;
-        this.uri = '/api/entries';
+        this.uri = '/api/entries/';
         this.sort = {parameter: 'entry_date', direction: 'desc'};
     }
 
@@ -34,10 +35,10 @@ export class Entries extends ObjectBaseClass {
 //             complete: entries.ajaxCompleteProcessing
 //         });
 
-        console.log("URL:"+this.uri+'/'+pageNumber+";\nfilter:"+requestParameters);
-        return Axios.post(this.uri+'/'+pageNumber, requestParameters)
+        console.log("URL:"+this.uri+pageNumber+";\nfilter:"+requestParameters);
+        return Axios.post(this.uri+pageNumber, requestParameters)
             .then(this.axiosSuccess.bind(this))
-            .catch(this.axiosFailure);
+            .catch(this.axiosFailure.bind(this));
     }
 
     axiosFailure(error){
@@ -45,15 +46,12 @@ export class Entries extends ObjectBaseClass {
             switch(error.response.status){
                 case 404:
                     this.assign = [];
-                    // TODO: notify user
-                    // notice.display(notice.typeInfo, "No entries were found");
-                    break;
+                    return {type: SnotifyStyle.info, message: "No entries were found"};
                 case 500:
                 default:
-                    // TODO: notify user of issue
                     this.assign = [];
-                    // notice.display(notice.typeDanger, "An error occurred while attempting to retrieve "+(filterModal.active?"filtered":"")+" entries");
-                    break;
+                    // return {type: SnotifyStyle.error, message: "An error occurred while attempting to retrieve "+(filterModal.active?"filtered":"")+" entries"};    // TODO: after filtering is in place
+                    return {type: SnotifyStyle.error, message: "An error occurred while attempting to retrieve entries"};
             }
         }
     }
@@ -81,14 +79,6 @@ export class Entries extends ObjectBaseClass {
 // var entries = {
 //     value: [],
 //     total: 0,
-
-//     load: function(pageNumber){
-//         entries.ajaxRequest(pageNumber, {});
-//     },
-
-//     filter: function(filterParameters, pageNumber){
-//         entries.ajaxRequest(pageNumber, filterParameters);
-//     },
 
 //     display: function(){
 //         entries.clearDisplay();

--- a/resources/assets/js/entry.js
+++ b/resources/assets/js/entry.js
@@ -89,7 +89,7 @@ export class Entry extends ObjectBaseClass {
                             return {fetched: false, notification: {type: SnotifyStyle.warning, message: "Entry does not exist"}};
                         case 500:
                         default:
-                            return {fetched: false, notification: {type: SnotifyStyle.error, message: "Error occurred while attempting to retrieve entry"}};
+                            return {fetched: false, notification: {type: SnotifyStyle.error, message: "An error occurred while attempting to retrieve entry"}};
                     }
                 case "POST":
                     switch(error.response.status){

--- a/resources/assets/js/entry.js
+++ b/resources/assets/js/entry.js
@@ -4,6 +4,7 @@
 
 import _ from 'lodash';
 import { ObjectBaseClass } from './objectBaseClass';
+import { SnotifyStyle } from 'vue-snotify';
 import Axios from "axios";
 import Store from './store';
 
@@ -69,23 +70,13 @@ export class Entry extends ObjectBaseClass {
         switch(response.config.method.toUpperCase()){
             case 'GET':
                 this.assign = this.processSuccessfulResponseData(response.data);
-                this.fetched = true;
-                break;
-
+                return {fetched: true, notification: {}};
             case "POST":
-                // TODO: send notice of successful entry creation
-                // notice.display(notice.typeSuccess, "New entry created");
-                break;
-
+                return {type: SnotifyStyle.success, message: "New entry created"};
             case "PUT":
-                // TODO: send notice of successful entry update
-                // notice.display(notice.typeSuccess, "Entry updated");
-                break;
-
+                return {type: SnotifyStyle.success, message: "Entry updated"};
             case "DELETE":
-                // TODO: send notice of successful deletion
-                // notice.display(notice.typeSuccess, "Entry was deleted");
-                break;
+                return {deleted: true, notification: {type: SnotifyStyle.success, message: "Entry was deleted"}}
         }
     }
 
@@ -95,56 +86,36 @@ export class Entry extends ObjectBaseClass {
                 case "GET":
                     switch(error.response.status){
                         case 404:
-                            // TODO: send a notice
-                            // notice.display(notice.typeWarning, "Entry does not exist");
-                            break;
+                            return {fetched: false, notification: {type: SnotifyStyle.warning, message: "Entry does not exist"}};
                         case 500:
                         default:
-                            // TODO: send a notice
-                            // notice.display(notice.typeDanger, 'Error occurred while attempting to retrieve entries');
+                            return {fetched: false, notification: {type: SnotifyStyle.error, message: "Error occurred while attempting to retrieve entry"}};
                     }
-                    this.fetched = true;
-                    break;
-
                 case "POST":
                     switch(error.response.status){
                         case 400:
-                            // TODO: send a notice
-                            // notice.display(notice.typeWarning, error.response.error);
-                            break;
+                            return {type: SnotifyStyle.warning, message: error.response.data.error};
                         case 500:
                         default:
-                            // TODO: send a notice
-                            // notice.display(notice.typeError, "An error occurred while attempting to create an entry");
+                            return {type: SnotifyStyle.error, message: "An error occurred while attempting to create an entry"};
                     }
-                    break;
-
                 case "PUT":
                     switch(error.response.status){
                         case 400:
                         case 404:
-                            // TODO: send a notice
-                            // notice.display(notice.typeWarning, error.response.error);
-                            break;
+                            return {type: SnotifyStyle.warning, message: error.response.data.error};
                         case 500:
                         default:
-                            // TODO: send a notice
-                            // notice.display(notice.typeError, "An error occurred while attempting to update entry ["+entryId+"]");
+                            return {type: SnotifyStyle.error, message: "An error occurred while attempting to update entry [%s]"};
                     }
-                    break;
-
                 case "DELETE":
                     switch(error.response.status){
                         case 404:
-                            // TODO: send a notice - delete entry
-                            // notice.display(notice.typeWarning, "Entry ["+entryId+"] does not exist and cannot be deleted");
-                            break;
+                            return {deleted: false, notification: {type: SnotifyStyle.warning, message: "Entry [%s] does not exist and cannot be deleted"}};
                         case 500:
                         default:
-                            // TODO: send a notice - delete entry
-                            // notice.display(notice.typeError, "An error occurred while attempting to delete entry ["+entryId+"]");
+                            return {deleted: false, notification: {type: SnotifyStyle.error, message: "An error occurred while attempting to delete entry [%s]"}};
                     }
-                    break;
             }
         }
     }

--- a/resources/assets/js/institutions.js
+++ b/resources/assets/js/institutions.js
@@ -1,4 +1,5 @@
 import { ObjectBaseClass } from './objectBaseClass';
+import { SnotifyStyle } from 'vue-snotify';
 import Store from './store';
 
 export class Institutions extends ObjectBaseClass {
@@ -14,13 +15,10 @@ export class Institutions extends ObjectBaseClass {
             switch(error.response.status){
                 case 404:
                     this.assign = [];
-                    // TODO: notify users
-                    //  notice.display(notice.typeInfo, "No institutions currently available");
+                    return {type: SnotifyStyle.info, message: "No institutions currently available"};
                 case 500:
                 default:
-                    // TODO: notify users of issue
-                    //  notice.display(notice.typeDanger, "Error occurred when attempting to retrieve institutions");
-                    break;
+                    return {type: SnotifyStyle.error, message: "An error occurred while attempting to retrieve institutions"};
             }
         }
     }

--- a/resources/assets/js/objectBaseClass.js
+++ b/resources/assets/js/objectBaseClass.js
@@ -12,7 +12,7 @@ export class ObjectBaseClass {
         console.log(this.uri);
         return Axios.get(this.uri)
             .then(this.axiosSuccess.bind(this))
-            .catch(this.axiosFailure);
+            .catch(this.axiosFailure.bind(this));
     }
 
     axiosSuccess(response){

--- a/resources/assets/js/tags.js
+++ b/resources/assets/js/tags.js
@@ -1,4 +1,5 @@
 import { ObjectBaseClass } from './objectBaseClass';
+import { SnotifyStyle } from 'vue-snotify';
 import Store from './store';
 
 export class Tags extends ObjectBaseClass {
@@ -17,9 +18,7 @@ export class Tags extends ObjectBaseClass {
                     break;
                 case 500:
                 default:
-                    // TODO: notify users of issue
-                    // notice.display(notice.typeDanger, "Error occurred when attempting to retrieve tags");
-                    break;
+                    return {type: SnotifyStyle.error, message: "An error occurred while attempting to retrieve tags"};
             }
         }
     }

--- a/resources/assets/js/version.js
+++ b/resources/assets/js/version.js
@@ -19,7 +19,7 @@ export class Version extends ObjectBaseClass {
                 case 404:
                 case 500:
                 default:
-                    this.set("N/A");
+                    this.assign = "N/A";
                     break;
             }
         }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -15,9 +15,3 @@
 
 // Snotify
 @import "~vue-snotify/styles/material";
-.snotifyToast__body{
-  font-size: 1.1em;
-}
-.snotify-success .snotifyToast__body{
-  color: #e1f1e1;
-}

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -7,7 +7,8 @@
 }
 
 // Bulma
-@import "node_modules/bulma/bulma.sass";
-@import "node_modules/bulma-badge/dist/bulma-badge.sass";
-@import "node_modules/bulma-checkradio/dist/css/bulma-checkradio.sass";
-@import "node_modules/bulma-tooltip/dist/bulma-tooltip.sass";
+@import "~bulma/bulma.sass";
+@import "~bulma-accordion/dist/bulma-accordion.sass";
+@import "~bulma-badge/dist/bulma-badge.sass";
+@import "~bulma-checkradio/dist/css/bulma-checkradio.sass";
+@import "~bulma-tooltip/dist/bulma-tooltip.sass";

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -12,3 +12,12 @@
 @import "~bulma-badge/dist/bulma-badge.sass";
 @import "~bulma-checkradio/dist/css/bulma-checkradio.sass";
 @import "~bulma-tooltip/dist/bulma-tooltip.sass";
+
+// Snotify
+@import "~vue-snotify/styles/material";
+.snotifyToast__body{
+  font-size: 1.1em;
+}
+.snotify-success .snotifyToast__body{
+  color: #e1f1e1;
+}

--- a/resources/views/vue.blade.php
+++ b/resources/views/vue.blade.php
@@ -37,8 +37,8 @@
             -->
             <loading-modal></loading-modal>
         </div>
-        <script type="text/javascript" src="{{asset('vue/js/app.js')}}"></script>
-        <script type="text/javascript" src="{{asset('vue/js/bulma-accordion.js')}}"></script>
     </div>
+    <script type="text/javascript" src="{{asset('vue/js/app.js')}}"></script>
+    <script type="text/javascript" src="{{asset('vue/js/bulma-accordion.js')}}"></script>
 </body>
 </html>

--- a/resources/views/vue.blade.php
+++ b/resources/views/vue.blade.php
@@ -35,6 +35,8 @@
             then it will look like the loading-modal is still active.
             -->
             <loading-modal></loading-modal>
+            <!-- notifications are the only exception -->
+            <vue-snotify></vue-snotify>
         </div>
     </div>
     <script type="text/javascript" src="{{asset('vue/js/app.js')}}"></script>

--- a/resources/views/vue.blade.php
+++ b/resources/views/vue.blade.php
@@ -14,7 +14,6 @@
     <link href="https://fonts.googleapis.com/css?family=Raleway:100,600" rel="stylesheet" type="text/css">
 
     <link href="{{asset('vue/css/app.css')}}" rel="stylesheet" type="text/css">
-    <link href="{{asset('vue/css/bulma-accordion.css')}}" rel="stylesheet" type="text/css">
     <link href="{{asset('vue/css/font-awesome.css')}}" rel="stylesheet" type="text/css">
     <link href="{{asset('vue/css/tags-input.css')}}" rel="stylesheet" type="text/css">
     <link href="{{asset('vue/css/vue-dropzone.css')}}" rel="stylesheet" type="text/css">

--- a/resources/views/vue.blade.php
+++ b/resources/views/vue.blade.php
@@ -36,7 +36,7 @@
             -->
             <loading-modal></loading-modal>
             <!-- notifications are the only exception -->
-            <vue-snotify></vue-snotify>
+            <notification></notification>
         </div>
     </div>
     <script type="text/javascript" src="{{asset('vue/js/app.js')}}"></script>

--- a/tests/Browser/EntryModalNewEntryTest.php
+++ b/tests/Browser/EntryModalNewEntryTest.php
@@ -2,11 +2,15 @@
 
 namespace Tests\Browser;
 
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Facades\Artisan;
 use Tests\Browser\Pages\HomePage;
 use Tests\DuskTestCase;
 use Laravel\Dusk\Browser;
 
 class EntryModalNewEntryTest extends DuskTestCase {
+
+    use DatabaseMigrations;
 
     private $_selector_modal = "@entry-modal";
     private $_selector_table = "#entry-table";
@@ -47,6 +51,11 @@ class EntryModalNewEntryTest extends DuskTestCase {
     private $_label_switch_expense = "Expense";
     private $_label_switch_income = "Income";
     private $_label_btn_dropzone_remove_file = "REMOVE FILE";
+
+    public function setUp(){
+        parent::setUp();
+        Artisan::call('db:seed', ['--class'=>'UiSampleDatabaseSeeder']);
+    }
 
     public function testEntryModalIsNotVisibleByDefault(){
         $this->browse(function (Browser $browser) {
@@ -422,6 +431,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
                     $modal_foot->click($this->_selector_modal_foot_save_btn);
                 })
                 ->waitForLoadingToStop()
+                ->assertNotification(HomePage::NOTIFICATION_SUCCESS, "New entry created")
                 ->assertMissing($this->_selector_modal)
                 ->with($this->_selector_table.' .has-background-warning.is-expense', function($table_row) use ($memo_field){
                     $table_row->assertSee($memo_field);
@@ -451,6 +461,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
                     $modal_foot->click($this->_selector_modal_foot_save_btn);
                 })
                 ->waitForLoadingToStop()
+                ->assertNotification(HomePage::NOTIFICATION_SUCCESS, "New entry created")
                 ->assertMissing($this->_selector_modal)
                 ->with($this->_selector_table.' .has-background-warning.is-income', function($table_row) use ($memo_field){
                     $table_row->assertSee($memo_field);
@@ -482,6 +493,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
                     $modal_foot->click($this->_selector_modal_foot_save_btn);
                 })
                 ->waitForLoadingToStop()
+                ->assertNotification(HomePage::NOTIFICATION_SUCCESS, "New entry created")
                 ->assertMissing($this->_selector_modal)
                 ->with($this->_selector_table.' .is-confirmed', function($table_row) use ($memo_field){
                     $table_row->assertSee($memo_field);
@@ -496,12 +508,12 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser) use ($account_type){
             $memo_field = "Test entry - attachments";
             $selector_row_has_attachments = $this->_selector_table.' .has-background-warning.has-attachments';
+            $upload_file_path = storage_path($this->getRandomTestFilePath());
             $browser
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
                 ->openNewEntryModal()
-                ->with($this->_selector_modal_body, function($modal_body) use ($account_type, $memo_field){
-                    $upload_file_path = storage_path($this->getRandomTestFilePath());
+                ->with($this->_selector_modal_body, function($modal_body) use ($account_type, $memo_field, $upload_file_path){
                     $modal_body
                         ->type($this->_selector_modal_body_value, "9.99")
                         ->waitUntilMissing($this->_selector_modal_body_account_type_is_loading, HomePage::WAIT_SECONDS)
@@ -510,10 +522,12 @@ class EntryModalNewEntryTest extends DuskTestCase {
                         ->attach($this->_selector_dropzone_hidden_file_input, $upload_file_path)
                         ->waitFor($this->_selector_dropzone_upload_thumbnail, HomePage::WAIT_SECONDS);
                 })
+                ->assertNotification(HomePage::NOTIFICATION_INFO, sprintf("uploaded: %s", basename($upload_file_path)))
                 ->with($this->_selector_modal_foot, function($modal_foot){
                     $modal_foot->click($this->_selector_modal_foot_save_btn);
                 })
                 ->waitForLoadingToStop()
+                ->assertNotification(HomePage::NOTIFICATION_SUCCESS, "New entry created")
                 ->assertMissing($this->_selector_modal)
                 ->with($selector_row_has_attachments, function($table_row) use ($memo_field){
                     $table_row->assertSee($memo_field);
@@ -561,6 +575,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
                     $modal_foot->click($this->_selector_modal_foot_save_btn);
                 })
                 ->waitForLoadingToStop()
+                ->assertNotification(HomePage::NOTIFICATION_SUCCESS, "New entry created")
                 ->assertMissing($this->_selector_modal)
                 ->with($this->_selector_table.' .has-background-warning.has-tags', function($table_row) use ($memo_field){
                     $table_row->assertSee($memo_field);
@@ -605,6 +620,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
                     $modal_foot->click($this->_selector_modal_foot_save_btn);
                 })
                 ->waitForLoadingToStop()
+                ->assertNotification(HomePage::NOTIFICATION_SUCCESS, "New entry created")
                 ->assertMissing($this->_selector_modal)
                 ->with($this->_selector_table.' .has-background-warning.has-attachments.has-tags', function($table_row) use ($memo_field){
                     $table_row->assertSee($memo_field);

--- a/tests/Browser/NavbarTest.php
+++ b/tests/Browser/NavbarTest.php
@@ -2,11 +2,14 @@
 
 namespace Tests\Browser;
 
+use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Tests\Browser\Pages\HomePage;
 use Tests\DuskTestCase;
 use Laravel\Dusk\Browser;
 
 class NavbarTest extends DuskTestCase {
+
+    use DatabaseMigrations;
 
     private $_selector_navbar = '@navbar';
     private $_selector_navbar_brand = ".navbar-brand";

--- a/tests/Browser/NotificationsTest.php
+++ b/tests/Browser/NotificationsTest.php
@@ -1,0 +1,544 @@
+<?php
+
+namespace Tests\Browser;
+
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Tests\Browser\Pages\HomePage;
+use Tests\DuskTestCase;
+use Laravel\Dusk\Browser;
+
+class NotificationsTest extends DuskTestCase {
+
+    use DatabaseMigrations;
+
+    private $_selector_notification = ".snotifyToast";
+    private $_selector_notification_info = ".snotify-info";
+    private $_selector_notification_error = ".snotify-error";
+    private $_selector_notification_success = ".snotify-success";
+
+    private $_message_error_occurred = "An error occurred while attempting to retrieve %s";
+    private $_message_not_found = "No %s currently available";
+
+    private $_selector_modal = "@entry-modal";
+    private $_selector_modal_body = "#entry-modal .modal-card-body";
+    private $_selector_modal_body_value = "input#entry-value";
+    private $_selector_modal_body_account_type = "select#entry-account-type";
+    private $_selector_modal_body_account_type_is_loading = ".select.is-loading select#entry-account-type";
+    private $_selector_modal_body_memo = "textarea#entry-memo";
+
+    private $_selector_modal_foot = "#entry-modal .modal-card-foot";
+    private $_selector_modal_foot_save_btn = "button#entry-save-btn";
+
+
+    public function setUp(){
+        parent::setUp();
+        Artisan::call('db:seed', ['--class'=>'UiSampleDatabaseSeeder']);
+    }
+
+    /**
+     * There should be no notifications when the following are successful:
+     *  - accounts
+     *  - account-types
+     *  - entries
+     *  - institutions
+     *  - tags
+     *
+     * @throws \Throwable
+     */
+    public function testNoNotificationOnFetch200(){
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->assertMissing($this->_selector_notification);
+        });
+    }
+
+    public function testNotificationFetchAccounts404(){
+        // FORCE 404 from `GET /api/accounts`
+        DB::statement("DELETE FROM accounts");
+
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage())
+                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS_LONG)
+                ->assertVisible($this->_selector_notification.$this->_selector_notification_info)
+                ->assertSee(sprintf($this->_message_not_found, "accounts"))
+                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_info, HomePage::WAIT_SECONDS);
+        });
+    }
+
+    public function testNotificationFetchAccounts500(){
+        // This query is accurate as of migration:
+        // 2018_07_17_160556_add_accounts_column_currency.php
+        $recreate_table_query = <<<MYSQL
+CREATE TABLE accounts (
+  id             int(10)  unsigned   PRIMARY KEY  auto_increment,
+  name           varchar(100),
+  institution_id int(10) unsigned,
+  disabled       tinyint(3) unsigned DEFAULT 0,
+  total          decimal(10,2)       DEFAULT 0.00,
+  currency       char(3)             DEFAULT "USD",
+  create_stamp   timestamp           NULL DEFAULT NULL,
+  modified_stamp timestamp           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  disabled_stamp timestamp           NULL DEFAULT NULL
+);
+MYSQL;
+
+        $this->browse(function (Browser $browser) use ($recreate_table_query){
+            // FORCE 500 from `GET /api/accounts`
+            DB::statement("DROP TABLE accounts");
+
+            $browser->visit(new HomePage())
+                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
+                ->assertVisible($this->_selector_notification.$this->_selector_notification_error)
+                ->assertSee(sprintf($this->_message_error_occurred, "accounts"))
+                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_error, HomePage::WAIT_SECONDS);
+
+            DB::statement($recreate_table_query);
+        });
+    }
+
+    public function testNotificationFetchAccountTypes404(){
+        // FORCE 404 from `GET /api/account-types`
+        DB::statement("DELETE FROM account_types");
+
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage())
+                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
+                ->assertVisible($this->_selector_notification.$this->_selector_notification_info)
+                ->assertSee(sprintf($this->_message_not_found, "account types"))
+                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_info, HomePage::WAIT_SECONDS);
+        });
+    }
+
+    public function testNotificationFetchAccountTypes500(){
+        // This query is accurate as of migration:
+        // 2018_09_25_011033_update_account_types_column_type.php
+        $recreate_table_query = <<<MYSQL
+CREATE TABLE account_types (
+  id             int(10)  unsigned   PRIMARY KEY  auto_increment,
+  type           enum('checking','savings','credit card','debit card','loan'),
+  last_digits    varchar(4),
+  name           varchar(100),
+  account_id int(10) unsigned,
+  disabled       tinyint(3) unsigned DEFAULT 0,
+  create_stamp   timestamp           NULL DEFAULT NULL,
+  modified_stamp timestamp           NOT NULL DEFAULT CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP,
+  disabled_stamp timestamp           NULL DEFAULT NULL
+);
+MYSQL;
+
+        $this->browse(function (Browser $browser) use ($recreate_table_query){
+            // FORCE 500 from `GET /api/account-types`
+            DB::statement("DROP TABLE account_types");
+
+            $browser->visit(new HomePage())
+                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
+                ->assertVisible($this->_selector_notification.$this->_selector_notification_error)
+                ->assertSee(sprintf($this->_message_error_occurred, "account types"))
+                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_error, HomePage::WAIT_SECONDS);
+
+            DB::statement($recreate_table_query);
+        });
+    }
+
+    public function testNotificationDeleteAttachment204(){
+        // TODO: write me...
+        $this->markTestIncomplete();
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage());
+            // TODO: wait for loading to stop
+            // TODO: select an existing entry with an attachment from the entries-table
+            // TODO: open said entry in an entry-modal
+            // TODO: click the "delete" attachment button
+            // TODO: wait for notification to pop up
+            // TODO: notification is type:info
+            // TODO: notification text:"Attachment has been deleted"
+            // TODO: wait 5 seconds for notification to disappear
+        });
+    }
+
+    public function testNotificationDeleteAttachment404(){
+        // TODO: write me...
+        $this->markTestIncomplete();
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage());
+            // TODO: wait for loading to stop
+            // TODO: select an existing entry with an attachment from the entries-table
+            // TODO: open said entry in an entry-modal
+            // TODO: click the "delete" attachment button
+            // TODO: FORCE 404 from `DELETE /api/attachment/{uuid}`
+            // TODO: wait for notification to pop up
+            // TODO: notification is type:warning
+            // TODO: notification text:"Could not delete attachment"
+            // TODO: wait 5 seconds for notification to disappear
+        });
+    }
+
+    public function testNotificationDeleteAttachment500(){
+        // TODO: write me...
+        $this->markTestIncomplete();
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage());
+            // TODO: wait for loading to stop
+            // TODO: select an existing entry with an attachment from the entries-table
+            // TODO: open said entry in an entry-modal
+            // TODO: click the "delete" attachment button
+            // TODO: FORCE 500 from `DELETE /api/attachment/{uuid}`
+            // TODO: wait for notification to pop up
+            // TODO: notification is type:error
+            // TODO: notification text:"An error occurred while attempting to delete entry attachment [%s]"
+            // TODO: wait 5 seconds for notification to disappear
+        });
+    }
+
+    public function testNotificationFetchEntries404(){
+        // TODO: see note: -----------------VVV-----------------
+        $this->markTestIncomplete("Can't do this right now. Need to move notifications into their own component");
+
+        // FORCE 404 from `GET /api/entries`
+        DB::statement("DELETE FROM entries");
+
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage())
+                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
+                ->assertVisible($this->_selector_notification.$this->_selector_notification_info)
+                ->assertSee("No entries were found")
+                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_info, HomePage::WAIT_SECONDS);
+        });
+    }
+
+    public function testNotificationFetchEntries500(){
+        // TODO: see note: -----------------VVV-----------------
+        $this->markTestIncomplete("Can't do this right now. Need to move notifications into their own component");
+
+        // This query is accurate as of migration:
+        // 2017_11_21_161444_rename_tags_tag_column_to_name.php
+        $recreate_table_query = <<<MYSQL
+CREATE TABLE entries (
+  id               int(10) unsigned      PRIMARY KEY  auto_increment,
+  entry_date       date,
+  account_type_id  int(10) unsigned,
+  entry_value      decimal(10,2),
+  memo             text,
+  expense          tinyint(3) unsigned,
+  confirm          tinyint(3) unsigned,
+  disabled         tinyint(1)            DEFAULT 0,
+  create_stamp     timestamp             NULL DEFAULT NULL,
+  modified_stamp   timestamp             NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  disabled_stamp   timestamp             NULL DEFAULT NULL 
+);
+MYSQL;
+
+        $this->browse(function (Browser $browser) use ($recreate_table_query){
+            // FORCE 500 from `GET /api/entries`
+            DB::statement("DROP TABLE entries");
+
+            $browser->visit(new HomePage())->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
+                ->assertVisible($this->_selector_notification.$this->_selector_notification_error)
+                ->assertSee(sprintf($this->_message_error_occurred, "entries"))
+                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_error, HomePage::WAIT_SECONDS);
+
+            DB::statement($recreate_table_query);
+
+
+        });
+    }
+
+    public function testNotificationSaveNewEntry201(){
+        $account_types = $this->getApiAccountTypes();
+        $account_type = $account_types[array_rand($account_types, 1)];
+
+        $this->browse(function(Browser $browser) use ($account_type){
+            $memo_field = "Test entry - new save - notification";
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openNewEntryModal()
+                ->with($this->_selector_modal_body, function($modal_body) use ($account_type, $memo_field){
+                    $modal_body
+                        ->type($this->_selector_modal_body_value, "9.87")
+                        ->waitUntilMissing($this->_selector_modal_body_account_type_is_loading, HomePage::WAIT_SECONDS)
+                        ->select($this->_selector_modal_body_account_type, $account_type['id'])
+                        ->type($this->_selector_modal_body_memo, $memo_field);
+                })
+                ->with($this->_selector_modal_foot, function($modal_foot){
+                    $modal_foot->click($this->_selector_modal_foot_save_btn);
+                })
+                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS_LONG)
+                ->assertVisible($this->_selector_notification.$this->_selector_notification_success)
+                ->assertSee("New entry created")
+                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_success, HomePage::WAIT_SECONDS);
+        });
+    }
+
+    public function testNotificationSaveNewEntry400(){
+        $this->markTestIncomplete();
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage());
+            // TODO: wait for loading to hide
+            // TODO: click the "New Entry" navbar button
+            // TODO: wait for modal to load
+            // TODO: fill in minimum required fields
+            // TODO: click the save button in the modal footer
+            // TODO: FORCE 400 from `POST /api/entry`
+            // TODO: FORCE this response: {error: "Forced failure"}
+            // TODO: wait for notification to pop up
+            // TODO: notification is type:warning
+            // TODO: notification text:"Forced failure"
+            // TODO: wait 5 seconds for notification to disappear
+        });
+    }
+
+    public function testNotificationSaveNewEntry500(){
+        $this->markTestIncomplete();
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage());
+            // TODO: wait for loading to hide
+            // TODO: click the "New Entry" navbar button
+            // TODO: wait for modal to load
+            // TODO: fill in minimum required fields
+            // TODO: click the save button in the modal footer
+            // TODO: FORCE 500 from `POST /api/entry`
+            // TODO: wait for notification to pop up
+            // TODO: notification is type:error
+            // TODO: notification text:"An error occurred while attempting to create an entry"
+            // TODO: wait 5 seconds for notification to disappear
+        });
+    }
+
+    public function testNotificationFetchEntry200(){
+        $this->markTestIncomplete();
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage());
+            // TODO: wait for loading to hide
+            // TODO: select an existing entry from the entries-table
+            // TODO: open said entry in an entry-modal
+            // TODO: make sure no notification pops up
+        });
+    }
+
+    public function testNotificationFetchEntry404(){
+        $this->markTestIncomplete();
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage());
+            // TODO: wait for loading to hide
+            // TODO: select an existing entry from the entries-table
+            // TODO: open said entry in an entry-modal
+            // TODO: FORCE 404 from `GET /api/entry{entry_id}`
+            // TODO: wait for notification to pop up
+            // TODO: notification is type:warning
+            // TODO: notification text:"Entry does not exist"
+            // TODO: wait 5 seconds for notification to disappear
+        });
+    }
+
+    public function testNotificationFetchEntry500(){
+        $this->markTestIncomplete();
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage());
+            // TODO: wait for loading to hide
+            // TODO: select an existing entry from the entries-table
+            // TODO: open said entry in an entry-modal
+            // TODO: FORCE 500 from `GET /api/entries`
+            // TODO: wait for notification to pop up
+            // TODO: notification is type:error
+            // TODO: notification text:"Error occurred while attempting to retrieve entry"
+            // TODO: wait 5 seconds for notification to disappear
+        });
+    }
+
+    public function testNotificationSaveExistingEntry200(){
+        $this->markTestIncomplete();
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage());
+            // TODO: wait for loading to hide
+            // TODO: select an existing entry from the entries-table
+            // TODO: open said entry in an entry-modal
+            // TODO: wait for modal to load
+            // TODO: change the value of one of the _required_ fields
+            // TODO: click the save button in the modal footer
+            // TODO: wait for notification to pop up
+            // TODO: notification is type:success
+            // TODO: notification text:"Entry updated"
+            // TODO: wait 5 seconds for notification to disappear
+        });
+    }
+
+    public function providerNotificationSaveExistingEntry4XX(){
+        return [
+            400=>[400, 'bad input | force failure'],
+            404=>[404, 'entry not found | force failure']
+        ];
+    }
+
+    /**
+     * @dataProvider providerNotificationSaveExistingEntry4XX
+     *
+     * @throws \Throwable
+     */
+    public function testNotificationSaveExistingEntry4XX($http_status, $error_response_message){
+        $this->markTestIncomplete();
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage());
+            // TODO: wait for loading to hide
+            // TODO: select an existing entry from the entries-table
+            // TODO: open said entry in an entry-modal
+            // TODO: wait for modal to load
+            // TODO: change the value of one of the _required_ fields
+            // TODO: click the save button in the modal footer
+            // TODO: FORCE `$http_status` from `GET /api/entry{entry_id}`
+            // TODO: FORCE this response: {error: `$error_response_message`}
+            // TODO: wait for notification to pop up
+            // TODO: notification is type:warning
+            // TODO: notification text:`$error_response_message`
+            // TODO: wait 5 seconds for notification to disappear
+        });
+    }
+
+    public function testNotificationSaveExistingEntry500(){
+        $this->markTestIncomplete();
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage());
+            // TODO: wait for loading to hide
+            // TODO: select an existing entry from the entries-table
+            // TODO: open said entry in an entry-modal
+            // TODO: wait for modal to load
+            // TODO: change the value of one of the _required_ fields
+            // TODO: click the save button in the modal footer
+            // TODO: FORCE 500 from `GET /api/entry{entry_id}`
+            // TODO: wait for notification to pop up
+            // TODO: notification is type:error
+            // TODO: notification text:"An error occurred while attempting to update entry [%s]"
+            // TODO: wait 5 seconds for notification to disappear
+        });
+    }
+
+    public function testNotificationDeleteEntry200(){
+        // TODO: write me...
+        $this->markTestIncomplete();
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage());
+            // TODO: wait for loading to hide
+            // TODO: select and existing entry from the entries-table
+            // TODO: open said entry in an entry-modal
+            // TODO: click the "delete" entry button in the modal footer
+            // TODO: wait for notification to pop up
+            // TODO: notification is type:success
+            // TODO: notification text:"Entry was deleted"
+            // TODO: wait 5 seconds for notification to disappear
+        });
+    }
+
+    public function testNotificationDeleteEntry404(){
+        // TODO: write me...
+        $this->markTestIncomplete();
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage());
+            // TODO: wait for loading to hide
+            // TODO: select and existing entry from the entries-table
+            // TODO: open said entry in an entry-modal
+            // TODO: click the "delete" entry button in the modal footer
+            // TODO: FORCE 404 from `GET /api/entry/{entry_id}`
+            // TODO: wait for notification to pop up
+            // TODO: notification is type:success
+            // TODO: notification text:"Entry [%s] does not exist and cannot be deleted"
+            // TODO: wait 5 seconds for notification to disappear
+        });
+    }
+
+    public function testNotificationDeleteEntry500(){
+        // TODO: write me...
+        $this->markTestIncomplete();
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage());
+            // TODO: wait for loading to hide
+            // TODO: select and existing entry from the entries-table
+            // TODO: open said entry in an entry-modal
+            // TODO: click the "delete" entry button in the modal footer
+            // TODO: FORCE 500 from `GET /api/entry/{entry_id}`
+            // TODO: wait for notification to pop up
+            // TODO: notification is type:error
+            // TODO: notification text:"An error occurred while attempting to delete entry [%s]"
+            // TODO: wait 5 seconds for notification to disappear
+        });
+    }
+
+    public function testNotificationFetchInstitutions404(){
+        // FORCE 404 from `GET /api/institutions`
+        DB::statement("DELETE FROM institutions");
+
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage())
+                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
+                ->assertVisible($this->_selector_notification.$this->_selector_notification_info)
+                ->assertSee(sprintf($this->_message_not_found, "institutions"))
+                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_info, HomePage::WAIT_SECONDS);
+        });
+    }
+
+    public function testNotificationFetchInstitutions500(){
+        // This query is accurate as of migration:
+        // 2017_06_26_170141_create_institutions_table.php
+        $recreate_table_query = <<<MYSQL
+CREATE TABLE institutions (
+  id             int(10) unsigned  PRIMARY KEY  auto_increment,
+  name           varchar(50),
+  active         tinyint(4)        DEFAULT 1,
+  create_stamp   timestamp         NULL DEFAULT NULL,
+  modified_stamp timestamp         NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+MYSQL;
+
+        $this->browse(function (Browser $browser) use ($recreate_table_query){
+            // FORCE 500 from `GET /api/institutions`
+            DB::statement("DROP TABLE institutions");
+
+            $browser->visit(new HomePage())
+                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
+                ->assertVisible($this->_selector_notification.$this->_selector_notification_error)
+                ->assertSee(sprintf($this->_message_error_occurred, "institutions"))
+                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_error, HomePage::WAIT_SECONDS);
+
+            DB::statement($recreate_table_query);
+        });
+    }
+
+    public function testNotificationFetchTags404(){
+        // FORCE 404 from `GET /api/tags`
+        DB::statement("DELETE FROM tags");
+
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->assertMissing($this->_selector_notification);
+        });
+    }
+
+    public function testNotificationFetchTags500(){
+        // This query is accurate as of migration:
+        // 2017_11_21_161444_rename_tags_tag_column_to_name.php
+        $recreate_table_query = <<<MYSQL
+CREATE TABLE tags (
+  id    int(10) unsigned  PRIMARY KEY  auto_increment,
+  name  varchar(50)
+);
+MYSQL;
+
+        $this->browse(function (Browser $browser) use ($recreate_table_query){
+            // FORCE 500 from `GET /api/tags`
+            DB::statement("DROP TABLE tags");
+
+            $browser->visit(new HomePage())
+                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
+                ->assertVisible($this->_selector_notification.$this->_selector_notification_error)
+                ->assertSee(sprintf($this->_message_error_occurred, "tags"))
+                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_error, HomePage::WAIT_SECONDS);
+
+            DB::statement($recreate_table_query);
+        });
+    }
+
+}
+

--- a/tests/Browser/NotificationsTest.php
+++ b/tests/Browser/NotificationsTest.php
@@ -13,24 +13,19 @@ class NotificationsTest extends DuskTestCase {
 
     use DatabaseMigrations;
 
-    private $_selector_notification = ".snotifyToast";
-    private $_selector_notification_info = ".snotify-info";
-    private $_selector_notification_error = ".snotify-error";
-    private $_selector_notification_success = ".snotify-success";
-
-    private $_message_error_occurred = "An error occurred while attempting to retrieve %s";
-    private $_message_not_found = "No %s currently available";
-
     private $_selector_modal = "@entry-modal";
     private $_selector_modal_body = "#entry-modal .modal-card-body";
     private $_selector_modal_body_value = "input#entry-value";
     private $_selector_modal_body_account_type = "select#entry-account-type";
     private $_selector_modal_body_account_type_is_loading = ".select.is-loading select#entry-account-type";
     private $_selector_modal_body_memo = "textarea#entry-memo";
-
     private $_selector_modal_foot = "#entry-modal .modal-card-foot";
     private $_selector_modal_foot_save_btn = "button#entry-save-btn";
 
+    private $_selector_notification = "@notification";
+
+    private $_message_error_occurred = "An error occurred while attempting to retrieve %s";
+    private $_message_not_found = "No %s currently available";
 
     public function setUp(){
         parent::setUp();
@@ -61,10 +56,7 @@ class NotificationsTest extends DuskTestCase {
 
         $this->browse(function (Browser $browser) {
             $browser->visit(new HomePage())
-                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS_LONG)
-                ->assertVisible($this->_selector_notification.$this->_selector_notification_info)
-                ->assertSee(sprintf($this->_message_not_found, "accounts"))
-                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_info, HomePage::WAIT_SECONDS);
+                ->assertNotification(HomePage::NOTIFICATION_INFO, sprintf($this->_message_not_found, "accounts"));
         });
     }
 
@@ -76,10 +68,7 @@ class NotificationsTest extends DuskTestCase {
             DB::statement("DROP TABLE accounts");
 
             $browser->visit(new HomePage())
-                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
-                ->assertVisible($this->_selector_notification.$this->_selector_notification_error)
-                ->assertSee(sprintf($this->_message_error_occurred, "accounts"))
-                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_error, HomePage::WAIT_SECONDS);
+                ->assertNotification(HomePage::NOTIFICATION_ERROR, sprintf($this->_message_error_occurred, "accounts"));
 
             DB::statement($recreate_table_query);
         });
@@ -91,10 +80,7 @@ class NotificationsTest extends DuskTestCase {
 
         $this->browse(function (Browser $browser) {
             $browser->visit(new HomePage())
-                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
-                ->assertVisible($this->_selector_notification.$this->_selector_notification_info)
-                ->assertSee(sprintf($this->_message_not_found, "account types"))
-                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_info, HomePage::WAIT_SECONDS);
+                ->assertNotification(HomePage::NOTIFICATION_INFO, sprintf($this->_message_not_found, "account types"));
         });
     }
 
@@ -106,10 +92,7 @@ class NotificationsTest extends DuskTestCase {
             DB::statement("DROP TABLE account_types");
 
             $browser->visit(new HomePage())
-                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
-                ->assertVisible($this->_selector_notification.$this->_selector_notification_error)
-                ->assertSee(sprintf($this->_message_error_occurred, "account types"))
-                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_error, HomePage::WAIT_SECONDS);
+                ->assertNotification(HomePage::NOTIFICATION_ERROR, sprintf($this->_message_error_occurred, "account types"));
 
             DB::statement($recreate_table_query);
         });
@@ -171,10 +154,7 @@ class NotificationsTest extends DuskTestCase {
 
         $this->browse(function (Browser $browser) {
             $browser->visit(new HomePage())
-                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
-                ->assertVisible($this->_selector_notification.$this->_selector_notification_info)
-                ->assertSee("No entries were found")
-                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_info, HomePage::WAIT_SECONDS);
+                ->assertNotification(HomePage::NOTIFICATION_INFO, "No entries were found");
         });
     }
 
@@ -185,10 +165,8 @@ class NotificationsTest extends DuskTestCase {
             // FORCE 500 from `GET /api/entries`
             DB::statement("DROP TABLE entries");
 
-            $browser->visit(new HomePage())->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
-                ->assertVisible($this->_selector_notification.$this->_selector_notification_error)
-                ->assertSee(sprintf($this->_message_error_occurred, "entries"))
-                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_error, HomePage::WAIT_SECONDS);
+            $browser->visit(new HomePage())
+                ->assertNotification(HomePage::NOTIFICATION_ERROR, sprintf($this->_message_error_occurred, "entries"));
 
             DB::statement($recreate_table_query);
         });
@@ -214,10 +192,7 @@ class NotificationsTest extends DuskTestCase {
                 ->with($this->_selector_modal_foot, function($modal_foot){
                     $modal_foot->click($this->_selector_modal_foot_save_btn);
                 })
-                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS_LONG)
-                ->assertVisible($this->_selector_notification.$this->_selector_notification_success)
-                ->assertSee("New entry created")
-                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_success, HomePage::WAIT_SECONDS);
+                ->assertNotification(HomePage::NOTIFICATION_SUCCESS, "New entry created");
         });
     }
 
@@ -419,10 +394,7 @@ class NotificationsTest extends DuskTestCase {
 
         $this->browse(function (Browser $browser) {
             $browser->visit(new HomePage())
-                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
-                ->assertVisible($this->_selector_notification.$this->_selector_notification_info)
-                ->assertSee(sprintf($this->_message_not_found, "institutions"))
-                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_info, HomePage::WAIT_SECONDS);
+                ->assertNotification(HomePage::NOTIFICATION_INFO, sprintf($this->_message_not_found, "institutions"));
         });
     }
 
@@ -434,10 +406,7 @@ class NotificationsTest extends DuskTestCase {
             DB::statement("DROP TABLE institutions");
 
             $browser->visit(new HomePage())
-                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
-                ->assertVisible($this->_selector_notification.$this->_selector_notification_error)
-                ->assertSee(sprintf($this->_message_error_occurred, "institutions"))
-                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_error, HomePage::WAIT_SECONDS);
+                ->assertNotification(HomePage::NOTIFICATION_ERROR, sprintf($this->_message_error_occurred, "institutions"));
 
             DB::statement($recreate_table_query);
         });
@@ -462,10 +431,7 @@ class NotificationsTest extends DuskTestCase {
             DB::statement("DROP TABLE tags");
 
             $browser->visit(new HomePage())
-                ->waitFor($this->_selector_notification, HomePage::WAIT_SECONDS)
-                ->assertVisible($this->_selector_notification.$this->_selector_notification_error)
-                ->assertSee(sprintf($this->_message_error_occurred, "tags"))
-                ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_error, HomePage::WAIT_SECONDS);
+                ->assertNotification(HomePage::NOTIFICATION_ERROR, sprintf($this->_message_error_occurred, "tags"));
 
             DB::statement($recreate_table_query);
         });

--- a/tests/Browser/NotificationsTest.php
+++ b/tests/Browser/NotificationsTest.php
@@ -57,7 +57,7 @@ class NotificationsTest extends DuskTestCase {
 
     public function testNotificationFetchAccounts404(){
         // FORCE 404 from `GET /api/accounts`
-        DB::statement("DELETE FROM accounts");
+        DB::statement("TRUNCATE accounts");
 
         $this->browse(function (Browser $browser) {
             $browser->visit(new HomePage())
@@ -69,21 +69,7 @@ class NotificationsTest extends DuskTestCase {
     }
 
     public function testNotificationFetchAccounts500(){
-        // This query is accurate as of migration:
-        // 2018_07_17_160556_add_accounts_column_currency.php
-        $recreate_table_query = <<<MYSQL
-CREATE TABLE accounts (
-  id             int(10)  unsigned   PRIMARY KEY  auto_increment,
-  name           varchar(100),
-  institution_id int(10) unsigned,
-  disabled       tinyint(3) unsigned DEFAULT 0,
-  total          decimal(10,2)       DEFAULT 0.00,
-  currency       char(3)             DEFAULT "USD",
-  create_stamp   timestamp           NULL DEFAULT NULL,
-  modified_stamp timestamp           NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  disabled_stamp timestamp           NULL DEFAULT NULL
-);
-MYSQL;
+        $recreate_table_query = $this->getTableRecreationQuery('accounts');
 
         $this->browse(function (Browser $browser) use ($recreate_table_query){
             // FORCE 500 from `GET /api/accounts`
@@ -101,7 +87,7 @@ MYSQL;
 
     public function testNotificationFetchAccountTypes404(){
         // FORCE 404 from `GET /api/account-types`
-        DB::statement("DELETE FROM account_types");
+        DB::statement("TRUNCATE account_types");
 
         $this->browse(function (Browser $browser) {
             $browser->visit(new HomePage())
@@ -113,21 +99,7 @@ MYSQL;
     }
 
     public function testNotificationFetchAccountTypes500(){
-        // This query is accurate as of migration:
-        // 2018_09_25_011033_update_account_types_column_type.php
-        $recreate_table_query = <<<MYSQL
-CREATE TABLE account_types (
-  id             int(10)  unsigned   PRIMARY KEY  auto_increment,
-  type           enum('checking','savings','credit card','debit card','loan'),
-  last_digits    varchar(4),
-  name           varchar(100),
-  account_id int(10) unsigned,
-  disabled       tinyint(3) unsigned DEFAULT 0,
-  create_stamp   timestamp           NULL DEFAULT NULL,
-  modified_stamp timestamp           NOT NULL DEFAULT CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP,
-  disabled_stamp timestamp           NULL DEFAULT NULL
-);
-MYSQL;
+        $recreate_table_query = $this->getTableRecreationQuery('account_types');
 
         $this->browse(function (Browser $browser) use ($recreate_table_query){
             // FORCE 500 from `GET /api/account-types`
@@ -194,11 +166,8 @@ MYSQL;
     }
 
     public function testNotificationFetchEntries404(){
-        // TODO: see note: -----------------VVV-----------------
-        $this->markTestIncomplete("Can't do this right now. Need to move notifications into their own component");
-
         // FORCE 404 from `GET /api/entries`
-        DB::statement("DELETE FROM entries");
+        DB::statement("TRUNCATE entries");
 
         $this->browse(function (Browser $browser) {
             $browser->visit(new HomePage())
@@ -210,26 +179,7 @@ MYSQL;
     }
 
     public function testNotificationFetchEntries500(){
-        // TODO: see note: -----------------VVV-----------------
-        $this->markTestIncomplete("Can't do this right now. Need to move notifications into their own component");
-
-        // This query is accurate as of migration:
-        // 2017_11_21_161444_rename_tags_tag_column_to_name.php
-        $recreate_table_query = <<<MYSQL
-CREATE TABLE entries (
-  id               int(10) unsigned      PRIMARY KEY  auto_increment,
-  entry_date       date,
-  account_type_id  int(10) unsigned,
-  entry_value      decimal(10,2),
-  memo             text,
-  expense          tinyint(3) unsigned,
-  confirm          tinyint(3) unsigned,
-  disabled         tinyint(1)            DEFAULT 0,
-  create_stamp     timestamp             NULL DEFAULT NULL,
-  modified_stamp   timestamp             NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  disabled_stamp   timestamp             NULL DEFAULT NULL 
-);
-MYSQL;
+        $recreate_table_query = $this->getTableRecreationQuery('entries');
 
         $this->browse(function (Browser $browser) use ($recreate_table_query){
             // FORCE 500 from `GET /api/entries`
@@ -241,8 +191,6 @@ MYSQL;
                 ->waitUntilMissing($this->_selector_notification.$this->_selector_notification_error, HomePage::WAIT_SECONDS);
 
             DB::statement($recreate_table_query);
-
-
         });
     }
 
@@ -467,7 +415,7 @@ MYSQL;
 
     public function testNotificationFetchInstitutions404(){
         // FORCE 404 from `GET /api/institutions`
-        DB::statement("DELETE FROM institutions");
+        DB::statement("TRUNCATE institutions");
 
         $this->browse(function (Browser $browser) {
             $browser->visit(new HomePage())
@@ -479,17 +427,7 @@ MYSQL;
     }
 
     public function testNotificationFetchInstitutions500(){
-        // This query is accurate as of migration:
-        // 2017_06_26_170141_create_institutions_table.php
-        $recreate_table_query = <<<MYSQL
-CREATE TABLE institutions (
-  id             int(10) unsigned  PRIMARY KEY  auto_increment,
-  name           varchar(50),
-  active         tinyint(4)        DEFAULT 1,
-  create_stamp   timestamp         NULL DEFAULT NULL,
-  modified_stamp timestamp         NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-MYSQL;
+        $recreate_table_query = $this->getTableRecreationQuery('institutions');
 
         $this->browse(function (Browser $browser) use ($recreate_table_query){
             // FORCE 500 from `GET /api/institutions`
@@ -507,7 +445,7 @@ MYSQL;
 
     public function testNotificationFetchTags404(){
         // FORCE 404 from `GET /api/tags`
-        DB::statement("DELETE FROM tags");
+        DB::statement("TRUNCATE tags");
 
         $this->browse(function (Browser $browser) {
             $browser->visit(new HomePage())
@@ -517,14 +455,7 @@ MYSQL;
     }
 
     public function testNotificationFetchTags500(){
-        // This query is accurate as of migration:
-        // 2017_11_21_161444_rename_tags_tag_column_to_name.php
-        $recreate_table_query = <<<MYSQL
-CREATE TABLE tags (
-  id    int(10) unsigned  PRIMARY KEY  auto_increment,
-  name  varchar(50)
-);
-MYSQL;
+        $recreate_table_query = $this->getTableRecreationQuery('tags');
 
         $this->browse(function (Browser $browser) use ($recreate_table_query){
             // FORCE 500 from `GET /api/tags`
@@ -538,6 +469,11 @@ MYSQL;
 
             DB::statement($recreate_table_query);
         });
+    }
+
+    private function getTableRecreationQuery($table_name){
+        $create_query = DB::select("SHOW CREATE TABLE ".$table_name);
+        return $create_query[0]->{"Create Table"};
     }
 
 }

--- a/tests/Browser/Pages/HomePage.php
+++ b/tests/Browser/Pages/HomePage.php
@@ -10,6 +10,11 @@ class HomePage extends Page {
     const WAIT_SECONDS = 10;
     const WAIT_SECONDS_LONG = 30;
 
+    const NOTIFICATION_ERROR = 'error';
+    const NOTIFICATION_INFO = 'info';
+    const NOTIFICATION_SUCCESS = 'success';
+    const NOTIFICATION_WARNING = 'warning';
+
     /**
      * Get the URL for the page.
      *
@@ -36,12 +41,21 @@ class HomePage extends Page {
      */
     public function elements(){
         return [
+            // navbar
             '@navbar'=>'.navbar',
             '@new-entry-modal-btn'=>'#nav-entry-modal',
+            // loading-modal
             '@loading'=>'#loading-modal',
+            // entry-modal
             '@entry-modal'=>'#entry-modal',
             '@entry-modal-save-btn'=>"#entry-modal button#entry-save-btn",
-            '@edit-existing-entry-modal-btn'=>"button.button.edit-entry-button"
+            '@edit-existing-entry-modal-btn'=>"button.button.edit-entry-button",
+            // notification-modal
+            '@notification'=>".snotifyToast",
+            '@notification-error'=>".snotifyToast.snotify-error",
+            '@notification-info'=>".snotifyToast.snotify-info",
+            '@notification-success'=>".snotifyToast.snotify-success",
+            '@notification-warning'=>"TBD", // TODO: find selector
         ];
     }
 
@@ -81,6 +95,30 @@ class HomePage extends Page {
             $browser->attribute("@entry-modal-save-btn", 'disabled'),
             "Entry-modal save button IS disabled"
         );
+    }
+
+    public function assertNotification(Browser $browser, $notification_type, $notification_message){
+        switch($notification_type){
+            case self::NOTIFICATION_ERROR:
+                $notification_type_selector = '@notification-error';
+                break;
+            case self::NOTIFICATION_INFO:
+            default:
+                $notification_type_selector = '@notification-info';
+                break;
+            case self::NOTIFICATION_SUCCESS:
+                $notification_type_selector = '@notification-success';
+                break;
+            case self::NOTIFICATION_WARNING:
+                $notification_type_selector = '@notification-warning';
+                break;
+        }
+
+        $browser
+            ->waitFor('@notification', self::WAIT_SECONDS)
+            ->assertVisible($notification_type_selector)
+            ->assertSee($notification_message)
+            ->waitUntilMissing($notification_type_selector, self::WAIT_SECONDS);
     }
 
 }

--- a/tests/Browser/Pages/HomePage.php
+++ b/tests/Browser/Pages/HomePage.php
@@ -55,7 +55,7 @@ class HomePage extends Page {
             '@notification-error'=>".snotifyToast.snotify-error",
             '@notification-info'=>".snotifyToast.snotify-info",
             '@notification-success'=>".snotifyToast.snotify-success",
-            '@notification-warning'=>"TBD", // TODO: find selector
+            '@notification-warning'=>".snotifyToast.snotify-warning", // TODO: confirm this is correct
         ];
     }
 
@@ -118,7 +118,11 @@ class HomePage extends Page {
             ->waitFor('@notification', self::WAIT_SECONDS)
             ->assertVisible($notification_type_selector)
             ->assertSee($notification_message)
-            ->waitUntilMissing($notification_type_selector, self::WAIT_SECONDS);
+            // Selenium has issues on some tests.
+            // We need to mouse over the navbar to make sure that notification continues its progress of dismissal.
+            ->mouseover('@navbar')
+            ->waitUntilMissing($notification_type_selector, self::WAIT_SECONDS)
+            ->pause(250);    // give the element another 0.25 seconds to fully disappear;
     }
 
 }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -11,15 +11,15 @@ let mix = require('laravel-mix');
  |
  */
 
-let cssDirectory     = 'public/vue/css';
-let nodeDirectory    = 'node_modules';
-let jsDirectory      = 'public/vue/js';
-let webFontDirectory = 'public/vue/webfonts';
+let cssDirectory            = 'public/vue/css';
+let nodeDirectory           = 'node_modules';
+let jsDirectory             = 'public/vue/js';
+let webFontDirectory        = 'public/vue/webfonts';
+let resourceAssetsDirectory = 'resources/assets';
 
 mix.js('resources/assets/js/app.js', jsDirectory)
     // bulma-accordion
-    .js(nodeDirectory+'/bulma-accordion/dist/bulma-accordion.js', jsDirectory)
-    .copy(nodeDirectory+'/bulma-accordion/dist/bulma-accordion.min.css', cssDirectory+'/bulma-accordion.css')
+    .js(nodeDirectory+'/bulma-accordion/dist/bulma-accordion.min.js', jsDirectory+'/bulma-accordion.js')
     // dropzone
     .copy(nodeDirectory+'/vue2-dropzone/dist/vue2Dropzone.css', cssDirectory+'/vue-dropzone.css')
     // font-awesome
@@ -28,7 +28,5 @@ mix.js('resources/assets/js/app.js', jsDirectory)
     .copy(nodeDirectory+'/@fortawesome/fontawesome-free/webfonts/fa-regular-400.woff2', webFontDirectory+'/fa-regular-400.woff2')
     // tags-input
     .copy(nodeDirectory+'/@voerro/vue-tagsinput/dist/style.css', cssDirectory+'/tags-input.css')
-    // bulma-checkradio
-    .copy(nodeDirectory+'/bulma-checkradio/dist/css/bulma-checkradio.min.css', cssDirectory+'/bulma-checkradio.css')
 
-    .sass('resources/assets/sass/app.scss', cssDirectory);
+    .sass(resourceAssetsDirectory+'/sass/app.scss', cssDirectory);


### PR DESCRIPTION

- Corrected bug with assigning version value when `GET /api/version` fails.
- Correcting bugs that came into existence in the `institutions-panel` & `entry-modal` components due to a rebase.
- Correcting a bug that came into existence in the `resources/views/vue.build.php` file due to a rebase.
- Corrected a bug in `resources/assets/js/objectBaseClass.js` that stop the ability to use the `this` JavaScript context variable when a `fetch` request is made.
- Moved node `devDependencies` to `dependencies`
- `bulma-accordion` and `bulma-checkradio` node package css do not need to have their own files, instead they can be bundled in the `app.scss` file.
- Modified `app.scss` file to better import the related `sass` files.
- Added UI notifications that occur at certain events.
- Moved notifications into their own component.
- Found a cleaner/safer way of recreating tables dropped during testing.
- Logic to assert a notification was visible was used repeatedly. Moved logic into a method in the HomePage dusk page class.
- Named the network all the docker containers are on when initialised by `docker-compose`.
- Added `DatabaseMigrations` trait to e2e tests.