### PR TITLE
Feature/vuejs ext/filter modal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,6 @@ script:
   - docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite web
   - docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite unit
   # Laravel Dusk (UI) testing
-  - docker container exec -t app.money-tracker artisan migrate:refresh
-  - docker container exec -t app.money-tracker artisan db:seed --class=UiSampleDatabaseSeeder
   - docker container exec -t app.money-tracker artisan dusk --stop-on-failure
 
 # $WEBHOOK_URL should be set in travis-ci settings

--- a/app/Providers/DuskServiceProvider.php
+++ b/app/Providers/DuskServiceProvider.php
@@ -43,6 +43,16 @@ class DuskServiceProvider extends DuskServiceProviderBase {
             }elseif(strpos($locale_date, '-') !== false){
                 $locale_date_components = explode('-', $locale_date);
             }
+
+            // we're assuming the year in the date provided will always be the last component
+            $year = end($locale_date_components);
+            if(strlen($year) == 2){    // this is assuming the year is the last component of the date
+                if($year >= 70 && $year <= 99){   // should never be a value before 1970
+                    $locale_date_components[count($locale_date_components)-1] = "19".$year;
+                } else {
+                    $locale_date_components[count($locale_date_components)-1] = "20".$year;
+                }
+            }
             foreach($locale_date_components as $key=>$date_component){
                 $locale_date_components[$key] = ($date_component < 10) ? '0'.$date_component : $date_component;
             }

--- a/docker/app.dockerfile
+++ b/docker/app.dockerfile
@@ -25,7 +25,7 @@ RUN mkdir -p  $APACHE_DOCUMENT_ROOT \
 RUN echo '#!/bin/bash\nphp /var/www/money-tracker/artisan "$@"' > /usr/local/bin/artisan \
     && chmod +x /usr/local/bin/artisan
 
-# select a php.ini file
+# select a php.ini config file; we use php.ini-development as it has "display_errors = On"
 RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini \
 	&& sed -i "s/;always_populate_raw_post_data = -1/always_populate_raw_post_data = -1/" $PHP_INI_DIR/php.ini
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ..:/var/www/money-tracker  # .. is interpreted as relative to the location of the Compose file
     environment:
-      - PHP_IDE_CONFIG="serverName=money-tracker.docker"
+      - PHP_IDE_CONFIG=serverName=money-tracker.docker
       - APP_ENV=docker
     extra_hosts:
       - dockerhost:$DOCKER_HOST_IP
@@ -39,6 +39,8 @@ services:
   selenium: # needed for e2e (End-to-End) testing
     image: selenium/standalone-chrome:latest
     container_name: "selenium.money-tracker"
+    depends_on:
+      - application
     links:
       - application:money-tracker.docker
     volumes:

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "randomcolor": "^0.5.3",
     "toastr": "^2.1.4",
     "v-hotkey": "^0.3.0",
-    "vue-js-toggle-button": "^1.2.3",
+    "vue": "^2.1.10",
+    "vue-js-toggle-button": "^1.3.1",
     "vue-snotify": "^3.2.1",
     "vue-spinner-component": "^1.0.5",
     "vue2-dropzone": "^3.2.2",
-    "vue": "^2.1.10",
     "vuex": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,33 +8,23 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.1.0",
     "@voerro/vue-tagsinput": "^1.8.0",
-    "bootstrap": "3.3.7",
-    "bootstrap-3-typeahead": "4.0.2",
-    "bootstrap-material-design-icons": "2.2.0",
-    "bootstrap-switch": "3.3.4",
-    "bootstrap-tagsinput": "^0.7.1",
+    "axios": "^0.16.2",
     "bulma": "^0.6.2",
     "bulma-accordion": "^1.0.1",
     "bulma-badge": "^1.0.1",
     "bulma-checkradio": "^2.1.0",
     "bulma-tooltip": "^1.0.4",
-    "jquery-file-upload": "4.0.2",
+    "cross-env": "^5.0.1",
+    "laravel-mix": "^1.0",
+    "lodash": "^4.17.4",
     "randomcolor": "^0.5.3",
     "toastr": "^2.1.4",
     "v-hotkey": "^0.3.0",
-    "vue-bulma-collapse": "^1.0.3",
     "vue-js-toggle-button": "^1.2.3",
     "vue-snotify": "^3.2.1",
     "vue-spinner-component": "^1.0.5",
     "vue2-dropzone": "^3.2.2",
+    "vue": "^2.1.10",
     "vuex": "^3.0.1"
-  },
-  "devDependencies": {
-    "axios": "^0.16.2",
-    "cross-env": "^5.0.1",
-    "laravel-mix": "^1.0",
-    "lodash": "^4.17.4",
-    "toastr": "^2.1.4",
-    "vue": "^2.1.10"
   }
 }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -10,6 +10,7 @@ Vue.use(VueHotkey);
 import EntryModal from './components/entry-modal';
 import EntriesTable from './components/entries-table';
 import EntriesTableEntryRow from './components/entries-table-entry-row';
+import FilterModal from "./components/filter-modal";
 import InstitutionsPanel from './components/institutions-panel';
 import LoadingModal from './components/loading-modal';
 import Navbar from './components/navbar';
@@ -51,6 +52,14 @@ Vue.prototype.$eventHub = new Vue({
         /**
          * @returns {string}
          */
+        EVENT_FILTER_MODAL_OPEN: function(){ return "open-filter-modal"; },
+        /**
+         * @returns {string}
+         */
+        EVENT_FILTER_MODAL_CLOSE: function(){ return "close-filter-modal"; },
+        /**
+         * @returns {string}
+         */
         EVENT_TRANSFER_MODAL_OPEN: function(){ return "open-transfer-model"; }
 
         // TODO: EVENT_UPDATE_ACCOUNTS: update accounts in institutions panel when there is an entry update
@@ -71,6 +80,7 @@ new Vue({
         EntryModal,
         EntriesTable,
         EntriesTableEntryRow,
+        FilterModal,
         InstitutionsPanel,
         LoadingModal,
         Navbar,
@@ -92,7 +102,7 @@ new Vue({
         let accountTypes = new AccountTypes();
         accountTypes.fetch().then(this.displayNotification.bind(this));
 
-        this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_TABLE_UPDATE);
+        this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_TABLE_UPDATE, 0);
 
         let institutions = new Institutions();
         institutions.fetch().then(this.displayNotification.bind(this));

--- a/resources/assets/js/components/entries-table-entry-row.vue
+++ b/resources/assets/js/components/entries-table-entry-row.vue
@@ -12,20 +12,20 @@
             'has-tags': tagIds.length > 0
             }">
         <td><button class="button is-inverted is-info fas fa-edit edit-entry-button" v-on:click="openEditEntryModal(id)"></button></td>
-        <td v-text="date"></td>
-        <td v-text="memo"></td>
-        <td class="has-text-right">
+        <td v-text="date" class="row-entry-date"></td>
+        <td v-text="memo" class="row-entry-memo"></td>
+        <td class="has-text-right" v-bind:class="{'row-entry-value': !expense}">
             <span v-if="expense"></span>
-            <span v-else>${{value}}</span>
+            <span v-else>{{value}}</span>
         </td>
-        <td class="has-text-right">
-            <span v-if="expense">${{value}}</span>
+        <td class="has-text-right" v-bind:class="{'row-entry-value': expense}">
+            <span v-if="expense">{{value}}</span>
             <span v-else></span>
         </td>
-        <td v-text="accountTypeName"></td>
-        <td><i v-bind:class="{ 'far fa-square': !hasAttachments, 'fas fa-check-square': hasAttachments }"></i></td>
-        <td><i v-bind:class="{ 'far fa-square': !isTransfer, 'fas fa-check-square': isTransfer }"></i></td>
-        <td><div class="tags">
+        <td class="row-entry-account-type" v-text="accountTypeName"></td>
+        <td class="row-entry-attachment-checkbox"><i v-bind:class="{ 'far fa-square': !hasAttachments, 'fas fa-check-square': hasAttachments }"></i></td>
+        <td class="row-entry-transfer-checkbox"><i v-bind:class="{ 'far fa-square': !isTransfer, 'fas fa-check-square': isTransfer }"></i></td>
+        <td class="row-entry-tags"><div class="tags">
             <span class="tag is-rounded is-dark" v-for="tagId in tagIds" v-text="getTagName(tagId)"></span>
         </div></td>
     </tr>

--- a/resources/assets/js/components/entry-modal.vue
+++ b/resources/assets/js/components/entry-modal.vue
@@ -11,7 +11,7 @@
                         v-model="entryData.confirm"
                         v-bind:disabled="isLocked"
                     />
-                    <label for="entry-confirm"
+                    <label for="entry-confirm" class="checkbox-adjusted-top"
                         v-bind:class="{'has-text-grey-light': !entryData.confirm, 'has-text-white': entryData.confirm}"
                         >Confirmed</label>
                 </div>
@@ -185,7 +185,7 @@
     import {Tags} from '../tags';
     import EntryModalAttachment from "./entry-modal-attachment";
     import Store from '../store';
-    import ToggleButton from 'vue-js-toggle-button/src/Button'
+    import { ToggleButton } from 'vue-js-toggle-button';
     import VoerroTagsInput from '@voerro/vue-tagsinput';
     import vue2Dropzone from 'vue2-dropzone';
 
@@ -227,10 +227,17 @@
                     attachments: []
                 },
 
+                currency: {
+                    euro:     {label: "EUR", class: "fa-euro-sign"},
+                    dollarUs: {label: "USD", class: "fa-dollar-sign"},
+                    dollarCa: {label: "CAD", class: "fa-dollar-sign"},
+                    pound:    {label: "GBP", class: "fa-pound-sign"}
+                },
+
                 toggleButtonProperties: {
-                    colors: {'checked': '#ffcc00', 'unchecked': '#00d1b2'},
+                    colors: {checked: '#ffcc00', unchecked: '#00d1b2'},
                     height: 40,
-                    labels: {'checked': 'Expense', 'unchecked': 'Income'},
+                    labels: {checked: 'Expense', unchecked: 'Income'},
                     width: 200,
                 },
             }
@@ -500,12 +507,6 @@
                         }
                     }.bind(this));
             },
-            notAvailable: function(){
-                alert("This feature is not currently available");
-            },
-            warningAlert: function(){
-                alert("WARNING: This feature is still in beta. Expect unintended consequences.");
-            },
             updateAccountTypeMeta: function(){
                 let account = this.accountTypesObject.getAccount(this.entryData.account_type_id);
                 this.accountTypeMeta.accountName = account.name;
@@ -513,18 +514,21 @@
                 this.accountTypeMeta.lastDigits = accountType.last_digits;
 
                 switch(account.currency){
-                    case 'EUR':
-                        this.accountTypeMeta.currencyClass = "fa-euro-sign";
+                    case this.currency.euro.label:
+                        this.accountTypeMeta.currencyClass = this.currency.euro.class;
                         break;
 
-                    case 'GBP':
-                        this.accountTypeMeta.currencyClass = "fa-pound-sign";
+                    case this.currency.pound.label:
+                        this.accountTypeMeta.currencyClass = this.currency.pound.class;
                         break;
 
-                    case 'USD':
-                    case 'CAD':
+                    case this.currency.dollarCa.label:
+                        this.accountTypeMeta.currencyClass = this.currency.dollarCa.class;
+                        break;
+
+                    case this.currency.dollarUs.label:
                     default:
-                        this.accountTypeMeta.currencyClass = 'fa-dollar-sign';
+                        this.accountTypeMeta.currencyClass = this.currency.dollarUs.class;
                 }
             },
             resetEntryData: function(){
@@ -560,10 +564,6 @@
 </script>
 
 <style scoped>
-    .is-checkradio[type=checkbox].is-block+label::after,
-    .is-checkradio[type=checkbox].is-block+label:after{
-        top: 0.4rem;
-    }
     .field-label.is-normal{
         font-size: 13px;
     }

--- a/resources/assets/js/components/filter-modal.vue
+++ b/resources/assets/js/components/filter-modal.vue
@@ -1,0 +1,478 @@
+<template>
+    <div id="filter-modal" class="modal" v-bind:class="{'is-active': isVisible}" v-hotkey="keymap">
+        <div class="modal-background"></div>
+        <div class="modal-card">
+            <header class="modal-card-head">
+                <p class="modal-card-title">Filter Entries</p>
+                <button class="delete" aria-label="close" v-on:click="closeModal"></button>
+            </header>
+
+            <section class="modal-card-body">
+                <div class="field is-horizontal">
+                    <!--Start Date-->
+                    <div class="field-label is-normal"><label class="label" for="filter-start-date">Start Date:</label></div>
+                    <div class="field-body"><div class="field"><div class="control">
+                        <input class="input has-text-grey-dark" id="filter-start-date" name="filter-start-date" type="date"
+                           v-model="filterData.startDate"
+                        />
+                    </div></div></div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <!--End Date-->
+                    <div class="field-label is-normal"><label class="label" for="filter-end-date">End Date:</label></div>
+                    <div class="field-body"><div class="field"><div class="control">
+                        <input class="input has-text-grey-dark" id="filter-end-date" name="filter-end-date" type="date"
+                           v-model="filterData.endDate"
+                        />
+                    </div></div></div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <!--Acccount/Account-type-->
+                    <div class="field-label is-normal no-padding-top"><div class="label">
+                        <toggle-button
+                            id="filter-account-account-types"
+                            v-model="filterData.accountOrAccountTypeSelected"
+                            v-bind:value="filterData.accountOrAccountTypeSelected"
+                            v-bind:labels="{checked: 'Account', unchecked: 'Account Type'}"
+                            v-bind:color="{checked: toggleButtonProperties.colors.unchecked, unchecked: toggleButtonProperties.colors.unchecked}"
+                            v-bind:height="36"
+                            v-bind:width="140"
+                            v-bind:sync="true"
+                            v-on:click.native="resetAccountOrAccountTypeField"
+                        />
+                    </div></div>
+                    <div class="field-body"><div class="field">
+                        <div class="control"><div class="select" v-bind:class="{'is-loading': !areAccountsAndAccountTypesSet}">
+                            <select name="filter-account-or-account-types-id" id="filter-account-or-account-types-id" class="has-text-grey-dark"
+                                v-model="filterData.accountOrAccountTypeId"
+                                v-on:change="updateAccountCurrency"
+                                >
+                                <option value="" selected>[ ALL ]</option>
+                                <option
+                                    v-for="accountOrAccountType in listAccountOrAccountTypes"
+                                    v-bind:key="accountOrAccountType.id"
+                                    v-bind:value="accountOrAccountType.id"
+                                    v-text="accountOrAccountType.name"
+                                ></option>
+                            </select>
+                        </div></div>
+                    </div></div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <!--Tags-->
+                    <div class="field-label is-normal"><label class="label">Tags:</label></div>
+                    <div class="field-body"><div class="tags" id="filter-tags" v-bind:class="{'is-loading': !areTagsSet}">
+                        <!--TODO: make all values collapsible-->
+                        <div class="field" v-for="tag in listTags">
+                            <input class="is-checkradio is-block is-info" type="checkbox" name="filter-tag[]"
+                               v-bind:id="'filter-tag-'+tag.id"
+                               v-bind:value="tag.id"
+                               v-bind:checked="filterData.tags[tag.id]"
+                               v-model="filterData.tags[tag.id]"
+                            />
+                            <label class="checkbox-adjusted-top" v-bind:for="'filter-tag-'+tag.id" v-text="tag.name"></label>
+                        </div>
+                    </div></div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <!--Income-->
+                    <div class="field-label is-normal"><label class="label" for="filter-is-income">Income:</label></div>
+                    <div class="field-body"><div class="field"><div class="control">
+                        <toggle-button
+                            id="filter-is-income"
+                            v-model="filterData.isIncome"
+                            v-bind:value="filterData.isIncome"
+                            v-bind:labels="toggleButtonProperties.labels"
+                            v-bind:color="toggleButtonProperties.colors"
+                            v-bind:height="toggleButtonProperties.height"
+                            v-bind:width="toggleButtonProperties.width"
+                            v-bind:sync="true"
+                            v-on:click.native="flipCompanionSwitch('isExpense')"
+                        />
+                    </div></div></div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <!--Expense-->
+                    <div class="field-label is-normal"><label class="label" for="filter-is-expense">Expense:</label></div>
+                    <div class="field-body"><div class="field"><div class="control">
+                        <toggle-button
+                            id="filter-is-expense"
+                            v-model="filterData.isExpense"
+                            v-bind:value="filterData.isExpense"
+                            v-bind:labels="toggleButtonProperties.labels"
+                            v-bind:color="toggleButtonProperties.colors"
+                            v-bind:height="toggleButtonProperties.height"
+                            v-bind:width="toggleButtonProperties.width"
+                            v-bind:sync="true"
+                            v-on:click.native="flipCompanionSwitch('isIncome')"
+                        />
+                    </div></div></div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <!--Has Attachment(s)-->
+                    <div class="field-label is-normal"><label class="label" for="filter-has-attachment">Has Attachment(s):</label></div>
+                    <div class="field-body"><div class="field"><div class="control">
+                        <toggle-button
+                            id="filter-has-attachment"
+                            v-model="filterData.hasAttachment"
+                            v-bind:value="filterData.hasAttachment"
+                            v-bind:labels="toggleButtonProperties.labels"
+                            v-bind:color="toggleButtonProperties.colors"
+                            v-bind:height="toggleButtonProperties.height"
+                            v-bind:width="toggleButtonProperties.width"
+                            v-bind:sync="true"
+                            v-on:click.native="flipCompanionSwitch('noAttachment')"
+                        />
+                    </div></div></div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <!--No Attachment(s)-->
+                    <div class="field-label is-normal"><label class="label" for="filter-no-attachment">No Attachment(s):</label></div>
+                    <div class="field-body"><div class="field"><div class="control">
+                        <toggle-button
+                            id="filter-no-attachment"
+                            v-model="filterData.noAttachment"
+                            v-bind:value="filterData.noAttachment"
+                            v-bind:labels="toggleButtonProperties.labels"
+                            v-bind:color="toggleButtonProperties.colors"
+                            v-bind:height="toggleButtonProperties.height"
+                            v-bind:width="toggleButtonProperties.width"
+                            v-bind:sync="true"
+                            v-on:click.native="flipCompanionSwitch('hasAttachment')"
+                        />
+                    </div></div></div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <!--Transfer-->
+                    <div class="field-label is-normal"><label class="label" for="filter-is-transfer">Transfer:</label></div>
+                    <div class="field-body"><div class="field"><div class="control">
+                        <toggle-button
+                            id="filter-is-transfer"
+                            v-model="filterData.isTransfer"
+                            v-bind:value="filterData.isTransfer"
+                            v-bind:labels="toggleButtonProperties.labels"
+                            v-bind:color="toggleButtonProperties.colors"
+                            v-bind:height="toggleButtonProperties.height"
+                            v-bind:width="toggleButtonProperties.width"
+                            v-bind:sync="true"
+                        />
+                    </div></div></div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <!--Unconfirmed-->
+                    <div class="field-label is-normal"><label class="label" for="filter-unconfirmed">Not Confirmed:</label></div>
+                    <div class="field-body"><div class="field"><div class="control">
+                        <toggle-button
+                            id="filter-unconfirmed"
+                            v-model="filterData.unconfirmed"
+                            v-bind:value="filterData.unconfirmed"
+                            v-bind:labels="toggleButtonProperties.labels"
+                            v-bind:color="toggleButtonProperties.colors"
+                            v-bind:height="toggleButtonProperties.height"
+                            v-bind:width="toggleButtonProperties.width"
+                            v-bind:sync="true"
+                        />
+                    </div></div></div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <!--Min Range-->
+                    <div class="field-label is-normal"><label class="label" for="filter-min-value">Min Range:</label></div>
+                    <div class="field-body"><div class="field"><div class="control has-icons-left">
+                        <input class="input has-text-grey-dark" id="filter-min-value" name="filter-min-value" type="text" placeholder="999.99"
+                            v-model="filterData.minValue"
+                            v-on:change="decimaliseValue('minValue')"
+                        />
+                        <span class="icon is-left"><i class="fas" v-bind:class="accountCurrencyClass"></i></span>
+                    </div></div></div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <!--Max Range:                      | [input]-->
+                    <div class="field-label is-normal"><label class="label" for="filter-max-value">Max Range:</label></div>
+                    <div class="field-body"><div class="field"><div class="control has-icons-left">
+                        <input class="input has-text-grey-dark" id="filter-max-value" name="filter-max-value" type="text" placeholder="999.99"
+                               v-model="filterData.maxValue"
+                               v-on:change="decimaliseValue('maxValue')"
+                        />
+                        <span class="icon is-left"><i class="fas" v-bind:class="accountCurrencyClass"></i></span>
+                    </div></div></div>
+                </div>
+            </section>
+
+            <footer class="modal-card-foot">
+                <div class="container">
+                    <div class="field is-grouped">
+                        <div class="control is-expanded"></div>
+                        <div class="control">
+                            <button type="button" id="filter-cancel-btn" class="button" v-on:click="closeModal">Cancel</button>
+                            <button type="button" id="filter-reset-btn" class="button is-warning" v-on:click="resetFields">
+                                <i class="fas fa-undo-alt has-padding-right"></i>Reset
+                            </button>
+                            <button type="button" id="filter-btn" class="button is-primary" v-on:click="makeFilterRequest">
+                                <i class="fas fa-search has-padding-right"></i>Filter
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </footer>
+        </div>
+    </div>
+</template>
+
+<script>
+    import _ from 'lodash';
+    import {Accounts} from '../accounts';
+    import {AccountTypes} from '../account-types';
+    import {Tags} from '../tags';
+    import { ToggleButton } from 'vue-js-toggle-button'
+
+    export default {
+        name: "filter-modal",
+        components: {
+            ToggleButton,
+        },
+        data: function(){
+            return {
+                accountsObject: new Accounts(),
+                accountTypesObject: new AccountTypes(),
+                tagsObject: new Tags(),
+
+                isVisible: false,
+
+                accountCurrencyClass: "fa-dollar-sign",
+
+                switchValueAccount: true,
+                switchValueAccountType: false,
+
+                filterData: {},
+                defaultData: {
+                    startDate: "",
+                    endDate: "",
+                    accountOrAccountTypeSelected: null, // will be set by resetFields
+                    accountOrAccountTypeId: "",
+                    tags: [],
+                    isIncome: false,
+                    isExpense: false,
+                    hasAttachment: false,
+                    noAttachment: false,
+                    isTransfer: false,
+                    unconfirmed: false,
+                    minValue: "",
+                    maxValue: ""
+                },
+
+                currencyClass: {
+                    euro: "fa-euro-sign",
+                    dollar: "fa-dollar-sign",
+                    pound: "fa-pound-sign"
+                },
+
+                toggleButtonProperties: {
+                    labels: {checked: 'Enabled', unchecked: 'Disabled'},
+                    colors: {checked: '#209CEE', unchecked: '#B5B5B5'},
+                    height: 40,
+                    width: 200,
+                },
+            }
+        },
+        computed: {
+            areAccountsAndAccountTypesSet: function(){
+                return this.listAccountTypes.length > 0 && this.listAccounts.length > 0;
+            },
+            areTagsSet: function(){
+                return !_.isEmpty(this.listTags);
+            },
+            listAccountOrAccountTypes: function(){
+                if(this.filterData.accountOrAccountTypeSelected === this.switchValueAccount){
+                    return this.listAccounts
+                } else if(this.filterData.accountOrAccountTypeSelected === this.switchValueAccountType){
+                    return this.listAccountTypes
+                }
+            },
+            listAccountTypes: function(){
+                let accountTypes = this.accountTypesObject.retrieve;
+                return _.orderBy(accountTypes, 'name');
+            },
+            listAccounts: function(){
+                let accounts = this.accountsObject.retrieve;
+                return _.orderBy(accounts, 'name');
+            },
+            listTags: function(){
+                let tags = this.tagsObject.retrieve;
+                return _.orderBy(tags, 'name');
+            }
+        },
+        methods: {
+            keymap: function(){
+                return {
+                    'ctrl+esc': this.closeModal
+                }
+            },
+            openModal: function(){
+                this.isVisible = true;
+            },
+            closeModal: function(){
+                this.isVisible = false;
+            },
+            updateAccountCurrency: function(){
+                let account = null;
+                if(this.filterData.accountOrAccountTypeSelected === this.switchValueAccount){
+                    account = this.accountsObject.find(this.filterData.accountOrAccountTypeId);
+                } else if(this.filterData.accountOrAccountTypeSelected === this.switchValueAccountType){
+                    account = this.accountTypesObject.getAccount(this.filterData.accountOrAccountTypeId);
+                }
+
+                switch(account.currency){
+                    case 'EUR':
+                        this.accountCurrencyClass = this.currencyClass.euro;
+                        break;
+
+                    case 'GBP':
+                        this.accountCurrencyClass = this.currencyClass.pound;
+                        break;
+
+                    case 'USD':
+                    case 'CAD':
+                    default:
+                        this.accountCurrencyClass = this.currencyClass.dollar;
+                }
+            },
+            resetAccountOrAccountTypeField: function(){
+                this.filterData.accountOrAccountTypeId = this.defaultData.accountOrAccountTypeId;
+                this.accountCurrencyClass = this.currencyClass.dollar;
+            },
+            resetFields: function(){
+                this.defaultData.accountOrAccountTypeSelected = this.switchValueAccount;
+                this.resetAccountOrAccountTypeField();
+                for(let t in this.listTags){
+                    this.defaultData.tags[this.listTags[t]['id']] = false;
+                }
+                this.filterData = _.clone(this.defaultData);
+            },
+            flipCompanionSwitch: function(companionFilter){
+                if(this.filterData[companionFilter] === true){
+                    this.filterData[companionFilter] = false;
+                }
+            },
+            decimaliseValue: function(valueField){
+                if(!_.isEmpty(this.filterData[valueField])){
+                    let cleanedValue = this.filterData[valueField].replace(/[^0-9.]/g, '');
+                    this.filterData[valueField] = parseFloat(cleanedValue).toFixed(2);
+                }
+            },
+            makeFilterRequest: function(){
+                this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_SHOW);
+                this.closeModal();
+
+                let filterDataParameters = {};
+
+                if(!_.isEmpty(this.filterData.startDate)){
+                    filterDataParameters.start_date = this.filterData.startDate;
+                }
+                if(!_.isEmpty(this.filterData.endDate)){
+                    filterDataParameters.end_date = this.filterData.endDate;
+                }
+
+                if(this.filterData.accountOrAccountTypeSelected === this.switchValueAccount){
+                    filterDataParameters.account = this.filterData.accountOrAccountTypeId;
+                } else if(this.filterData.accountOrAccountTypeSelected === this.switchValueAccountType){
+                    filterDataParameters.account_type = this.filterData.accountOrAccountTypeId;
+                }
+
+                if(_.isArray(this.filterData.tags)){
+                    filterDataParameters.tags = [];
+                    this.filterData.tags.forEach(function(isSelected, tagId){
+                        if(isSelected){
+                            filterDataParameters.tags.push(tagId);
+                        }
+                    });
+                }
+
+                if(this.filterData.isIncome){
+                    filterDataParameters.expense = false;
+                } else if(this.filterData.isExpense){
+                    filterDataParameters.expense = true;
+                }
+
+                if(this.filterData.hasAttachment){
+                    filterDataParameters.attachments = true;
+                } else if(this.filterData.noAttachment){
+                    filterDataParameters.attachments = false;
+                }
+
+                if(this.filterData.isTransfer){
+                    filterDataParameters.is_transfer = true;
+                }
+
+                if(this.filterData.unconfirmed){
+                    filterDataParameters.unconfirmed = true;
+                }
+
+                if(!_.isEmpty(this.filterData.minValue)){
+                    filterDataParameters.min_value = this.filterData.minValue;
+                }
+                if(!_.isEmpty(this.filterData.maxValue)){
+                    filterDataParameters.max_value = this.filterData.maxValue;
+                }
+
+                this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_TABLE_UPDATE, {pageNumber: 0, filterParameters: filterDataParameters});
+            }
+        },
+        created: function(){
+            this.$eventHub.listen(this.$eventHub.EVENT_FILTER_MODAL_OPEN, this.openModal);
+            this.$eventHub.listen(this.$eventHub.EVENT_FILTER_MODAL_CLOSE, this.closeModal);
+        },
+        mounted: function(){
+            this.resetFields();
+        }
+    }
+</script>
+
+<style lang="scss" scoped>
+$font-size: 0.85rem;
+$quarter-margin: 0.25rem;
+
+.field-label{
+    &.is-normal{
+        font-size: $font-size;
+        margin-right: 0.75rem;
+        padding-top: 0.5rem;
+
+        &.no-padding-top{
+            padding-top: 0;
+        }
+    }
+
+    .label{
+        width: 10rem;
+    }
+}
+.vue-js-switch{
+    font-size: $font-size;
+}
+#filter-account-or-account-types-id{
+    min-width: 16rem;
+}
+.tags{
+    margin: 0;
+
+    .field {
+        margin: $quarter-margin 0;
+
+        label.checkbox-adjusted-top {
+            margin: $quarter-margin;
+            padding-right: 0.5rem;
+        }
+    }
+}
+</style>

--- a/resources/assets/js/components/institutions-panel.vue
+++ b/resources/assets/js/components/institutions-panel.vue
@@ -15,6 +15,7 @@
                 v-bind:name="institution.name"
             ></institutions-panel-institution>
 
+            <!-- TODO: replace all of this with something better... -->
             <div class="accordion" v-show="inactiveAccountsAreAvailable">
                 <div class="panel-block accordion-header toggle institution-node">
                     <p>Closed Accounts</p>

--- a/resources/assets/js/components/navbar.vue
+++ b/resources/assets/js/components/navbar.vue
@@ -57,16 +57,13 @@
                 this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_MODAL_OPEN);
             },
             openFilterModal: function(){
-                this.modalNotAvailable();
+                this.$eventHub.broadcast(this.$eventHub.EVENT_FILTER_MODAL_OPEN);
             },
             openTransferModal: function(){
                 this.$eventHub.broadcast(this.$eventHub.EVENT_TRANSFER_MODAL_OPEN);
             },
             clickNavbarAvatarImage: function(){
                 this.navbarAvatarImageClicked = !this.navbarAvatarImageClicked;
-            },
-            modalNotAvailable: function(){
-                alert("Modal not currently available");
             }
         }
     }

--- a/resources/assets/js/components/transfer-modal.vue
+++ b/resources/assets/js/components/transfer-modal.vue
@@ -371,12 +371,6 @@
                     this.closeModal();
                 }.bind(this));
             },
-            notAvailable: function(){
-                alert("This feature is not currently available");
-            },
-            warningAlert: function(){
-                alert("WARNING: This feature is still in beta. Expect unintended consequences.");
-            },
             updateAccountTypeMeta: function(accountTypeSelect){
                 let account = this.accountTypesObject.getAccount(this.transferData[accountTypeSelect+'_account_type_id']);
                 this.accountTypeMeta[accountTypeSelect].accountName = account.name;
@@ -424,10 +418,6 @@
 </script>
 
 <style scoped>
-    .is-checkradio[type=checkbox].is-block+label::after,
-    .is-checkradio[type=checkbox].is-block+label:after{
-        top: 0.4rem;
-    }
     .field-label.is-normal{
         font-size: 0.875rem;
     }

--- a/resources/assets/js/entries.js
+++ b/resources/assets/js/entries.js
@@ -19,24 +19,20 @@ export class Entries extends ObjectBaseClass {
 
         let requestParameters = {};
         for(let parameter in filterParameters){
-            if(filterParameters.hasOwnProperty(parameter) && filterParameters[parameter] !== null){
-                requestParameters.parameter = filterParameters[parameter];
+            if(filterParameters.hasOwnProperty(parameter)
+                && !_.isNull(filterParameters[parameter])
+                && (
+                    !_.isEmpty(filterParameters[parameter])
+                    || _.isBoolean(filterParameters[parameter])
+                    || (_.isNumber(filterParameters[parameter]) && filterParameters[parameter] !== 0)
+                )
+            ){
+                requestParameters[parameter] = filterParameters[parameter];
             }
         }
         requestParameters.sort = this.sort;
-        // TODO: fetch a filtered request
-//         $.ajax({
-//             beforeSend: function(){
-//                 loading.start();
-//                 filterModal.active = !$.isEmptyObject(filterParameters);
-//                 paginate.filterState = filterParameters;
-//             },
-//             data: JSON.stringify(requestParameters),
-//             dataType: 'json',
-//             complete: entries.ajaxCompleteProcessing
-//         });
 
-        console.log("URL:"+this.uri+pageNumber+";\nfilter:"+requestParameters);
+        console.log("URL:"+this.uri+pageNumber+";\nfilter:"+JSON.stringify(requestParameters));
         return Axios.post(this.uri+pageNumber, requestParameters)
             .then(this.axiosSuccess.bind(this))
             .catch(this.axiosFailure.bind(this));

--- a/resources/assets/js/store.js
+++ b/resources/assets/js/store.js
@@ -9,7 +9,10 @@ export default new Vuex.Store({
 
     state: {
         // token: '',
-        currentPage: 0,
+        pagination: {
+            currentPage: 0,
+            currentFilter: {}
+        },
         version: '',
         tags: [],
         institutions: [],
@@ -30,7 +33,14 @@ export default new Vuex.Store({
          * @returns {number}
          */
         currentPage: function(state){
-            return state.currentPage;
+            return state.pagination.currentPage;
+        },
+
+        /**
+         * @returns {state.pagination.currentFilter|{}}
+         */
+        currentFilter: function(state){
+            return state.pagination.currentFilter;
         },
 
         /**
@@ -90,7 +100,10 @@ export default new Vuex.Store({
         //     state.token = '';
         // }
         currentPage: function(state, pageNumber){
-            state.currentPage = (pageNumber < 0) ? 0 : pageNumber
+            state.pagination.currentPage = (pageNumber < 0) ? 0 : pageNumber
+        },
+        currentFilter: function(state, filter){
+            state.pagination.currentFilter = filter;
         },
         setStateOf: function(state, payload){
             let storeTypes = this.getters.getAllStoreTypes;
@@ -108,6 +121,9 @@ export default new Vuex.Store({
         // }
         currentPage: function(context, payload){
             context.commit('currentPage', payload);
+        },
+        currentFilter: function(context, payload){
+            context.commit('currentFilter', payload);
         },
         setStateOf: function(context, payload){
             context.commit('setStateOf', payload);

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -1,7 +1,3 @@
-.has-padding-right{
-  padding-right: 5px;
-}
-
 #institutions-panel-column{
   background-color: whitesmoke;
 }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -6,6 +6,15 @@
   padding-right: 0.375rem;
 }
 
+.no-padding-top{
+  padding-top: 0;
+}
+
+.is-checkradio[type=checkbox].is-block+label.checkbox-adjusted-top::after,
+.is-checkradio[type=checkbox].is-block+label.checkbox-adjusted-top:after{
+  top: 0.4rem;
+}
+
 /* additional styling for voerro-tags-input component */
 .tags-input input{
   font-size: 0.75rem;

--- a/resources/views/vue.blade.php
+++ b/resources/views/vue.blade.php
@@ -31,6 +31,7 @@
             <!-- modal components -->
             <entry-modal></entry-modal>
             <transfer-modal></transfer-modal>
+            <filter-modal></filter-modal>
             <!--
             loading-modal must ALWAYS be on the bottom.
             This way if the loading-modal is active and another modal is active,

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -60,7 +60,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                                 ->assertSee($this->_label_entry_not_new)
                                 ->assertSee($this->_label_btn_confirmed);
                             $entry_confirm_class = $modal_head->attribute($this->_selector_modal_entry_btn_confirmed_label, 'class');
-                            $this->assertEquals($this->_class_light_grey_text, $entry_confirm_class);
+                            $this->assertContains($this->_class_light_grey_text, $entry_confirm_class);
                         })
 
                         ->with($this->_selector_modal_body, function($modal_body) use ($entry_data, $data_expense_switch_label){

--- a/tests/Browser/EntryModalNewEntryTest.php
+++ b/tests/Browser/EntryModalNewEntryTest.php
@@ -99,12 +99,24 @@ class EntryModalNewEntryTest extends DuskTestCase {
                     $entry_modal_body
                         ->assertSee('Date:')
                         ->assertVisible($this->_selector_modal_entry_field_date)
-                        ->assertInputValue($this->_selector_modal_entry_field_date, date("Y-m-d"))
+                        ->assertInputValue($this->_selector_modal_entry_field_date, date("Y-m-d"));
+                    $this->assertEquals(
+                        'date',
+                        $entry_modal_body->attribute($this->_selector_modal_entry_field_date, 'type'),
+                        $this->_selector_modal_entry_field_date.' is not type="date"'
+                    );
 
+                    $entry_modal_body
                         ->assertSee('Value:')
                         ->assertVisible($this->_selector_modal_entry_field_value)
-                        ->assertInputValue($this->_selector_modal_entry_field_value, "")
+                        ->assertInputValue($this->_selector_modal_entry_field_value, "");
+                    $this->assertEquals(
+                        'text',
+                        $entry_modal_body->attribute($this->_selector_modal_entry_field_value, 'type'),
+                        $this->_selector_modal_entry_field_value.' is not type="text"'
+                    );
 
+                    $entry_modal_body
                         ->assertSee('Account Type:')
                         ->assertVisible($this->_selector_modal_entry_field_account_type)
                         ->assertSelected($this->_selector_modal_entry_field_account_type, "")
@@ -117,6 +129,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
 
                         ->assertVisible($this->_selector_modal_entry_field_expense)
                         ->assertSee($this->_label_expense_switch_expense)
+                        ->assertElementColour($this->_selector_modal_entry_field_expense.' '.$this->_class_switch_core, $this->_color_expense_switch_expense)
                         ->assertDontSee($this->_label_expense_switch_income)
 
                         ->assertSee('Tags:')
@@ -127,18 +140,6 @@ class EntryModalNewEntryTest extends DuskTestCase {
                         ->with($this->_selector_modal_entry_field_upload, function($file_upload){
                             $file_upload->assertSee($this->_label_file_upload);
                         });
-
-                    $this->assertEquals(
-                        'date',
-                        $entry_modal_body->attribute($this->_selector_modal_entry_field_date, 'type'),
-                        $this->_selector_modal_entry_field_date.' is not type="date"'
-                    );
-
-                    $this->assertEquals(
-                        'text',
-                        $entry_modal_body->attribute($this->_selector_modal_entry_field_value, 'type'),
-                        $this->_selector_modal_entry_field_value.' is not type="text"'
-                    );
                 });
         });
     }
@@ -252,8 +253,11 @@ class EntryModalNewEntryTest extends DuskTestCase {
                 ->with($this->_selector_modal_body, function($entry_modal_body){
                     $entry_modal_body
                         ->assertSee($this->_label_expense_switch_expense)
+                        ->assertElementColour($this->_selector_modal_entry_field_expense.' '.$this->_class_switch_core, $this->_color_expense_switch_expense)
                         ->click($this->_selector_modal_entry_field_expense)
+                        ->pause(500) // 0.5 seconds - need to wait for the transition to complete after click
                         ->assertSee($this->_label_expense_switch_income)
+                        ->assertElementColour($this->_selector_modal_entry_field_expense.' '.$this->_class_switch_core, $this->_color_expense_switch_income)
                         ->assertDontSee($this->_label_expense_switch_expense);
                 });
         });

--- a/tests/Browser/FilterModalTest.php
+++ b/tests/Browser/FilterModalTest.php
@@ -1,0 +1,763 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Account;
+use Facebook\WebDriver\WebDriverBy;
+use Faker\Factory as FakerFactory;
+use Faker\Generator;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Browser\Pages\HomePage;
+use Tests\DuskTestCase;
+use Laravel\Dusk\Browser;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Tests\Traits\HomePageSelectors;
+
+class FilterModalTest extends DuskTestCase {
+
+    use DatabaseMigrations;
+    use HomePageSelectors;
+
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    private $_partial_selector_filter_tag = "#filter-tag-";
+
+    public function setUp(){
+        parent::setUp();
+        Artisan::call('db:seed', ['--class'=>'UiSampleDatabaseSeeder']);
+
+        $this->faker = FakerFactory::create();
+    }
+
+    public function testModalHeaderHasCorrectElements(){
+        $this->browse(function(Browser $browser){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openFilterModal()
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_head, function($modal){
+                    $modal
+                        ->assertSee("Filter Entries")
+                        ->assertVisible($this->_selector_modal_btn_close);
+                });
+        });
+    }
+
+    public function testModalBodyHasCorrectElements(){
+        $accounts = $this->getApiAccounts();
+        $tags = $this->getApiTags();
+
+        $this->browse(function(Browser $browser) use ($accounts, $tags){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openFilterModal()
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function($modal) use ($accounts, $tags){
+                    $modal
+                        // start date - input
+                        ->assertSee("Start Date:")
+                        ->assertVisible($this->_selector_modal_filter_field_start_date)
+                        ->assertInputValue($this->_selector_modal_filter_field_start_date, "");
+                    $this->assertEquals(
+                        'date',
+                        $modal->attribute($this->_selector_modal_filter_field_start_date, 'type'),
+                        $this->_selector_modal_filter_field_start_date.' is not type="date"'
+                    );
+
+                    $modal
+                        // end date - input
+                        ->assertSee("End Date:")
+                        ->assertVisible($this->_selector_modal_filter_field_end_date)
+                        ->assertInputValue($this->_selector_modal_filter_field_end_date, "");
+                    $this->assertEquals(
+                        'date',
+                        $modal->attribute($this->_selector_modal_filter_field_end_date, 'type'),
+                        $this->_selector_modal_filter_field_end_date.' is not type="date"'
+                    );
+
+                    $modal
+                        // account/account-type - switch
+                        ->assertVisible($this->_selector_modal_filter_field_switch_account_and_account_type)
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_account_and_account_type, "Account")
+                        ->assertElementColour(
+                            $this->_selector_modal_filter_field_switch_account_and_account_type.' '.$this->_class_switch_core,
+                            $this->_color_filter_switch_default
+                        )
+
+                        //account/account-type - select
+                        ->assertVisible($this->_selector_modal_filter_field_account_and_account_type)
+                        ->assertSelected($this->_selector_modal_filter_field_account_and_account_type, "")
+                        ->assertSeeIn($this->_selector_modal_filter_field_account_and_account_type, $this->_label_select_option_filter_default)
+                        ->assertSelectHasOption($this->_selector_modal_filter_field_account_and_account_type, "")
+                        ->assertSelectHasOptions($this->_selector_modal_filter_field_account_and_account_type, collect($accounts)->pluck('id')->toArray())
+
+                        // tags - button(s)
+                        ->assertSee("Tags:")
+                        ->assertVisible($this->_selector_modal_filter_field_tags);
+
+                    foreach($tags as $tag){
+                        $tag_selector = $this->_selector_modal_filter_field_tags.' '.$this->_partial_selector_filter_tag.$tag['id'];
+                        $modal
+                            ->assertNotChecked($tag_selector)
+                            ->assertSeeIn($tag_selector.'+label', $tag['name']);
+                    }
+
+                    $modal
+                        // income - switch
+                        ->assertSee("Income:")
+                        ->assertVisible($this->_selector_modal_filter_field_switch_income)
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_income, $this->_label_switch_disabled)
+                        ->assertElementColour(
+                            $this->_selector_modal_filter_field_switch_income.' '.$this->_class_switch_core,
+                            $this->_color_filter_switch_default
+                        )
+
+                        // expense - switch
+                        ->assertSee("Expense:")
+                        ->assertVisible($this->_selector_modal_filter_field_switch_expense)
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_expense, $this->_label_switch_disabled)
+                        ->assertElementColour(
+                            $this->_selector_modal_filter_field_switch_expense.' '.$this->_class_switch_core,
+                            $this->_color_filter_switch_default
+                        )
+
+                        // has attachment - switch
+                        ->assertSee("Has Attachment(s):")
+                        ->assertVisible($this->_selector_modal_filter_field_switch_has_attachment)
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_has_attachment, $this->_label_switch_disabled)
+                        ->assertElementColour(
+                            $this->_selector_modal_filter_field_switch_has_attachment.' '.$this->_class_switch_core,
+                            $this->_color_filter_switch_default
+                        )
+
+                        // no attachment - switch
+                        ->assertSee("No Attachment(s):")
+                        ->assertVisible($this->_selector_modal_filter_field_switch_no_attachment)
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_no_attachment, $this->_label_switch_disabled)
+                        ->assertElementColour(
+                            $this->_selector_modal_filter_field_switch_no_attachment.' '.$this->_class_switch_core,
+                            $this->_color_filter_switch_default
+                        )
+
+                        // is transfer - switch
+                        ->assertSee("Transfer:")
+                        ->assertVisible($this->_selector_modal_filter_field_switch_transfer)
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_transfer, $this->_label_switch_disabled)
+                        ->assertElementColour(
+                            $this->_selector_modal_filter_field_switch_transfer.' '.$this->_class_switch_core,
+                            $this->_color_filter_switch_default
+                        )
+
+                        // unconfirmed - switch
+                        ->assertSee("Not Confirmed:")
+                        ->assertVisible($this->_selector_modal_filter_field_switch_unconfirmed)
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_unconfirmed, $this->_label_switch_disabled)
+                        ->assertElementColour(
+                            $this->_selector_modal_filter_field_switch_unconfirmed.' '.$this->_class_switch_core,
+                            $this->_color_filter_switch_default
+                        )
+
+                        // min range - input
+                        ->assertSee("Min Range:")
+                        ->assertVisible($this->_selector_modal_filter_field_min_value)
+                        ->assertInputValue($this->_selector_modal_filter_field_min_value, "");
+                    $this->assertEquals(
+                        'text',
+                        $modal->attribute($this->_selector_modal_filter_field_min_value, 'type'),
+                        $this->_selector_modal_filter_field_min_value.' is not type="text"'
+                    );
+
+                    $modal
+                        // max range - input
+                        ->assertSee("Max Range:")
+                        ->assertVisible($this->_selector_modal_filter_field_max_value)
+                        ->assertInputValue($this->_selector_modal_filter_field_max_value, "");
+                    $this->assertEquals(
+                        'text',
+                        $modal->attribute($this->_selector_modal_filter_field_max_value, 'type'),
+                        $this->_selector_modal_filter_field_max_value.' is not type="text"'
+                    );
+                });
+        });
+    }
+
+    public function testModalFooterHasCorrectElements(){
+        $this->browse(function(Browser $browser){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openFilterModal()
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_foot, function($modal){
+                    $modal
+                        ->assertVisible($this->_selector_modal_filter_btn_cancel)
+                        ->assertSee($this->_label_btn_cancel)
+                        ->assertVisible($this->_selector_modal_filter_btn_reset)
+                        ->assertSee($this->_label_btn_reset)
+                        ->assertVisible($this->_selector_modal_filter_btn_filter)
+                        ->assertSee($this->_label_btn_filter);
+                });
+        });
+    }
+
+    public function testModalHasTheCorrectNumberOfInputs(){
+        $filter_modal_field_selectors = [
+            $this->_selector_modal_filter_field_start_date,
+            $this->_selector_modal_filter_field_end_date,
+            $this->_selector_modal_filter_field_account_and_account_type,
+            $this->_selector_modal_filter_field_tags,
+            $this->_selector_modal_filter_field_switch_income,
+            $this->_selector_modal_filter_field_switch_expense,
+            $this->_selector_modal_filter_field_switch_has_attachment,
+            $this->_selector_modal_filter_field_switch_no_attachment,
+            $this->_selector_modal_filter_field_switch_transfer,
+            $this->_selector_modal_filter_field_switch_unconfirmed,
+            $this->_selector_modal_filter_field_min_value,
+            $this->_selector_modal_filter_field_max_value,
+        ];
+
+        $this->browse(function(Browser $browser) use ($filter_modal_field_selectors){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openFilterModal()
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function($modal) use ($filter_modal_field_selectors){
+                    $filter_modal_elements = $modal->elements('div.field.is-horizontal');
+                    $this->assertCount(count($filter_modal_field_selectors), $filter_modal_elements);
+                });
+        });
+    }
+
+    public function testCloseTransferModalWithXButtonInHeader(){
+        $this->browse(function(Browser $browser){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openFilterModal()
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_head, function($modal){
+                    $modal->click($this->_selector_modal_btn_close);
+                })
+                ->assertMissing($this->_selector_modal_filter);
+        });
+    }
+
+    public function testCloseTransferModalWithCancelButtonInFooter(){
+        $this->browse(function(Browser $browser){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openFilterModal()
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_foot, function($modal){
+                    $modal->click($this->_selector_modal_filter_btn_cancel);
+                })
+                ->assertMissing($this->_selector_modal_filter);
+        });
+    }
+
+    public function testFlipAccountAndAccountTypeSwitch(){
+        $accounts = $this->getApiAccounts();
+        $account_types = $this->getApiAccountTypes();
+
+        $this->browse(function(Browser $browser) use ($accounts, $account_types){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openFilterModal()
+                ->with($this->_selector_modal_filter, function($modal) use ($accounts, $account_types){
+                    $modal
+                        ->assertVisible($this->_selector_modal_filter_field_switch_account_and_account_type)
+                        ->assertVisible($this->_selector_modal_filter_field_account_and_account_type)
+
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_account_and_account_type, "Account")
+                        ->assertElementColour($this->_selector_modal_filter_field_switch_account_and_account_type.' '.$this->_class_switch_core, $this->_color_filter_switch_default)
+
+                        ->assertSelected($this->_selector_modal_filter_field_account_and_account_type, "")
+                        ->assertSeeIn($this->_selector_modal_filter_field_account_and_account_type, $this->_label_select_option_filter_default)
+                        ->assertSelectHasOption($this->_selector_modal_filter_field_account_and_account_type, "")
+                        ->assertSelectHasOptions($this->_selector_modal_filter_field_account_and_account_type, collect($accounts)->pluck('id')->toArray());
+
+                    // test currency displayed in "Min Range" & "Max Range" fields is $
+                    $this->assertContains($this->_class_icon_dollar, $modal->attribute($this->_selector_modal_filter_field_min_value_icon, 'class'));
+                    $this->assertContains($this->_class_icon_dollar, $modal->attribute($this->_selector_modal_filter_field_max_value_icon, 'class'));
+
+                    // select an account and confirm the name in the select changes
+                    $account_to_select = $this->faker->randomElement($accounts);
+                    $modal
+                        ->select($this->_selector_modal_filter_field_account_and_account_type, $account_to_select['id'])
+                        ->assertSeeIn($this->_selector_modal_filter_field_account_and_account_type, $account_to_select['name']);
+
+                    // test select account changes currency displayed in "Min Range" & "Max Range" fields
+                    $fail_message = "account data:".json_encode($account_to_select);
+                    $this->assertContains(
+                        $this->getCurrencyClassFromCurrency($account_to_select['currency']),
+                        $modal->attribute($this->_selector_modal_filter_field_min_value_icon, 'class'),
+                        $fail_message
+                    );
+                    $this->assertContains($this->getCurrencyClassFromCurrency(
+                        $account_to_select['currency']),
+                        $modal->attribute($this->_selector_modal_filter_field_max_value_icon, 'class'),
+                        $fail_message
+                    );
+
+                    $modal
+                        ->click($this->_selector_modal_filter_field_switch_account_and_account_type)
+                        ->pause(1000)   // 1 second
+
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_account_and_account_type, "Account Type")
+                        ->assertElementColour($this->_selector_modal_filter_field_switch_account_and_account_type.' '.$this->_class_switch_core, $this->_color_filter_switch_default)
+
+                        ->assertSelected($this->_selector_modal_filter_field_account_and_account_type, "")
+                        ->assertSeeIn($this->_selector_modal_filter_field_account_and_account_type, $this->_label_select_option_filter_default)
+                        ->assertSelectHasOption($this->_selector_modal_filter_field_account_and_account_type, "")
+                        ->assertSelectHasOptions($this->_selector_modal_filter_field_account_and_account_type, collect($account_types)->pluck('id')->toArray());
+
+                    // test currency displayed in "Min Range" & "Max Range" fields is $
+                    $this->assertContains($this->_class_icon_dollar, $modal->attribute($this->_selector_modal_filter_field_min_value_icon, 'class'));
+                    $this->assertContains($this->_class_icon_dollar, $modal->attribute($this->_selector_modal_filter_field_max_value_icon, 'class'));
+
+                    $account_type_to_select = $this->faker->randomElement($account_types);
+                    $modal
+                        // select an account and confirm the name in the select changes
+                        ->select($this->_selector_modal_filter_field_account_and_account_type, $account_type_to_select['id'])
+                        ->assertSeeIn($this->_selector_modal_filter_field_account_and_account_type, $account_type_to_select['name']);
+
+                    // test select account-type changes currency displayed in "Min Range" & "Max Range" fields
+                    $account_from_account_type = collect($accounts)->where('id', '=', $account_type_to_select['account_id'])->first();
+                    $fail_message = "account-type data:".json_encode($account_type_to_select)."\naccount data:".json_encode($account_from_account_type);
+                    $this->assertContains(
+                        $this->getCurrencyClassFromCurrency($account_from_account_type['currency']),
+                        $modal->attribute($this->_selector_modal_filter_field_min_value_icon, 'class'),
+                        $fail_message
+                    );
+                    $this->assertContains($this->getCurrencyClassFromCurrency($account_from_account_type['currency']),
+                        $modal->attribute($this->_selector_modal_filter_field_max_value_icon, 'class'),
+                        $fail_message
+                    );
+                });
+        });
+    }
+
+    private function getCurrencyClassFromCurrency($currency){
+        switch($currency){
+            case 'EUR':
+                return $this->_class_icon_euro;
+                break;
+
+            case 'GBP':
+                return $this->_class_icon_pound;
+                break;
+
+            case 'USD':
+            case 'CAD':
+            default:
+                return $this->_class_icon_dollar;
+        }
+    }
+
+    public function providerFlipSwitch(){
+        return [
+            "flip income"=>['#filter-is-income'],
+            "flip expense"=>['#filter-is-expense'],
+            "flip has-attachment"=>['#filter-has-attachment'],
+            "flip no-attachment"=>['#filter-no-attachment'],
+            "flip transfer"=>['#filter-is-transfer'],
+            "flip not confirmed"=>['#filter-unconfirmed']
+        ];
+    }
+
+    /**
+     * @dataProvider providerFlipSwitch
+     * @param string $switch_selector
+     *
+     * @throws \Throwable
+     */
+    public function testFlipSwitch($switch_selector){
+        $accounts = $this->getApiAccounts();
+        $account_types = $this->getApiAccountTypes();
+
+        $this->browse(function(Browser $browser) use ($switch_selector, $accounts, $account_types){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openFilterModal()
+                ->with($this->_selector_modal_filter, function($modal) use ($switch_selector, $accounts, $account_types){
+                    $modal
+                        ->assertVisible($switch_selector)
+                        ->assertSeeIn($switch_selector, $this->_label_switch_disabled)
+                        ->assertElementColour($switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_default)
+                        ->click($switch_selector)
+                        ->pause(1000)   // 1 second
+                        ->assertSeeIn($switch_selector, $this->_label_switch_enabled)
+                        ->assertElementColour($switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_active);
+                });
+        });
+    }
+
+    public function providerFlippingCompanionSwitches(){
+        return [
+            "flip income with expense"=>['#filter-is-income', '#filter-is-expense'],
+            "flip expense with income"=>['#filter-is-expense', '#filter-is-income'],
+            "flip has-attachment with no-attachment"=>['#filter-has-attachment', '#filter-no-attachment'],
+            "flip no-attachment with has-attachment"=>['#filter-no-attachment', '#filter-has-attachment']
+        ];
+    }
+
+    /**
+     * @dataProvider providerFlippingCompanionSwitches
+     * @param string $init_switch_selector
+     * @param string $companion_switch_selector
+     *
+     * @throws \Throwable
+     */
+    public function testFlippingCompanionSwitches($init_switch_selector, $companion_switch_selector){
+        $this->browse(function(Browser $browser) use ($init_switch_selector, $companion_switch_selector){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openFilterModal()
+                ->with($this->_selector_modal_filter, function($modal) use ($init_switch_selector, $companion_switch_selector){
+                    $modal
+                        ->assertVisible($init_switch_selector)
+                        ->assertSeeIn($init_switch_selector, $this->_label_switch_disabled)
+                        ->assertElementColour($init_switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_default)
+                        ->assertVisible($companion_switch_selector)
+                        ->assertSeeIn($companion_switch_selector, $this->_label_switch_disabled)
+                        ->assertElementColour($companion_switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_default)
+                        ->click($init_switch_selector)
+                        ->pause(1000)   // 1 second
+                        ->assertSeeIn($init_switch_selector, $this->_label_switch_enabled)
+                        ->assertElementColour($init_switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_active)
+                        ->assertSeeIn($companion_switch_selector, $this->_label_switch_disabled)
+                        ->assertElementColour($companion_switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_default)
+                        ->click($companion_switch_selector)
+                        ->pause(1000)   // 1 second
+                        ->assertSeeIn($companion_switch_selector, $this->_label_switch_enabled)
+                        ->assertElementColour($companion_switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_active)
+                        ->assertSeeIn($init_switch_selector, $this->_label_switch_disabled)
+                        ->assertElementColour($init_switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_default);
+                });
+        });
+    }
+
+    public function providerRangeValueConvertsIntoDecimalOfTwoPlaces(){
+        return [
+            'Min Range'=>['#filter-min-value'],
+            'Max Range'=>['#filter-max-value'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerRangeValueConvertsIntoDecimalOfTwoPlaces
+     * @param $field_selector
+     *
+     * @throws \Throwable
+     */
+    public function testRangeValueConvertsIntoDecimalOfTwoPlaces($field_selector){
+        $this->browse(function(Browser $browser) use ($field_selector){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openFilterModal()
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function($modal) use ($field_selector){
+                    $modal
+                        ->type($field_selector, "rh48r7th72.9ewd3dadh1")
+                        ->click($this->_selector_modal_filter_field_end_date)
+                        ->assertInputValue($field_selector, "48772.93");
+                });
+        });
+    }
+
+    public function testClickingOnTagButtons(){
+        $this->browse(function(Browser $browser){
+            $browser->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openFilterModal()
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function ($modal){
+                    $tags = $this->getApiTags();
+                    foreach($tags as $tag){
+                        $selector_tag_checkbox = $this->_selector_modal_filter_field_tags.' '.$this->_partial_selector_filter_tag.$tag['id'];
+                        $selector_tag_label = $selector_tag_checkbox.'+label';
+                        $modal
+                            ->assertNotChecked($selector_tag_checkbox)
+                            ->assertElementColour($selector_tag_label, $this->_color_filter_btn_tag_default)
+                            ->click($selector_tag_label)
+                            ->assertChecked($selector_tag_checkbox)
+                            ->assertElementColour($selector_tag_label, $this->_color_filter_btn_tag_active);
+                    }
+                });
+        });
+    }
+
+    public function testResetFields(){
+        $this->browse(function(Browser $browser){
+            $tags = $this->getApiTags();
+
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openFilterModal()
+                // modify all (or at least most) fields
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function($modal) use ($tags){
+                    $time_from_browser = $modal->getBrowserLocaleDate();
+                    $start_date = $modal->processLocaleDateForTyping($time_from_browser);
+
+                    $account_types = $this->getApiAccountTypes();
+                    $account_type = $this->faker->randomElement($account_types);
+
+                    $tags_to_select = $this->faker->randomElements($tags, $this->faker->numberBetween(1, count($tags)));
+
+                    $companion_switch_set_1 = [$this->_selector_modal_filter_field_switch_expense, $this->_selector_modal_filter_field_switch_income];
+                    $companion_switch_set_2 = [$this->_selector_modal_filter_field_switch_has_attachment, $this->_selector_modal_filter_field_switch_no_attachment];
+
+                    $modal
+                        ->type($this->_selector_modal_filter_field_start_date, $start_date)
+                        ->type($this->_selector_modal_filter_field_end_date, $start_date)
+                        ->click($this->_selector_modal_filter_field_switch_account_and_account_type)
+                        ->select($this->_selector_modal_filter_field_account_and_account_type, $account_type['id']);
+
+                    foreach($tags_to_select as $tag_to_select){
+                        $modal->click($this->_selector_modal_filter_field_tags.' '.$this->_partial_selector_filter_tag.$tag_to_select['id'].'+label');
+                    }
+
+                    $modal
+                        ->click($this->faker->randomElement($companion_switch_set_1))
+                        ->click($this->faker->randomElement($companion_switch_set_2))
+                        ->click($this->_selector_modal_filter_field_switch_transfer)
+                        ->click($this->_selector_modal_filter_field_switch_unconfirmed)
+                        ->type($this->_selector_modal_filter_field_max_value, "65.43")
+                        ->type($this->_selector_modal_filter_field_min_value, "9.87");
+                })
+
+                // click reset button
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_foot, function($modal){
+                    $modal
+                        ->assertVisible($this->_selector_modal_filter_btn_reset)
+                        ->click($this->_selector_modal_filter_btn_reset)
+                        ->pause(1000);  // 1 second
+                })
+
+                // confirm all fields have been reset
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function($modal) use ($tags){
+                    $modal
+                        ->assertInputValue($this->_selector_modal_filter_field_start_date, '')
+                        ->assertInputValue($this->_selector_modal_filter_field_end_date, '')
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_account_and_account_type, "Account")
+                        ->assertSelected($this->_selector_modal_filter_field_account_and_account_type, '');
+
+                    foreach($tags as $tag){
+                        $modal->assertNotChecked($this->_selector_modal_filter_field_tags.' '.$this->_partial_selector_filter_tag.$tag['id']);
+                    }
+
+                    $modal
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_income, $this->_label_switch_disabled)
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_expense, $this->_label_switch_disabled)
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_has_attachment, $this->_label_switch_disabled)
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_no_attachment, $this->_label_switch_disabled)
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_transfer, $this->_label_switch_disabled)
+                        ->assertSeeIn($this->_selector_modal_filter_field_switch_unconfirmed, $this->_label_switch_disabled)
+                        ->assertInputValue($this->_selector_modal_filter_field_min_value, "")
+                        ->assertInputValue($this->_selector_modal_filter_field_max_value, "");
+
+                    $this->assertContains($this->_class_icon_dollar, $modal->attribute($this->_selector_modal_filter_field_min_value_icon, 'class'));
+                    $this->assertContains($this->_class_icon_dollar, $modal->attribute($this->_selector_modal_filter_field_max_value_icon, 'class'));
+                });
+        });
+    }
+
+    public function providerClickFilterButtonToFilterResults(){
+        return [
+            "Start Date"=>[$this->_selector_modal_filter_field_start_date],
+            "End Date"=>[$this->_selector_modal_filter_field_end_date],
+            "Account&Account-type"=>[$this->_selector_modal_filter_field_account_and_account_type],
+            "Tags"=>[$this->_partial_selector_filter_tag],
+            "Income"=>[$this->_selector_modal_filter_field_switch_income],
+            "Expense"=>[$this->_selector_modal_filter_field_switch_expense],
+            "Has Attachments"=>[$this->_selector_modal_filter_field_switch_has_attachment],
+            "No Attachments"=>[$this->_selector_modal_filter_field_switch_no_attachment],
+            "Transfer"=>[$this->_selector_modal_filter_field_switch_transfer],
+            "Unconfirmed"=>[$this->_selector_modal_filter_field_switch_unconfirmed],
+            "Min Range"=>[$this->_selector_modal_filter_field_min_value],
+            "Max Range"=>[$this->_selector_modal_filter_field_max_value],
+        ];
+    }
+
+    /**
+     * @dataProvider providerClickFilterButtonToFilterResults
+     * @param $filter_param
+     *
+     * @throws \Throwable
+     */
+    public function testClickFilterButtonToFilterResults($filter_param){
+        $this->browse(function(Browser $browser) use ($filter_param){
+            $filter_value = '';
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openFilterModal()
+                // modify all (or at least most) fields
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function($modal) use ($filter_param, &$filter_value){
+                    switch($filter_param){
+                        case $this->_selector_modal_filter_field_start_date:
+                        case $this->_selector_modal_filter_field_end_date:
+                            $filter_value = ['actual'=>$this->faker->date("Y-m-d")];
+                            $browser_date = $modal->getDateFromLocale($modal->getBrowserLocale(), $filter_value['actual']);
+                            $filter_value['typed'] = $modal->processLocaleDateForTyping($browser_date);
+                            $modal->type($filter_param, $filter_value['typed']);
+                            break;
+
+                        case $this->_selector_modal_filter_field_account_and_account_type:
+                            $is_account = $this->faker->boolean;
+                            if($is_account){
+                                // account
+                                $filter_values = $this->getApiAccounts();
+                            } else {
+                                // account-type
+                                $modal->click($this->_selector_modal_filter_field_switch_account_and_account_type);
+                                $filter_values = $this->getApiAccountTypes();
+                            }
+                            $filter_value = collect($filter_values)->random(1)->first();
+                            $modal->select($filter_param, $filter_value['id']);
+
+                            if($is_account){
+                                $account = Account::find_account_with_types($filter_value['id']);
+                                $filter_value = $account->account_types->pluck('name')->toArray();
+                            } else {
+                                $filter_value = $filter_value['name'];
+                            }
+                            break;
+
+                        case $this->_partial_selector_filter_tag:
+                            $tags = $this->getApiTags();
+                            $filter_value = collect($tags)->random(3)->toArray();
+                            foreach($filter_value as $tag){
+                                $modal->click($filter_param.$tag['id'].'+label');
+                            }
+                            break;
+
+                        case $this->_selector_modal_filter_field_switch_income:
+                        case $this->_selector_modal_filter_field_switch_expense:
+                        case $this->_selector_modal_filter_field_switch_has_attachment:
+                        case $this->_selector_modal_filter_field_switch_no_attachment:
+                        case $this->_selector_modal_filter_field_switch_transfer:
+                        case $this->_selector_modal_filter_field_switch_unconfirmed:
+                            $modal->click($filter_param);
+                            break;
+
+                        case $this->_selector_modal_filter_field_min_value:
+                        case $this->_selector_modal_filter_field_max_value:
+                            $filter_value = $this->faker->randomFloat(2, 0, 100);
+                            // need to use type() here otherwise vuejs won't pick up the update
+                            $modal->type($filter_param, $filter_value);
+                            break;
+
+                        default:
+                            throw new \InvalidArgumentException("Unknown filter parameter provided:".$filter_param);
+                    }
+                })
+
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_foot, function($modal){
+                    $modal->click($this->_selector_modal_filter_btn_filter);
+                })
+                ->waitForLoadingToStop()
+                ->assertMissing($this->_selector_modal_filter)
+
+                // confirm only rows matching the filter parameters are shown
+                ->with($this->_selector_table.' '.$this->_selector_table_body, function($table) use ($filter_param, $filter_value){
+                    $table_rows = $table->elements('tr');
+                    foreach($table_rows as $table_row){
+                        switch($filter_param){
+                            case $this->_selector_modal_filter_field_start_date:
+                                // only rows with dates >= $start_date
+                                $row_entry_date = $table_row->findElement(WebDriverBy::cssSelector($this->_selector_table_row_date))->getText();
+                                $this->assertGreaterThanOrEqual(
+                                    strtotime($filter_value['actual']),
+                                    strtotime($row_entry_date),
+                                    'Row date "'.$row_entry_date.'" less than filter start date "'.$filter_value['actual'].'" typed as "'.$filter_value['typed'].'"'
+                                );
+                                break;
+
+                            case $this->_selector_modal_filter_field_end_date:
+                                // only rows with dates <= $end_date
+                                $row_entry_date = $table_row->findElement(WebDriverBy::cssSelector($this->_selector_table_row_date))->getText();
+                                $this->assertLessThanOrEqual(
+                                    strtotime($filter_value['actual']),
+                                    strtotime($row_entry_date),
+                                    'Row date "'.$row_entry_date.'" greater than filter start date "'.$filter_value['actual'].'" typed as "'.$filter_value['typed'].'"'
+                                );
+                                break;
+
+                            case $this->_selector_modal_filter_field_account_and_account_type:
+                                // only rows with account-type(s)
+                                $row_entry_account_type = $table_row->findElement(WebDriverBy::cssSelector($this->_selector_table_row_account_type))->getText();
+                                if(is_array($filter_value)){
+                                    $this->assertContains($row_entry_account_type, $filter_value);
+                                } else {
+                                    $this->assertEquals($row_entry_account_type, $filter_value);
+                                }
+                                break;
+
+                            case $this->_partial_selector_filter_tag:
+                                // only rows with .has-tags class
+                                $this->assertContains('has-tags', $table_row->getAttribute('class'));
+                                // each row will contain the selected tag text
+                                $row_entry_tags = explode("\n", $table_row->findElement(WebDriverBy::cssSelector($this->_selector_table_row_tags))->getText());
+                                $filter_value_names = collect($filter_value)->pluck('name')->toArray();
+                                $this->assertNotEmpty(
+                                    array_intersect($row_entry_tags, $filter_value_names),
+                                    sprintf(
+                                        "Could not find any of these tags [%s] in the list of filtered tags [%s]",
+                                        implode(',', $row_entry_tags),
+                                        implode(', ', $filter_value_names)
+                                    )
+                                );
+                                break;
+
+                            case $this->_selector_modal_filter_field_switch_income:
+                                // only rows with .is-income class
+                                $this->assertContains('is-income', $table_row->getAttribute('class'));
+                                break;
+                            case $this->_selector_modal_filter_field_switch_expense:
+                                // only rows with .is-expense class
+                                $this->assertContains('is-expense', $table_row->getAttribute('class'));
+                                break;
+                            case $this->_selector_modal_filter_field_switch_has_attachment:
+                                // only rows with .has-attachments class
+                                $this->assertContains('has-attachments', $table_row->getAttribute('class'));
+                                break;
+                            case $this->_selector_modal_filter_field_switch_no_attachment:
+                                // rows DO NOT CONTAIN .has-attachments class
+                                $this->assertNotContains('has-attachments', $table_row->getAttribute('class'));
+                                break;
+                            case $this->_selector_modal_filter_field_switch_transfer:
+                                // only rows with .is-transfer class
+                                $this->assertContains('is-transfer', $table_row->getAttribute('class'));
+                                break;
+                            case $this->_selector_modal_filter_field_switch_unconfirmed:
+                                // rows DO NOT CONTAIN .is-confirmed class
+                                $table_row_class = $table_row->getAttribute('class');
+                                $this->assertNotContains('is-confirmed', $table_row_class);
+                                $this->assertContains('has-background-warning', $table_row_class);
+                                break;
+                            case $this->_selector_modal_filter_field_min_value:
+                                // only rows with value >= min_value
+                                $row_entry_value = $table_row->findElement(WebDriverBy::cssSelector($this->_selector_table_row_value))->getText();
+                                $this->assertGreaterThanOrEqual($filter_value, $row_entry_value);
+                                break;
+
+                            case $this->_selector_modal_filter_field_max_value:
+                                // only rows with value <= max_value
+                                $row_entry_value = $table_row->findElement(WebDriverBy::cssSelector($this->_selector_table_row_value))->getText();
+                                $this->assertLessThanOrEqual($filter_value, $row_entry_value);
+                                break;
+
+                            default:
+                                throw new \InvalidArgumentException("Unknown filter parameter provided:".$filter_param);
+                        }
+                    }
+            });
+        });
+    }
+
+}

--- a/tests/Browser/NotificationsTest.php
+++ b/tests/Browser/NotificationsTest.php
@@ -8,10 +8,12 @@ use Illuminate\Support\Facades\DB;
 use Tests\Browser\Pages\HomePage;
 use Tests\DuskTestCase;
 use Laravel\Dusk\Browser;
+use Tests\Traits\InjectDatabaseStateIntoException;
 
 class NotificationsTest extends DuskTestCase {
 
     use DatabaseMigrations;
+    use InjectDatabaseStateIntoException;
 
     private $_selector_unconfirmed_expense = "tr.has-background-warning.is-expense";
     private $_selector_unconfirmed_income = 'tr.has-background-warning.is-income';
@@ -34,6 +36,7 @@ class NotificationsTest extends DuskTestCase {
     public function setUp(){
         parent::setUp();
         Artisan::call('db:seed', ['--class'=>'UiSampleDatabaseSeeder']);
+        $this->setDatabaseStateInjectionPermission(self::$ALLOW_INJECT_DATABASE_STATE_ON_EXCEPTION);
     }
 
     /**

--- a/tests/Browser/Pages/HomePage.php
+++ b/tests/Browser/Pages/HomePage.php
@@ -45,6 +45,7 @@ class HomePage extends Page {
             '@navbar'=>'.navbar',
             '@new-entry-modal-btn'=>'#nav-entry-modal',
             '@add-transfer-btn'=>'#nav-transfer-modal',
+            '@open-filter-btn'=>'#nav-filter-modal',
             // loading-modal
             '@loading'=>'#loading-modal',
             // entry-modal
@@ -54,6 +55,8 @@ class HomePage extends Page {
             // transfer-modal
             '@transfer-modal'=>'#transfer-modal',
             '@transfer-modal-save-btn'=>"#transfer-modal button#transfer-save-btn",
+            // filter-modal
+            '@filter-modal'=>'#filter-modal',
             // notification-modal
             '@notification'=>".snotifyToast",
             '@notification-error'=>".snotifyToast.snotify-error",
@@ -77,6 +80,10 @@ class HomePage extends Page {
         $this->openModalFromNavbar($browser, "@add-transfer-btn", '@transfer-modal');
     }
 
+    public function openFilterModal(Browser $browser){
+        $this->openModalFromNavbar($browser, "@open-filter-btn", "@filter-modal");
+    }
+
     public function openModalFromNavbar(Browser $browser, $selector_btn, $selector_modal){
         $browser->with('@navbar', function($navbar) use ($selector_btn){
             $navbar->click($selector_btn);
@@ -94,34 +101,34 @@ class HomePage extends Page {
     }
 
     public function assertEntryModalSaveButtonIsDisabled(Browser $browser){
-        PHPUnit::assertEquals(
-            'true',
-            $browser->attribute("@entry-modal-save-btn", 'disabled'),
-            "Entry-modal save button is NOT disabled"
-        );
+        $this->assertModalSaveButtonIsDisabled($browser, "@entry-modal-save-btn", "entry-modal save button is NOT disabled");
     }
 
     public function assertTransferModalSaveButtonIsDisabled(Browser $browser){
+        $this->assertModalSaveButtonIsDisabled($browser, "@transfer-modal-save-btn", "transfer-modal save button is NOT disabled");
+    }
+
+    protected function assertModalSaveButtonIsDisabled(Browser $browser, $modal_save_btn_selector, $fail_message){
         PHPUnit::assertEquals(
             'true',
-            $browser->attribute("@transfer-modal-save-btn", 'disabled'),
-            "transfer-modal save button is NOT disabled"
+            $browser->attribute($modal_save_btn_selector, 'disabled'),
+            $fail_message
         );
     }
 
     public function assertEntryModalSaveButtonIsNotDisabled(Browser $browser){
-        PHPUnit::assertNotEquals(
-            'true',
-            $browser->attribute("@entry-modal-save-btn", 'disabled'),
-            "Entry-modal save button IS disabled"
-        );
+        $this->assertModalSaveButtonIsNotDisabled($browser, "@entry-modal-save-btn", "entry-modal save button IS disabled");
     }
 
     public function assertTransferModalSaveButtonIsNotDisabled(Browser $browser){
+        $this->assertModalSaveButtonIsNotDisabled($browser, "@transfer-modal-save-btn", "transfer-modal save button IS disabled");
+    }
+
+    protected function assertModalSaveButtonIsNotDisabled(Browser $browser, $modal_save_btn_selector, $fail_message){
         PHPUnit::assertNotEquals(
             'true',
-            $browser->attribute("@transfer-modal-save-btn", 'disabled'),
-            "transfer-modal save button IS disabled"
+            $browser->attribute($modal_save_btn_selector, 'disabled'),
+            $fail_message
         );
     }
 
@@ -151,6 +158,34 @@ class HomePage extends Page {
             ->mouseover('@navbar')
             ->waitUntilMissing($notification_type_selector, self::WAIT_SECONDS)
             ->pause(250);    // give the element another 0.25 seconds to fully disappear;
+    }
+
+    /**
+     * @param Browser $browser
+     * @param string $element_selector
+     * @param string $expected_colour
+     * @param string $element_pseudo_selector
+     */
+    public function assertElementColour(Browser $browser, $element_selector, $expected_colour, $element_pseudo_selector=''){
+        $element_hex_colour = $browser->script([
+            'css_color = window.getComputedStyle(document.querySelector("'.$element_selector.'"), "'.$element_pseudo_selector.'").getPropertyValue("background-color");',
+            'rgb = css_color.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/);',
+            'if(rgb === null){
+            hex = css_color;    // assuming that the CSS color returned is HEX
+        } else {
+            r = (parseInt(rgb[1]) < 16 ? "0" : "")+parseInt(rgb[1]).toString(16);
+            g = (parseInt(rgb[2]) < 16 ? "0" : "")+parseInt(rgb[2]).toString(16);
+            b = (parseInt(rgb[3]) < 16 ? "0" : "")+parseInt(rgb[3]).toString(16);
+            hex = "#"+r+g+b;
+        }',
+            'return hex;'
+        ]);
+
+        PHPUnit::assertEquals(
+            strtoupper($expected_colour),
+            strtoupper($element_hex_colour[3]),
+            "Expected colour [$expected_colour] does not match actual colour [".$element_hex_colour[3]."] of element [$element_selector]"
+        );
     }
 
 }

--- a/tests/Browser/TransferModalTest.php
+++ b/tests/Browser/TransferModalTest.php
@@ -147,7 +147,7 @@ class TransferModalTest extends DuskTestCase {
     }
 
     public function testCloseTransferModalWithHotkey(){
-        $this->markTestSkipped("hotkey not working on transfer-modal yet");
+        $this->markTestSkipped("FIXME: hotkey not working on transfer-modal yet");
         $this->browse(function(Browser $browser){
             $browser
                 ->visit(new HomePage())
@@ -520,9 +520,9 @@ class TransferModalTest extends DuskTestCase {
         $browser
             ->with($table_row_selector, function($table_row) use ($transfer_entry_data, $entry_modal_date_input_value, $has_tags, $has_attachments){
                 $table_row
-                    ->assertSee($entry_modal_date_input_value)
-                    ->assertSee($transfer_entry_data['memo'])
-                    ->assertSee($transfer_entry_data['value'])
+                    ->assertSeeIn($this->_selector_table_row_date, $entry_modal_date_input_value)
+                    ->assertSeeIn($this->_selector_table_row_memo, $transfer_entry_data['memo'])
+                    ->assertSeeIn($this->_selector_table_row_value, $transfer_entry_data['value'])
                     ->assertVisible($this->_selector_table_row_transfer_checkbox.' '.$this->_selector_table_is_checked_checkbox);
                 if($has_tags){
                     $table_row->assertSee($transfer_entry_data['tag']);

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -38,9 +38,12 @@ abstract class DuskTestCase extends BaseTestCase {
      */
     public function getApiTags(){
         $tags_response = $this->get("/api/tags");
-        $tags = $tags_response->json();
-        unset($tags['count']);
-        return $tags;
+        return $this->removeCountFromApiResponse($tags_response->json());
+    }
+
+    public function getApiAccounts(){
+        $accounts_response = $this->get("/api/accounts");
+        return $this->removeCountFromApiResponse($accounts_response->json());
     }
 
     /**
@@ -48,9 +51,7 @@ abstract class DuskTestCase extends BaseTestCase {
      */
     public function getApiAccountTypes(){
         $account_types_response = $this->get("/api/account-types");
-        $account_types = $account_types_response->json();
-        unset($account_types['count']);
-        return $account_types;
+        return $this->removeCountFromApiResponse($account_types_response->json());
     }
 
     /**
@@ -59,8 +60,12 @@ abstract class DuskTestCase extends BaseTestCase {
      */
     public function getApiEntry($entry_id){
         $entry_response = $this->get("/api/entry/".$entry_id);
-        $entry = $entry_response->json();
-        return $entry;
+        return $this->removeCountFromApiResponse($entry_response->json());
+    }
+
+    private function removeCountFromApiResponse($api_call_response){
+        unset($api_call_response['count']);
+        return $api_call_response;
     }
 
     /**

--- a/tests/Traits/HomePageSelectors.php
+++ b/tests/Traits/HomePageSelectors.php
@@ -13,6 +13,7 @@ trait HomePageSelectors {
 
     // generic - modal
     private $_selector_modal_head = ".modal-card-head";
+    private $_selector_modal_title = ".modal-card-title";
     private $_selector_modal_body = ".modal-card-body";
     private $_selector_modal_foot = ".modal-card-foot";
     private $_selector_modal_btn_close = "button.delete";
@@ -26,7 +27,7 @@ trait HomePageSelectors {
     private $_selector_modal_dropzone_btn_remove = ".dz-remove";
 
     // entry-modal
-    private $_selector_modal_entry = "@entry-modal";
+    private $_selector_modal_entry = "@entry-modal";  // see Browser\Pages\HomePage.php
     private $_selector_modal_entry_btn_confirmed = "#entry-confirm";
     private $_selector_modal_entry_btn_confirmed_label = "#entry-confirm + label";
     private $_selector_modal_entry_field_entry_id = "#entry-id";
@@ -54,7 +55,7 @@ trait HomePageSelectors {
     private $_selector_modal_entry_btn_save = "button#entry-save-btn";
 
     // transfer-modal
-    private $_selector_modal_transfer = "@transfer-modal";
+    private $_selector_modal_transfer = "@transfer-modal";  // see Browser\Pages\HomePage.php
     private $_selector_modal_transfer_field_date = "input#transfer-date";
     private $_selector_modal_transfer_field_value = "input#transfer-value";
     private $_selector_modal_transfer_field_from = "select#from-account-type";
@@ -74,14 +75,42 @@ trait HomePageSelectors {
     private $_selector_modal_transfer_btn_cancel = "#transfer-cancel-btn";
     private $_selector_modal_transfer_btn_save = "#transfer-save-btn";
 
+    // filter-modal
+    private $_selector_modal_filter = "@filter-modal";  // see Browser\Pages\HomePage.php
+    private $_selector_modal_filter_field_start_date = "#filter-start-date";
+    private $_selector_modal_filter_field_end_date = "#filter-end-date";
+    private $_selector_modal_filter_field_switch_account_and_account_type = "#filter-account-account-types";
+    private $_selector_modal_filter_field_account_and_account_type = "#filter-account-or-account-types-id";
+    private $_selector_modal_filter_field_tags= "#filter-tags";
+    private $_selector_modal_filter_field_switch_income = "#filter-is-income";
+    private $_selector_modal_filter_field_switch_expense = "#filter-is-expense";
+    private $_selector_modal_filter_field_switch_has_attachment = "#filter-has-attachment";
+    private $_selector_modal_filter_field_switch_no_attachment = "#filter-no-attachment";
+    private $_selector_modal_filter_field_switch_transfer = "#filter-is-transfer";
+    private $_selector_modal_filter_field_switch_unconfirmed = "#filter-unconfirmed";
+    private $_selector_modal_filter_field_min_value = "#filter-min-value";
+    private $_selector_modal_filter_field_max_value = "#filter-max-value";
+    private $_selector_modal_filter_field_min_value_icon = "#filter-min-value+span i";
+    private $_selector_modal_filter_field_max_value_icon = "#filter-max-value+span i";
+    private $_selector_modal_filter_btn_cancel = "#filter-cancel-btn";
+    private $_selector_modal_filter_btn_reset = "#filter-reset-btn";
+    private $_selector_modal_filter_btn_filter = "#filter-btn";
+
     // entries-table
     private $_selector_table = "#entry-table";
+    private $_selector_table_head = 'thead';
+    private $_selector_table_body = 'tbody';
     private $_selector_table_unconfirmed_expense = "tr.has-background-warning.is-expense";
     private $_selector_table_unconfirmed_income = 'tr.has-background-warning.is-income';
     private $_selector_table_confirmed_expense = 'tr.is-confirmed.is-expense';
     private $_selector_table_confirmed_income = 'tr.has-background-success.is-confirmed.is-income';
-    private $_selector_table_row_transfer_checkbox = "td:nth-last-child(2)";
-    private $_selector_table_row_attachment_checkbox = "td:nth-last-child(3)";
+    private $_selector_table_row_date = 'td.row-entry-date';
+    private $_selector_table_row_memo = 'td.row-entry-memo';
+    private $_selector_table_row_value = 'td.row-entry-value';
+    private $_selector_table_row_account_type = 'td.row-entry-account-type';
+    private $_selector_table_row_transfer_checkbox = "td.row-entry-transfer-checkbox";
+    private $_selector_table_row_attachment_checkbox = "td.row-entry-attachment-checkbox";
+    private $_selector_table_row_tags = "td.row-entry-tags";
     private $_selector_table_is_checked_checkbox = ".fas.fa-check-square";
     private $_selector_table_unchecked_checkbox = "far fa-square";
     private $_selector_pagination_btn_next = "button#paginate-btn-next";
@@ -95,13 +124,31 @@ trait HomePageSelectors {
     private $_label_account_type_meta_last_digits = "Last 4 Digits:";
     private $_label_expense_switch_expense = "Expense";
     private $_label_expense_switch_income = "Income";
+    private $_label_switch_enabled = "Enabled";
+    private $_label_switch_disabled = "Disabled";
+    private $_label_select_option_filter_default = "[ ALL ]";
     private $_label_file_upload = "Drag & Drop";
     private $_label_btn_dropzone_remove_file = "REMOVE FILE";
     private $_label_btn_cancel = "Cancel";
     private $_label_btn_delete = "Delete";
     private $_label_btn_save = "Save changes";
+    private $_label_btn_reset = "Reset";
+    private $_label_btn_filter = "Filter";
     private $_label_notification_file_upload_success = "uploaded: %s";
     private $_label_notification_transfer_saved = "Transfer entry created";
     private $_label_notification_new_entry_created = "New entry created";
+
+    // ###*** COLOURS ***###
+    private $_color_expense_switch_expense = "#ffcc00";
+    private $_color_expense_switch_income = "#00d1b2";
+    private $_color_filter_switch_default = "#B5B5B5";
+    private $_color_filter_switch_active = "#209CEE";
+    private $_color_filter_btn_tag_default = "#f5f5f5";
+    private $_color_filter_btn_tag_active = "#209CEE";
+
+    private $_class_switch_core = ".v-switch-core";
+    private $_class_icon_euro = "fa-euro-sign";
+    private $_class_icon_dollar = "fa-dollar-sign";
+    private $_class_icon_pound = "fa-pound-sign";
 
 }


### PR DESCRIPTION
- Updated `docker/app.dockerfile` so that we use a provided php.ini file
- Modified the `docker/docker-compose.yml` environment variable of the `application` service. The `selenium` service is now dependant on the `application` service.
- Added output to the `UiSampleDatabaseSeeder.php`.
- Bumping vue-js-toggle-button package version.
- Made modifications to the `processLocaleDateForTyping` Dusk Browser macro function to better handle year values of 2 characters.
- Removed `artisan migrate:refresh` and `artisan db:seed` commands from travis-ci prior to running `artisan dusk`. `artisan dusk` now does it itself.
- Added filter-modal functionality.
- Added classes to the entry-table row cells.
- Added assertions on element colours.
- Injecting database state on failures for the Dusk `NotificationTest.php` test class.