### PR TITLE
Feature/vuejs-ext/pagination

### DIFF
--- a/app/Entry.php
+++ b/app/Entry.php
@@ -205,6 +205,15 @@ class Entry extends BaseModel {
         return $this->attachments()->count() > 0;
     }
 
+    public function has_tags(){
+        try{
+            return $this->tags()->count() > 0;
+        } catch(\Exception $e){
+            error_log($e);
+            return false;
+        }
+    }
+
     /**
      * @return array
      */

--- a/app/Http/Controllers/Api/EntryController.php
+++ b/app/Http/Controllers/Api/EntryController.php
@@ -85,20 +85,20 @@ class EntryController extends Controller {
             return $this->provide_paged_entries_response([], $page_number);
         }
 
-        if(empty($filter_data['sort']) || !is_array($filter_data['sort'])){
+        if(empty($filter_data[self::FILTER_KEY_SORT]) || !is_array($filter_data[self::FILTER_KEY_SORT])){
             $sort_by = Entry::DEFAULT_SORT_PARAMETER;
             $sort_direction = Entry::DEFAULT_SORT_DIRECTION;
         } else {
-            $sort_by = empty($filter_data['sort']['parameter']) ? Entry::DEFAULT_SORT_PARAMETER : $filter_data['sort']['parameter'];
-            if(empty($filter_data['sort']['direction']) || !in_array($filter_data['sort']['direction'], [Entry::SORT_DIRECTION_ASC, Entry::SORT_DIRECTION_DESC])){
+            $sort_by = empty($filter_data[self::FILTER_KEY_SORT][self::FILTER_KEY_SORT_PARAMETER]) ? Entry::DEFAULT_SORT_PARAMETER : $filter_data[self::FILTER_KEY_SORT][self::FILTER_KEY_SORT_PARAMETER];
+            if(empty($filter_data[self::FILTER_KEY_SORT][self::FILTER_KEY_SORT_DIRECTION]) || !in_array($filter_data[self::FILTER_KEY_SORT][self::FILTER_KEY_SORT_DIRECTION], [Entry::SORT_DIRECTION_ASC, Entry::SORT_DIRECTION_DESC])){
                 $sort_direction = Entry::DEFAULT_SORT_DIRECTION;
             } else {
-                $sort_direction = $filter_data['sort']['direction'];
+                $sort_direction = $filter_data[self::FILTER_KEY_SORT][self::FILTER_KEY_SORT_DIRECTION];
             }
-            unset($filter_data['sort']);
+            unset($filter_data[self::FILTER_KEY_SORT]);
         }
 
-        $filter_validator = Validator::make($filter_data, self::get_filter_details());
+        $filter_validator = Validator::make($filter_data, self::get_filter_details(isset($filter_data[self::FILTER_KEY_TAGS])));
         if($filter_validator->fails()){
             return response(['error'=>'invalid filter provided'], HttpStatus::HTTP_BAD_REQUEST);
         }
@@ -470,7 +470,7 @@ class EntryController extends Controller {
         } else {
             foreach($entries_collection as $entry){
                 $entry->has_attachments = $entry->has_attachments();
-                $entry->tags = $entry->get_tag_ids();
+                $entry->tags = ($entry->has_tags()) ? $entry->tags = $entry->get_tag_ids() : [];
                 $entry->is_transfer = !is_null($entry->transfer_entry_id);
                 unset($entry->transfer_entry_id);
             }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -24,7 +24,7 @@ class AppServiceProvider extends ServiceProvider {
         // IDE Helper
         if ($this->app->environment() !== 'production') {
             $this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
-            $this->app->register(\Laravel\Dusk\DuskServiceProvider::class);
+            $this->app->register(DuskServiceProvider::class);
         }
     }
 }

--- a/app/Providers/DuskServiceProvider.php
+++ b/app/Providers/DuskServiceProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Providers;
+
+use Laravel\Dusk\Browser;
+use Laravel\Dusk\DuskServiceProvider as DuskServiceProviderBase;
+
+class DuskServiceProvider extends DuskServiceProviderBase {
+
+    /**
+     * Bootstrap the application services.
+     *
+     * @return void
+     */
+    public function boot(){
+        parent::boot(); // needed to allow original DuskServiceProvider to do it's thing
+
+        Browser::macro('scrollToElement', function ($element = null) {
+            $this->script("$('html, body').animate({ scrollTop: $('$element').offset().top }, 0);");
+
+            return $this;
+        });
+
+        Browser::macro('getBrowserLocale', function(){
+            $browser_locale = $this->script('return (navigator.language || navigator.languages[0] || navigator.browserLanguage)');
+            return $browser_locale[0];
+        });
+
+        Browser::macro('getBrowserLocaleDate', function(){
+            $browser_locale_date = $this->script('return new Date().toLocaleDateString()');
+            return $browser_locale_date[0];
+        });
+
+        Browser::macro('processLocaleDateForTyping', function($locale_date){
+            $locale_date_components = [];
+            if(strpos($locale_date, '/') !== false){
+                $locale_date_components = explode('/', $locale_date);
+            }elseif(strpos($locale_date, '-') !== false){
+                $locale_date_components = explode('-', $locale_date);
+            }
+            foreach($locale_date_components as $key=>$date_component){
+                $locale_date_components[$key] = ($date_component < 10) ? '0'.$date_component : $date_component;
+            }
+            return implode('', $locale_date_components);
+        });
+    }
+
+    /**
+     * Register the application services.
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function register(){
+        parent::register();  // needed to allow original DuskServiceProvider to do it's thing
+    }
+
+}

--- a/app/Providers/DuskServiceProvider.php
+++ b/app/Providers/DuskServiceProvider.php
@@ -26,6 +26,11 @@ class DuskServiceProvider extends DuskServiceProviderBase {
             return $browser_locale[0];
         });
 
+        Browser::macro('getDateFromLocale', function($locale, $date){
+            $formatter = new \IntlDateFormatter($locale, \IntlDateFormatter::SHORT, \IntlDateFormatter::NONE);
+            return $formatter->format(new \DateTime($date));
+        });
+
         Browser::macro('getBrowserLocaleDate', function(){
             $browser_locale_date = $this->script('return new Date().toLocaleDateString()');
             return $browser_locale_date[0];

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "keywords": ["laravel"],
     "type": "project",
     "require": {
+        "ext-intl": "*",
         "ext-json": "*",
         "php": ">=5.6.4",
         "doctrine/dbal": "^2.5",

--- a/docker/app.dockerfile
+++ b/docker/app.dockerfile
@@ -2,8 +2,9 @@ FROM php:5.6-apache
 
 # install php extensions
 RUN apt-get update \
-	&& apt-get install -y libmcrypt-dev mysql-client zlib1g-dev --no-install-recommends \
-    && docker-php-ext-install mcrypt pdo_mysql zip \
+	&& apt-get install -y libmcrypt-dev mysql-client zlib1g-dev libicu-dev g++ --no-install-recommends \
+	&& docker-php-ext-configure intl \
+    && docker-php-ext-install mcrypt pdo_mysql zip intl \
 	&& pecl install xdebug-2.5.5 \
     && docker-php-ext-enable xdebug
 

--- a/docker/app.dockerfile
+++ b/docker/app.dockerfile
@@ -24,6 +24,10 @@ RUN mkdir -p  $APACHE_DOCUMENT_ROOT \
 RUN echo '#!/bin/bash\nphp /var/www/money-tracker/artisan "$@"' > /usr/local/bin/artisan \
     && chmod +x /usr/local/bin/artisan
 
+# select a php.ini file
+RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini \
+	&& sed -i "s/;always_populate_raw_post_data = -1/always_populate_raw_post_data = -1/" $PHP_INI_DIR/php.ini
+
 # set php timezone
 RUN echo 'date.timezone = "UTC"' >> $PHP_INI_DIR/conf.d/php-timezone.ini
 

--- a/resources/assets/js/components/entries-table.vue
+++ b/resources/assets/js/components/entries-table.vue
@@ -72,7 +72,7 @@
                 return this.entries.retrieve;
             },
             isNextButtonVisible: function(){
-                return this.entries.count > this.pageMax && this.pageMax*(this.currentPage+1) < this.entries.responseCount
+                return this.entries.count > this.pageMax && this.pageMax*(this.currentPage+1) < this.entries.count
             },
             isPrevButtonVisible: function(){
                 return this.currentPage !== 0;

--- a/resources/assets/js/components/entries-table.vue
+++ b/resources/assets/js/components/entries-table.vue
@@ -1,65 +1,103 @@
 <template>
-    <table id="entry-table" class="table is-narrow is-striped is-hoverable is-fullwidth">
-        <thead>
-            <tr>
-                <th></th>
-                <th>Date</th>
-                <th>Memo</th>
-                <th class="has-text-right">Income</th>
-                <th class="has-text-right">Expense</th>
-                <th>Type</th>
-                <th><i class="fas fa-paperclip"></i></th>
-                <th><i class="fas fa-exchange-alt"></i></th>
-                <th><i class="fas fa-tags"></i></th>
-            </tr>
-        </thead>
-        <tbody>
-            <!-- TODO: update entry transfers are a thing -->
-            <entries-table-entry-row
-                v-for="entry in listOfEntries"
-                v-bind:key="entry.id"
-                v-bind:id="entry.id"
-                v-bind:date="entry.entry_date"
-                v-bind:accountTypeId="entry.account_type_id"
-                v-bind:value="entry.entry_value"
-                v-bind:memo="entry.memo"
-                v-bind:expense="entry.expense"
-                v-bind:confirm="entry.confirm"
-                v-bind:disabled="entry.disabled"
-                v-bind:hasAttachments="entry.has_attachments"
-                v-bind:isTransfer="entry.is_transfer"
-                v-bind:tagIds="entry.tags"
-            ></entries-table-entry-row>
-        </tbody>
-    </table>
+    <div>
+        <table id="entry-table" class="table is-narrow is-striped is-hoverable is-fullwidth">
+            <thead>
+                <tr>
+                    <th></th>
+                    <th>Date</th>
+                    <th>Memo</th>
+                    <th class="has-text-right">Income</th>
+                    <th class="has-text-right">Expense</th>
+                    <th>Type</th>
+                    <th><i class="fas fa-paperclip"></i></th>
+                    <th><i class="fas fa-exchange-alt"></i></th>
+                    <th><i class="fas fa-tags"></i></th>
+                </tr>
+            </thead>
+            <tbody>
+                <!-- TODO: update entry transfers are a thing -->
+                <entries-table-entry-row
+                    v-for="entry in listOfEntries"
+                    v-bind:key="entry.id"
+                    v-bind:id="entry.id"
+                    v-bind:date="entry.entry_date"
+                    v-bind:accountTypeId="entry.account_type_id"
+                    v-bind:value="entry.entry_value"
+                    v-bind:memo="entry.memo"
+                    v-bind:expense="entry.expense"
+                    v-bind:confirm="entry.confirm"
+                    v-bind:disabled="entry.disabled"
+                    v-bind:hasAttachments="entry.has_attachments"
+                    v-bind:isTransfer="entry.is_transfer"
+                    v-bind:tagIds="entry.tags"
+                ></entries-table-entry-row>
+            </tbody>
+        </table>
+        <div id="pagination-buttons" class="level">
+            <div class="level-left">
+                <div class="level-item"><button id="paginate-btn-prev" class="button is-primary"
+                    v-on:click="prevPage"
+                    v-show="isPrevButtonVisible"
+                >Previous</button></div>
+            </div>
+            <div class="level-right">
+                <div class="level-item"><button id="paginate-btn-next" class="button is-primary"
+                    v-on:click="nextPage"
+                    v-show="isNextButtonVisible"
+                >Next</button></div>
+            </div>
+        </div>
+    </div>
 </template>
 
 <script>
     import {Entries} from '../entries';
     import EntriesTableEntryRow from "./entries-table-entry-row";
+    import Store from '../store';
 
     export default {
         name: "entries-table",
         components: {EntriesTableEntryRow},
         data: function(){
             return {
-                entries: new Entries()
+                entries: new Entries(),
+                pageMax: 50
             }
         },
         computed: {
+            currentPage: function(){
+                return Store.getters.currentPage;
+            },
             listOfEntries: function(){
                 return this.entries.retrieve;
+            },
+            isNextButtonVisible: function(){
+                return this.entries.count > this.pageMax && this.pageMax*(this.currentPage+1) < this.entries.responseCount
+            },
+            isPrevButtonVisible: function(){
+                return this.currentPage !== 0;
             }
         },
         methods: {
-            updateEntriesTable: function(){
-                this.entries.fetch()
+            updateEntriesTable: function(pageNumber){
+                this.entries.fetch(pageNumber)
                     .then(function(notification){
                         this.$eventHub.broadcast(this.$eventHub.EVENT_NOTIFICATION, notification);
                     }.bind(this))
                     .finally(function(){
                         this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_HIDE);
                     }.bind(this));
+            },
+            nextPage: function(){
+                this.setPage(this.currentPage+1);
+            },
+            prevPage: function(){
+                this.setPage(this.currentPage-1);
+            },
+            setPage: function(newPageNumber){
+                this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_SHOW);
+                Store.dispatch('currentPage', newPageNumber);
+                this.updateEntriesTable(this.currentPage);
             }
         },
         created: function(){
@@ -69,5 +107,13 @@
 </script>
 
 <style scoped>
-
+    table#entry-table{
+        margin-bottom: 0.25rem;
+    }
+    #pagination-buttons{
+        padding: 0 7px 5px;
+    }
+    #pagination-buttons .button{
+        width: 100px;
+    }
 </style>

--- a/resources/assets/js/components/entry-modal.vue
+++ b/resources/assets/js/components/entry-modal.vue
@@ -184,6 +184,7 @@
     import {SnotifyStyle} from 'vue-snotify';
     import {Tags} from '../tags';
     import EntryModalAttachment from "./entry-modal-attachment";
+    import Store from '../store';
     import ToggleButton from 'vue-js-toggle-button/src/Button'
     import VoerroTagsInput from '@voerro/vue-tagsinput';
     import vue2Dropzone from 'vue2-dropzone';
@@ -235,6 +236,9 @@
             }
         },
         computed: {
+            currentPage: function(){
+                return Store.getters.currentPage;
+            },
             isConfirmed: function(){
                 return this.entryData.confirm && this.entryData.id;
             },
@@ -471,7 +475,7 @@
                             {type: notification.type, message: notification.message.replace('%s', this.entryData.id)}
                         );
                     }
-                    this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_TABLE_UPDATE);
+                    this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_TABLE_UPDATE, this.currentPage);
                     this.closeModal();
                 }.bind(this));
             },
@@ -488,7 +492,7 @@
                         }
                         this.closeModal();
                         if(deleteResult.deleted){
-                            this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_TABLE_UPDATE);
+                            this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_TABLE_UPDATE, this.currentPage);
                             // don't need to broadcast an event to hide the loading modal here
                             // already taken care of at the end of the entry-table update event process
                         } else {

--- a/resources/assets/js/components/transfer-modal.vue
+++ b/resources/assets/js/components/transfer-modal.vue
@@ -152,6 +152,7 @@
     import {Entry} from "../entry";
     import {SnotifyStyle} from 'vue-snotify';
     import {Tags} from '../tags';
+    import Store from '../store';
     import VoerroTagsInput from '@voerro/vue-tagsinput';
     import vue2Dropzone from 'vue2-dropzone';
 
@@ -217,6 +218,9 @@
             },
             canShowToAccountTypeMeta: function(){
                 return this.canShowAccountTypeMeta(this.transferData.to_account_type_id);
+            },
+            currentPage: function(){
+                return Store.getters.currentPage;
             },
             hasValidFromAccountTypeBeenSelected: function(){
                 return this.hasValidAccountTypeBeenSelected(this.transferData.from_account_type_id);
@@ -363,7 +367,7 @@
                             {type: notification.type, message: notification.message}
                         );
                     }
-                    this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_TABLE_UPDATE);
+                    this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_TABLE_UPDATE, this.currentPage);
                     this.closeModal();
                 }.bind(this));
             },

--- a/resources/assets/js/entries.js
+++ b/resources/assets/js/entries.js
@@ -10,6 +10,7 @@ export class Entries extends ObjectBaseClass {
         this.storeType = Store.getters.STORE_TYPE_ENTRIES;
         this.uri = '/api/entries/';
         this.sort = {parameter: 'entry_date', direction: 'desc'};
+        this.count = 0;
     }
 
     fetch(pageNumber, filterParameters = {}){
@@ -57,7 +58,7 @@ export class Entries extends ObjectBaseClass {
     }
 
     processSuccessfulResponseData(responseData){
-        let responseCount = parseInt(responseData.count);
+        this.count = parseInt(responseData.count);
         delete responseData.count;
 
         // convert responseData object into an array
@@ -66,7 +67,7 @@ export class Entries extends ObjectBaseClass {
             entry.fetchStamp = null;
             return entry;
         });
-        if(responseCount !== entriesInResponse.length) {
+        if(this.count !== entriesInResponse.length) {
             // FIXME: add error checking for request count values
             // notice.display(notice.typeWarning, "Not all "+storeType+" were downloaded");
         }

--- a/resources/assets/js/store.js
+++ b/resources/assets/js/store.js
@@ -9,6 +9,7 @@ export default new Vuex.Store({
 
     state: {
         // token: '',
+        currentPage: 0,
         version: '',
         tags: [],
         institutions: [],
@@ -25,11 +26,36 @@ export default new Vuex.Store({
         //     return state.token;
         // }
 
+        /**
+         * @returns {number}
+         */
+        currentPage: function(state){
+            return state.currentPage;
+        },
+
+        /**
+         * @returns {string}
+         */
         STORE_TYPE_ACCOUNTS: function(){ return 'accounts' },
+        /**
+         * @returns {string}
+         */
         STORE_TYPE_ACCOUNT_TYPES: function(){ return 'accountTypes' },
+        /**
+         * @returns {string}
+         */
         STORE_TYPE_ENTRIES: function(){ return 'entries' },
+        /**
+         * @returns {string}
+         */
         STORE_TYPE_INSTITUTIONS: function(){ return 'institutions' },
+        /**
+         * @returns {string}
+         */
         STORE_TYPE_TAGS: function(){ return 'tags' },
+        /**
+         * @returns {string}
+         */
         STORE_TYPE_VERSION: function(){ return 'version' },
 
         getStateOf: function(state, getters){
@@ -63,7 +89,9 @@ export default new Vuex.Store({
         // unauthenticate: function(state){
         //     state.token = '';
         // }
-
+        currentPage: function(state, pageNumber){
+            state.currentPage = (pageNumber < 0) ? 0 : pageNumber
+        },
         setStateOf: function(state, payload){
             let storeTypes = this.getters.getAllStoreTypes;
             if(storeTypes.indexOf(payload.type) >= 0){
@@ -78,11 +106,12 @@ export default new Vuex.Store({
         // unauthenticate: function(context){
         //     context.commit('unauthenticate');
         // }
-
+        currentPage: function(context, payload){
+            context.commit('currentPage', payload);
+        },
         setStateOf: function(context, payload){
             context.commit('setStateOf', payload);
         }
-
     },
     plugins: [
         // createPersistedState()  // allows us to store state locally

--- a/resources/views/vue.blade.php
+++ b/resources/views/vue.blade.php
@@ -28,7 +28,9 @@
             <div class="column">
                 <entries-table></entries-table>
             </div>
+            <!-- modal components -->
             <entry-modal></entry-modal>
+            <transfer-modal></transfer-modal>
             <!--
             loading-modal must ALWAYS be on the bottom.
             This way if the loading-modal is active and another modal is active,
@@ -37,7 +39,6 @@
             <loading-modal></loading-modal>
             <!-- notifications are the only exception -->
             <notification></notification>
-            <transfer-modal></transfer-modal>
         </div>
     </div>
     <script type="text/javascript" src="{{asset('vue/js/app.js')}}"></script>

--- a/tests/Browser/PaginationTest.php
+++ b/tests/Browser/PaginationTest.php
@@ -17,6 +17,9 @@ class PaginationTest extends DuskTestCase {
     use DatabaseMigrations;
     use HomePageSelectors;
 
+    const RESIZE_WIDTH_PX = 1400;
+    const RESIZE_HEIGHT_PX = 2500;
+
     const PAGE_NUMBER_ZERO = 0;
     const PAGE_NUMBER_ONE = 1;
     const PAGE_NUMBER_TWO = 2;
@@ -40,6 +43,7 @@ class PaginationTest extends DuskTestCase {
             $browser
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
+                ->resize(self::RESIZE_WIDTH_PX, self::RESIZE_HEIGHT_PX)
                 ->assertMissing($this->_selector_pagination_btn_next)
                 ->assertMissing($this->_selector_pagination_btn_prev);
         });
@@ -54,6 +58,7 @@ class PaginationTest extends DuskTestCase {
             $browser
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
+                ->resize(self::RESIZE_WIDTH_PX, self::RESIZE_HEIGHT_PX)
                 ->assertMissing($this->_selector_pagination_btn_prev)
                 ->assertVisible($this->_selector_pagination_btn_next);
         });
@@ -73,6 +78,7 @@ class PaginationTest extends DuskTestCase {
             $browser
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
+                ->resize(self::RESIZE_WIDTH_PX, self::RESIZE_HEIGHT_PX)
                 ->assertVisible($this->_selector_pagination_btn_next)
                 ->click($this->_selector_pagination_btn_next)
                 ->waitForLoadingToStop()
@@ -100,6 +106,7 @@ class PaginationTest extends DuskTestCase {
             $browser
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
+                ->resize(self::RESIZE_WIDTH_PX, self::RESIZE_HEIGHT_PX)
                 ->assertVisible($this->_selector_pagination_btn_next);
 
             $this->assertEntriesDisplayed($browser, $entries);
@@ -123,6 +130,7 @@ class PaginationTest extends DuskTestCase {
             $browser
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
+                ->resize(self::RESIZE_WIDTH_PX, self::RESIZE_HEIGHT_PX)
                 ->click($this->_selector_pagination_btn_next)
                 ->waitForLoadingToStop();
 
@@ -170,6 +178,7 @@ class PaginationTest extends DuskTestCase {
             $browser
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
+                ->resize(self::RESIZE_WIDTH_PX, self::RESIZE_HEIGHT_PX)
                 ->click($this->_selector_pagination_btn_next)
                 ->waitForLoadingToStop();
 
@@ -204,7 +213,6 @@ class PaginationTest extends DuskTestCase {
      * @param array $entries
      */
     private function assertEntriesDisplayed(Browser $browser, $entries){
-        $browser->resize(1400, 2500);
         foreach($entries as $entry){
             $browser
                 ->assertSeeIn($this->_selector_table, $entry['entry_date'])

--- a/tests/Browser/PaginationTest.php
+++ b/tests/Browser/PaginationTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Entry;
+use App\Http\Controllers\Api\EntryController;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Tests\Browser\Pages\HomePage;
+use Tests\DuskTestCase;
+use Laravel\Dusk\Browser;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Tests\Traits\HomePageSelectors;
+
+class PaginationTest extends DuskTestCase {
+
+    use DatabaseMigrations;
+    use HomePageSelectors;
+
+    const PAGE_NUMBER_ZERO = 0;
+    const PAGE_NUMBER_ONE = 1;
+    const PAGE_NUMBER_TWO = 2;
+
+    const ENTRY_COUNT_ONE = 10;     // number of entries needed to be generated for 1 page of results
+    const ENTRY_COUNT_TWO = 40;     // number of entries needed to be generated for 2 pages of results
+    const ENTRY_COUNT_THREE = 75;   // number of entries needed to be generated for 3 pages of results
+
+    public function setUp(){
+        parent::setUp();
+        Artisan::call('db:seed', ['--class'=>'UiSampleDatabaseSeeder']);
+    }
+
+    public function testPaginationButtonsNotVisibleIfEntryCountLessThanPageMax(){
+        DB::statement("TRUNCATE entries");
+        factory(Entry::class, self::ENTRY_COUNT_ONE)->create($this->entryOverrideAttributes());
+        $entries = $this->getApiEntries();
+        $this->assertLessThan(EntryController::MAX_ENTRIES_IN_RESPONSE, $entries['count']);
+
+        $this->browse(function (Browser $browser){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->assertMissing($this->_selector_pagination_btn_next)
+                ->assertMissing($this->_selector_pagination_btn_prev);
+        });
+    }
+
+    public function testNextPaginationButtonVisibleIfEntryCountGreaterThanPageMax(){
+        factory(Entry::class, self::ENTRY_COUNT_TWO)->create($this->entryOverrideAttributes());
+        $entries = $this->getApiEntries();
+        $this->assertGreaterThanOrEqual(EntryController::MAX_ENTRIES_IN_RESPONSE, $entries['count']);
+
+        $this->browse(function (Browser $browser){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->assertMissing($this->_selector_pagination_btn_prev)
+                ->assertVisible($this->_selector_pagination_btn_next);
+        });
+    }
+
+    public function testPreviousPaginationButtonsVisiblePagedToNextPage(){
+        factory(Entry::class, self::ENTRY_COUNT_THREE)->create($this->entryOverrideAttributes());
+        $entries_page1 = $this->getApiEntries(self::PAGE_NUMBER_ONE);
+        $entries_page2 = $this->getApiEntries(self::PAGE_NUMBER_TWO);
+
+        $this->assertEquals($entries_page1['count'], $entries_page2['count']);
+        $this->assertGreaterThanOrEqual(EntryController::MAX_ENTRIES_IN_RESPONSE*2, $entries_page1['count']);
+        $this->assertLessThan(EntryController::MAX_ENTRIES_IN_RESPONSE*3, $entries_page2['count']);
+
+        $this->browse(function (Browser $browser) use ($entries_page1, $entries_page2){
+            unset($entries_page1['count'], $entries_page2['count']);
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->assertVisible($this->_selector_pagination_btn_next)
+                ->click($this->_selector_pagination_btn_next)
+                ->waitForLoadingToStop()
+                ->assertVisible($this->_selector_pagination_btn_prev);
+            $this->assertEntriesDisplayed($browser, $entries_page1);
+
+            $browser
+                ->assertVisible($this->_selector_pagination_btn_next)
+                ->click($this->_selector_pagination_btn_next)
+                ->waitForLoadingToStop()
+                ->assertVisible($this->_selector_pagination_btn_prev)
+                ->assertMissing($this->_selector_pagination_btn_next);
+            $this->assertEntriesDisplayed($browser, $entries_page2);
+
+        });
+    }
+
+    public function testClickPreviousPaginationButtonToViewFirstPageOfEntries(){
+        factory(Entry::class, self::ENTRY_COUNT_TWO)->create($this->entryOverrideAttributes());
+        $entries = $this->getApiEntries();
+        $this->assertGreaterThanOrEqual(EntryController::MAX_ENTRIES_IN_RESPONSE, $entries['count']);
+        unset($entries['count']);
+
+        $this->browse(function (Browser $browser) use ($entries){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->assertVisible($this->_selector_pagination_btn_next);
+
+            $this->assertEntriesDisplayed($browser, $entries);
+
+            $browser
+                ->click($this->_selector_pagination_btn_next)
+                ->waitForLoadingToStop()
+                ->click($this->_selector_pagination_btn_prev)
+                ->waitForLoadingToStop();
+
+            $this->assertEntriesDisplayed($browser, $entries);
+        });
+    }
+
+    public function testPaginationWithEntryCreationUsingEntryModal(){
+        factory(Entry::class, self::ENTRY_COUNT_TWO)->create($this->entryOverrideAttributes());
+        $entries_original = $this->getApiEntries(self::PAGE_NUMBER_ONE);
+        $this->assertGreaterThan(EntryController::MAX_ENTRIES_IN_RESPONSE, $entries_original['count']);
+
+        $this->browse(function(Browser $browser) use ($entries_original){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->click($this->_selector_pagination_btn_next)
+                ->waitForLoadingToStop();
+
+            $entries_count = $entries_original['count'];
+            unset($entries_original['count']);
+            $this->assertEntriesDisplayed($browser, $entries_original);
+
+            $new_entry_date = date("Y-m-d", strtotime($entries_original[0]['entry_date'].' - 1 day'));
+            $new_entry_date_to_type = $browser->processLocaleDateForTyping($browser->getDateFromLocale($browser->getBrowserLocale(), $new_entry_date));
+
+            $browser
+                ->openNewEntryModal()
+                ->with($this->_selector_modal_entry, function($entry_modal_body) use ($new_entry_date_to_type){
+                    $account_types = $this->getApiAccountTypes();
+                    $account_type_id = collect($account_types)->pluck('id')->random(1)->first();
+                    $entry_modal_body
+                        ->type($this->_selector_modal_entry_field_date, $new_entry_date_to_type)
+                        ->type($this->_selector_modal_entry_field_value, "342.36")
+                        ->select($this->_selector_modal_entry_field_account_type, $account_type_id)
+                        ->type($this->_selector_modal_entry_field_memo, "Pagination entry-modal test")
+                        ->click($this->_selector_modal_entry_btn_save);
+                })
+                ->waitForLoadingToStop()
+                ->assertVisible($this->_selector_pagination_btn_prev);
+
+            $entries_updated = $this->getApiEntries(self::PAGE_NUMBER_ONE);
+            $this->assertGreaterThan($entries_count, $entries_updated['count']);
+            unset($entries_updated['count']);
+            $this->assertEntriesDisplayed($browser, $entries_updated);
+        });
+    }
+
+    public function testPaginationWithEntryCreationUsingTransferModal(){
+        factory(Entry::class, self::ENTRY_COUNT_TWO)->create($this->entryOverrideAttributes());
+        $entries_original = $this->getApiEntries(self::PAGE_NUMBER_ONE);
+        $this->assertGreaterThan(EntryController::MAX_ENTRIES_IN_RESPONSE, $entries_original['count']);
+
+        $all_account_types = $this->getApiAccountTypes();
+        $account_type_ids = collect($all_account_types)->pluck('id')->random(2)->toArray();
+
+        $this->browse(function(Browser $browser) use ($entries_original, $account_type_ids){
+            $entries_count = $entries_original['count'];
+            unset($entries_original['count']);
+
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->click($this->_selector_pagination_btn_next)
+                ->waitForLoadingToStop();
+
+            $this->assertEntriesDisplayed($browser, $entries_original);
+
+            $new_entry_date = date("Y-m-d", strtotime($entries_original[0]['entry_date'].' - 1 day'));
+            $new_entry_date_to_type = $browser->processLocaleDateForTyping($browser->getDateFromLocale($browser->getBrowserLocale(), $new_entry_date));
+
+            $browser
+                ->openTransferModal()
+                ->with($this->_selector_modal_transfer, function($modal) use ($new_entry_date_to_type, $account_type_ids){
+                    $modal
+                        ->type($this->_selector_modal_transfer_field_date, $new_entry_date_to_type)
+                        ->type($this->_selector_modal_transfer_field_value, "4820.23")
+                        ->select($this->_selector_modal_transfer_field_from, $account_type_ids[0])
+                        ->select($this->_selector_modal_transfer_field_to, $account_type_ids[1])
+                        ->type($this->_selector_modal_transfer_field_memo, "Pagination transfer-modal test")
+                        ->click($this->_selector_modal_transfer_btn_save);
+                })
+                ->waitForLoadingToStop()
+                ->assertVisible($this->_selector_pagination_btn_prev);
+
+            $entries_updated = $this->getApiEntries(self::PAGE_NUMBER_ONE);
+            $this->assertGreaterThan($entries_count, $entries_updated['count']);
+            unset($entries_updated['count']);
+            $this->assertEntriesDisplayed($browser, $entries_updated);
+        });
+    }
+
+    /**
+     * @param Browser $browser
+     * @param array $entries
+     */
+    private function assertEntriesDisplayed(Browser $browser, $entries){
+        $browser->resize(1400, 2500);
+        foreach($entries as $entry){
+            $browser
+                ->assertSeeIn($this->_selector_table, $entry['entry_date'])
+                ->assertSeeIn($this->_selector_table, $entry['memo'])
+                ->assertSeeIn($this->_selector_table, $entry['entry_value']);
+        }
+    }
+
+    private function entryOverrideAttributes(){
+        $account_types = $this->getApiAccountTypes();
+        $account_type_id = collect($account_types)->pluck('id')->random(1)->first();
+        return ['disabled'=>0, 'account_type_id'=>$account_type_id];
+    }
+
+}

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -33,6 +33,9 @@ abstract class DuskTestCase extends BaseTestCase {
         );
     }
 
+    /**
+     * @return array
+     */
     public function getApiTags(){
         $tags_response = $this->get("/api/tags");
         $tags = $tags_response->json();
@@ -40,6 +43,9 @@ abstract class DuskTestCase extends BaseTestCase {
         return $tags;
     }
 
+    /**
+     * @return array
+     */
     public function getApiAccountTypes(){
         $account_types_response = $this->get("/api/account-types");
         $account_types = $account_types_response->json();
@@ -47,10 +53,24 @@ abstract class DuskTestCase extends BaseTestCase {
         return $account_types;
     }
 
+    /**
+     * @param int $entry_id
+     * @return array
+     */
     public function getApiEntry($entry_id){
         $entry_response = $this->get("/api/entry/".$entry_id);
         $entry = $entry_response->json();
         return $entry;
+    }
+
+    /**
+     * @param int $page_number
+     * @return array
+     */
+    public function getApiEntries($page_number=0){
+        $entries_response = $this->json('POST', '/api/entries/'.$page_number, ["sort"=>["parameter"=>"entry_date", "direction"=>"desc"]]);
+        $entries = $entries_response->json();
+        return $entries;
     }
 
 }

--- a/tests/Traits/HomePageSelectors.php
+++ b/tests/Traits/HomePageSelectors.php
@@ -55,8 +55,8 @@ trait HomePageSelectors {
 
     // transfer-modal
     private $_selector_modal_transfer = "@transfer-modal";
-    private $_selector_modal_transfer_field_date = "#transfer-date";
-    private $_selector_modal_transfer_field_value = "#transfer-value";
+    private $_selector_modal_transfer_field_date = "input#transfer-date";
+    private $_selector_modal_transfer_field_value = "input#transfer-value";
     private $_selector_modal_transfer_field_from = "select#from-account-type";
     private $_selector_modal_transfer_field_from_is_loading = ".select.is-loading select#from-account-type";
     private $_selector_modal_transfer_meta_account_name_from = "#from-account-type-meta-account-name";
@@ -84,7 +84,8 @@ trait HomePageSelectors {
     private $_selector_table_row_attachment_checkbox = "td:nth-last-child(3)";
     private $_selector_table_is_checked_checkbox = ".fas.fa-check-square";
     private $_selector_table_unchecked_checkbox = "far fa-square";
-
+    private $_selector_pagination_btn_next = "button#paginate-btn-next";
+    private $_selector_pagination_btn_prev = "button#paginate-btn-prev";
 
     // ###*** LABELS ***###
     private $_label_entry_new = "Entry: new";


### PR DESCRIPTION
- Using `php.ini-development` as the default `php.ini` for the `app.money-tracker`.
- Turning off `always_populate_raw_post_data` as it is deprecated and isn't turned off by default.
- Created a Service provider for Dusk that extends the original Service provider.
- Added Browser macros to the new Dusk service provider.
- Moved `getBrowserLocaleDate()` and `processLocaleDateForTyping()` methods from `TransferModalTest` to be Browser macros.
- Added pagination to the entries-table component.