### PR TITLE
support/rebuild-institutions-panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ docker/docker-yarn.sh run build-dev
 ##### Bring "up" application container(s)
 ```bash
 docker-compose -f docker/docker-compose.yml up -d
-# composer doesn't right to the correct .env file
+# composer doesn't write to the correct .env file during setup
 # so we need to generate the APP_KEY value again
 docker container exec -t app.money-tracker artisan key:generate
 ```

--- a/README.md
+++ b/README.md
@@ -275,9 +275,7 @@ Assuming we already have our docker environment already setup ([instructions her
 ```bash
 # Run PhpUnit tests
 docker container exec -t app.money-tracker vendor/bin/phpunit --stop-on-failure
-# Run Dusk tests
-docker container exec -t app.money-tracker artisan migrate:refresh
-docker container exec -t app.money-tracker artisan db:seed --class=UiSampleDatabaseSeeder
+# Run Laravel Dusk tests
 docker container exec -t app.money-tracker artisan dusk --stop-on-failure
 ```
 

--- a/app/Account.php
+++ b/app/Account.php
@@ -13,7 +13,8 @@ class Account extends BaseModel {
         'id'
     ];
     protected $casts = [
-        'disabled'=>'boolean'
+        'disabled'=>'boolean',
+        'total'=>'float'
     ];
     protected $dates = [
         'create_stamp',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build-dev": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "build-dev": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js && echo 'process completed @ ' `date`",
     "build-dev-watch": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
     "build-prod": "cross-env NODE_ENV=production  node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
@@ -9,17 +9,16 @@
     "@fortawesome/fontawesome-free": "^5.1.0",
     "@voerro/vue-tagsinput": "^1.8.0",
     "axios": "^0.16.2",
-    "bulma": "^0.6.2",
-    "bulma-accordion": "^1.0.1",
+    "bulma": "^0.7.4",
     "bulma-badge": "^1.0.1",
     "bulma-checkradio": "^2.1.0",
-    "bulma-tooltip": "^1.0.4",
     "cross-env": "^5.0.1",
     "laravel-mix": "^1.0",
     "lodash": "^4.17.4",
     "randomcolor": "^0.5.3",
     "toastr": "^2.1.4",
     "v-hotkey": "^0.3.0",
+    "v-tooltip": "^2.0.0-rc.33",
     "vue": "^2.1.10",
     "vue-js-toggle-button": "^1.3.1",
     "vue-snotify": "^3.2.1",

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -7,6 +7,9 @@ Vue.use(Snotify, {toast: {timeout: 5000}});
 import VueHotkey from 'v-hotkey';
 Vue.use(VueHotkey);
 
+import VTooltip from 'v-tooltip';
+Vue.use(VTooltip);
+
 import EntryModal from './components/entry-modal';
 import EntriesTable from './components/entries-table';
 import EntriesTableEntryRow from './components/entries-table-entry-row';

--- a/resources/assets/js/components/entries-table-entry-row.vue
+++ b/resources/assets/js/components/entries-table-entry-row.vue
@@ -1,5 +1,6 @@
 <template>
     <tr
+        v-bind:id="'entry-'+id"
         v-bind:class="{
             'has-background-warning': !confirm,
             'has-background-success': confirm && !expense,
@@ -81,7 +82,7 @@
     $stripe-even-opacity: 0.15;
 
     @mixin set-background-color($background-color){
-        background-color: rgba($background-color, $stripe-odd-opacity);
+        background-color: rgba($background-color, $stripe-odd-opacity) !important;
         &:nth-child(even){
             background-color: rgba($background-color, $stripe-even-opacity) !important;
         }
@@ -98,5 +99,9 @@
     }
     tr.has-background-success{
         @include set-background-color($success-bg);
+    }
+
+    td.row-entry-date{
+        width: 6.85rem;
     }
 </style>

--- a/resources/assets/js/components/filter-modal.vue
+++ b/resources/assets/js/components/filter-modal.vue
@@ -429,6 +429,9 @@
                             filterDataParameters.tags.push(tagId);
                         }
                     });
+                    if(_.isEmpty(filterDataParameters.tags)){
+                        delete filterDataParameters.tags;
+                    }
                 }
 
                 if(this.filterData.isIncome){

--- a/resources/assets/js/components/institutions-panel-institution.vue
+++ b/resources/assets/js/components/institutions-panel-institution.vue
@@ -1,64 +1,90 @@
 <template>
-    <div v-bind:id="'institution-id-'+this.institutionId" class="accordion">
-        <div class="institution-node panel-block accordion-header toggle">
-            <p v-text="this.institutionName"></p>
-        </div>
-        <div class="accordion-body panel">
+    <li v-bind:id="'institution-'+id" class="institution-panel-institution" v-bind:class="accordionClasses">
+        <a class="institution-panel-institution-name"  v-on:click="toggleAccordion">
+            <span class="panel-icon">
+                <i v-bind:class="openCloseIcon" aria-hidden="true"></i>
+            </span>
+            <span class="name-label" v-text="name"></span>
+        </a>
+
+        <ul class="institution-panel-institution-accounts">
             <institutions-panel-institution-account
-                v-for="account in activeInstitutionAccounts"
+                v-for="account in activeAccountsInInstitution"
                 v-bind:key="account.id"
                 v-bind:id="account.id"
                 v-bind:name="account.name"
+                v-bind:accountCurrency="account.currency"
                 v-bind:total="account.total"
             ></institutions-panel-institution-account>
-        </div>
-    </div>
+        </ul>
+    </li>
 </template>
 
 <script>
-    import {Accounts} from "../accounts";
+    import {Accounts} from '../accounts';
     import InstitutionsPanelInstitutionAccount from "./institutions-panel-institution-account";
 
     export default {
         name: "institutions-panel-institution",
-        components: {
-            InstitutionsPanelInstitutionAccount,
+        components: {InstitutionsPanelInstitutionAccount},
+        props: {
+            id: Number,
+            name: String
         },
-        props: ['id', 'name'],
         data: function(){
             return {
-                accounts: new Accounts(),
-            }
+                isOpen: false,
+                openCloseIcons: {
+                    opened: 'fas fa-chevron-up',
+                    closed: 'fas fa-chevron-down'
+                },
+                accountsObject: new Accounts(),
+            };
         },
         computed: {
-            institutionId: function(){
-                return this.id;
+            openCloseIcon: function(){
+                return this.isOpen ? this.openCloseIcons.opened : this.openCloseIcons.closed;
             },
-            institutionName: function(){
-                return this.name;
+            closedAccountsOpenCloseIcon: function(){
+                return this.isOpen ? this.openCloseIcons.closed : this.openCloseIcons.opened;
             },
-            activeAccounts: function(){
-                return this.accounts.retrieve.filter(function(account){
-                    return !account.disabled
-                })
+            accordionClasses: function(){
+                return this.isOpen ? '' : 'is-closed';
             },
-            activeInstitutionAccounts: function(){
-                return this.activeAccounts.filter(function(account){
-                    if(account.hasOwnProperty('institution_id')){
-                        return this.institutionId === account.institution_id;
-                    }
+            accountsInInstitution: function(){
+                return this.accountsObject.retrieve.filter(function(account){
+                    return account.institution_id === this.id;
                 }.bind(this));
+            },
+            activeAccountsInInstitution: function(){
+                return this.accountsInInstitution.filter(function(account){
+                    return !account.disabled;
+                });
+            }
+        },
+        methods:{
+            toggleAccordion: function(){
+                this.isOpen = !this.isOpen;
             },
         }
     }
 </script>
 
-<style scoped>
-    .institution-node{
-        background-color: initial !important;
-        color: #363636 !important;
-        border-bottom: 0;
+<style lang="scss" scoped>
+    .institution-panel-institution-accounts{
+        max-height: 20rem;
+        overflow: hidden;
+        font-weight: 400;
+        margin-top: 0;
+        -webkit-transition: all 0.3s ease-in-out;
+        -moz-transition: all 0.3s ease-in-out;
+        -o-transition: all 0.3s ease-in-out;
+        transition: all 0.3s ease-in-out;
+    }
+
+    .is-closed{
+        .institution-panel-institution-accounts{
+            max-height: 0;
+        }
     }
 </style>
-
-

--- a/resources/assets/js/components/navbar.vue
+++ b/resources/assets/js/components/navbar.vue
@@ -1,9 +1,18 @@
 <template>
-    <nav class="navbar is-black is-transparent" role="navigation" aria-label="dropdown navigation">
+    <nav class="navbar is-black is-transparent is-fixed-top" role="navigation" aria-label="dropdown navigation">
         <div class="navbar-brand">
             <span class="navbar-item"><img src="imgs/logo-white.png" alt="Money Tracker" /></span>
+
+            <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false"
+               v-bind:class="{'is-active': hasNavbarBurgerMenuBeenClicked}"
+               v-on:click="clickNavbarBurger"
+            >
+                <span aria-hidden="true"></span>
+                <span aria-hidden="true"></span>
+                <span aria-hidden="true"></span>
+            </a>
         </div>
-        <div class="navbar-menu">
+        <div class="navbar-menu" v-bind:class="{'is-active': hasNavbarBurgerMenuBeenClicked}">
             <div class="navbar-end">
                 <a id="nav-entry-modal" class="navbar-item" v-on:click="openAddEntryModal"><i class="fas fa-plus-circle"></i> Add Entry</a>
                 <a id="nav-transfer-modal" class="navbar-item" v-on:click="openTransferModal"><i class="fas fa-exchange-alt"></i> Add Transfer</a>
@@ -13,12 +22,12 @@
                     v-bind:class="{'is-active': hasNavbarAvatarImageBeenClicked}"
                     v-on:click="clickNavbarAvatarImage"
                     >
-                    <a id="profile-nav-link" class="navbar-link"><img src="imgs/profile-placeholder.jpeg" alt="AVATAR"/></a>
+                    <a id="profile-nav-link" class="navbar-link is-hidden-touch"><img src="imgs/profile-placeholder.jpeg" alt="AVATAR"/></a>
 
                     <div class="navbar-dropdown is-boxed is-right">
-                        <div class="navbar-item">TODO: NAME</div>
+                        <div class="navbar-item is-hidden-touch">TODO: NAME</div>
                         <hr class="navbar-divider">
-                        <div id="app-version" class="navbar-item has-text-info is-italic">Version: {{appVersion}}</div>
+                        <div id="app-version" class="navbar-item has-text-info is-italic is-hidden-touch">Version: {{appVersion}}</div>
                         <hr class="navbar-divider">
                         <a class="navbar-item" href="stats"><i class="fas fa-chart-pie"></i> Statistics</a>
                         <a class="navbar-item" href="settings"><i class="fas fa-cog"></i> Settings</a>
@@ -40,12 +49,16 @@
             return {
                 defaultAppVersion: 'x.y.z',
                 navbarAvatarImageClicked: false,
+                navbarBurgerClicked: false,
                 version: new Version(),
             }
         },
         computed: {
             hasNavbarAvatarImageBeenClicked: function(){
                 return this.navbarAvatarImageClicked;
+            },
+            hasNavbarBurgerMenuBeenClicked: function(){
+                return this.navbarBurgerClicked;
             },
             appVersion: function(){
                 let appVersion = this.version.retrieve;//'x.y.z';
@@ -64,6 +77,9 @@
             },
             clickNavbarAvatarImage: function(){
                 this.navbarAvatarImageClicked = !this.navbarAvatarImageClicked;
+            },
+            clickNavbarBurger: function(){
+                this.navbarBurgerClicked = !this.navbarBurgerClicked;
             }
         }
     }

--- a/resources/assets/js/currency.js
+++ b/resources/assets/js/currency.js
@@ -1,0 +1,12 @@
+/**
+ * Created by denis.oconnor on 2019-03-01
+ */
+
+export default {
+    currency: {
+        euro: { label: "EUR", class: "fas fa-euro-sign" },
+        dollarUs: { label: "USD", class: "fas fa-dollar-sign" },
+        dollarCa: { label: "CAD", class: "fas fa-dollar-sign" },
+        pound: { label: "GBP", class: "fas fa-pound-sign" }
+    }
+};

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -1,5 +1,17 @@
-#institutions-panel-column{
-  background-color: whitesmoke;
+// Bulma
+@import "~bulma/bulma.sass";
+@import "~bulma-badge/dist/bulma-badge.sass";
+@import "~bulma-checkradio/dist/css/bulma-checkradio.sass";
+
+// Snotify
+@import "~vue-snotify/styles/material";
+
+// v-tooltip
+@import "tooltip";
+
+// custom styling
+.columns.is-gapless{
+  margin-top: 3.25rem;
 }
 
 .has-padding-right{
@@ -22,13 +34,3 @@
 .tags-input span{
   margin: 0 0.3rem 0 0;
 }
-
-// Bulma
-@import "~bulma/bulma.sass";
-@import "~bulma-accordion/dist/bulma-accordion.sass";
-@import "~bulma-badge/dist/bulma-badge.sass";
-@import "~bulma-checkradio/dist/css/bulma-checkradio.sass";
-@import "~bulma-tooltip/dist/bulma-tooltip.sass";
-
-// Snotify
-@import "~vue-snotify/styles/material";

--- a/resources/assets/sass/tooltip.scss
+++ b/resources/assets/sass/tooltip.scss
@@ -1,0 +1,110 @@
+/* v-tooltip styling */
+.tooltip {
+  display: block !important;
+  z-index: 10000;
+
+  .tooltip-inner {
+    background: black;
+    color: white;
+    border-radius: 16px;
+    padding: 5px 10px 4px;
+  }
+
+  .tooltip-arrow {
+    width: 0;
+    height: 0;
+    border-style: solid;
+    position: absolute;
+    margin: 5px;
+    border-color: black;
+    z-index: 1;
+  }
+
+  &[x-placement^="top"] {
+    margin-bottom: 5px;
+
+    .tooltip-arrow {
+      border-width: 5px 5px 0 5px;
+      border-left-color: transparent !important;
+      border-right-color: transparent !important;
+      border-bottom-color: transparent !important;
+      bottom: -5px;
+      left: calc(50% - 5px);
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+
+  &[x-placement^="bottom"] {
+    margin-top: 5px;
+
+    .tooltip-arrow {
+      border-width: 0 5px 5px 5px;
+      border-left-color: transparent !important;
+      border-right-color: transparent !important;
+      border-top-color: transparent !important;
+      top: -5px;
+      left: calc(50% - 5px);
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+
+  &[x-placement^="right"] {
+    margin-left: 5px;
+
+    .tooltip-arrow {
+      border-width: 5px 5px 5px 0;
+      border-left-color: transparent !important;
+      border-top-color: transparent !important;
+      border-bottom-color: transparent !important;
+      left: -5px;
+      top: calc(50% - 5px);
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
+
+  &[x-placement^="left"] {
+    margin-right: 5px;
+
+    .tooltip-arrow {
+      border-width: 5px 0 5px 5px;
+      border-top-color: transparent !important;
+      border-right-color: transparent !important;
+      border-bottom-color: transparent !important;
+      right: -5px;
+      top: calc(50% - 5px);
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
+
+  &.popover {
+    $color: #f9f9f9;
+
+    .popover-inner {
+      background: $color;
+      color: black;
+      padding: 24px;
+      border-radius: 5px;
+      box-shadow: 0 5px 30px rgba(black, .1);
+    }
+
+    .popover-arrow {
+      border-color: $color;
+    }
+  }
+
+  &[aria-hidden='true'] {
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity .15s, visibility .15s;
+  }
+
+  &[aria-hidden='false'] {
+    visibility: visible;
+    opacity: 1;
+    transition: opacity .15s;
+  }
+}

--- a/resources/views/vue.blade.php
+++ b/resources/views/vue.blade.php
@@ -45,6 +45,5 @@
         </div>
     </div>
     <script type="text/javascript" src="{{asset('vue/js/app.js')}}"></script>
-    <script type="text/javascript" src="{{asset('vue/js/bulma-accordion.js')}}"></script>
 </body>
 </html>

--- a/tests/Browser/ATest.php
+++ b/tests/Browser/ATest.php
@@ -4,8 +4,16 @@ namespace Tests\Browser;
 
 use Tests\DuskTestCase;
 use Laravel\Dusk\Browser;
+use Laravel\Dusk\TestCase as BaseTestCase;
 
 class ATest extends DuskTestCase {
+
+    /**
+     * Override the setUp() from DuskTestCase
+     */
+    protected function setUp(){
+        BaseTestCase::setUp();
+    }
 
     /**
      * A basic browser test to make sure selenium integration works

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -24,11 +24,6 @@ class EntryModalExistingEntryTest extends DuskTestCase {
     private $_class_has_tags = "has-tags";
     private $_class_existing_attachment = "existing-attachment";
 
-    public function setUp(){
-        parent::setUp();
-        Artisan::call('db:seed', ['--class'=>'UiSampleDatabaseSeeder']);
-    }
-
     public function providerUnconfirmedEntry(){
         return [
             "Expense"=>[$this->_selector_table_unconfirmed_expense, $this->_label_expense_switch_expense],

--- a/tests/Browser/EntryModalNewEntryTest.php
+++ b/tests/Browser/EntryModalNewEntryTest.php
@@ -14,11 +14,6 @@ class EntryModalNewEntryTest extends DuskTestCase {
     use DatabaseMigrations;
     use HomePageSelectors;
 
-    public function setUp(){
-        parent::setUp();
-        Artisan::call('db:seed', ['--class'=>'UiSampleDatabaseSeeder']);
-    }
-
     public function testEntryModalIsNotVisibleByDefault(){
         $this->browse(function (Browser $browser) {
             $browser

--- a/tests/Browser/FilterModalTest.php
+++ b/tests/Browser/FilterModalTest.php
@@ -39,7 +39,7 @@ class FilterModalTest extends DuskTestCase {
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
                 ->openFilterModal()
-                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_head, function($modal){
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_head, function(Browser $modal){
                     $modal
                         ->assertSee("Filter Entries")
                         ->assertVisible($this->_selector_modal_btn_close);
@@ -56,7 +56,7 @@ class FilterModalTest extends DuskTestCase {
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
                 ->openFilterModal()
-                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function($modal) use ($accounts, $tags){
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function(Browser $modal) use ($accounts, $tags){
                     $modal
                         // start date - input
                         ->assertSee("Start Date:")
@@ -191,7 +191,7 @@ class FilterModalTest extends DuskTestCase {
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
                 ->openFilterModal()
-                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_foot, function($modal){
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_foot, function(Browser $modal){
                     $modal
                         ->assertVisible($this->_selector_modal_filter_btn_cancel)
                         ->assertSee($this->_label_btn_cancel)
@@ -224,7 +224,7 @@ class FilterModalTest extends DuskTestCase {
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
                 ->openFilterModal()
-                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function($modal) use ($filter_modal_field_selectors){
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function(Browser $modal) use ($filter_modal_field_selectors){
                     $filter_modal_elements = $modal->elements('div.field.is-horizontal');
                     $this->assertCount(count($filter_modal_field_selectors), $filter_modal_elements);
                 });
@@ -237,7 +237,7 @@ class FilterModalTest extends DuskTestCase {
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
                 ->openFilterModal()
-                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_head, function($modal){
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_head, function(Browser $modal){
                     $modal->click($this->_selector_modal_btn_close);
                 })
                 ->assertMissing($this->_selector_modal_filter);
@@ -250,7 +250,7 @@ class FilterModalTest extends DuskTestCase {
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
                 ->openFilterModal()
-                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_foot, function($modal){
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_foot, function(Browser $modal){
                     $modal->click($this->_selector_modal_filter_btn_cancel);
                 })
                 ->assertMissing($this->_selector_modal_filter);
@@ -309,7 +309,7 @@ class FilterModalTest extends DuskTestCase {
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
                 ->openFilterModal()
-                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function($modal) use ($has_disabled_account, $has_disabled_account_type, $accounts, $account_types){
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function(Browser $modal) use ($has_disabled_account, $has_disabled_account_type, $accounts, $account_types){
                     $modal
                         ->assertVisible($this->_selector_modal_filter_field_switch_account_and_account_type)
                         ->assertVisible($this->_selector_modal_filter_field_account_and_account_type)
@@ -346,7 +346,7 @@ class FilterModalTest extends DuskTestCase {
                     $this->assertContains($this->_class_icon_dollar, $modal->attribute($this->_selector_modal_filter_field_max_value_icon, 'class'));
 
                     // select an account and confirm the name in the select changes
-                    $account_to_select = $this->faker->randomElement($accounts);
+                    $account_to_select = collect($accounts)->where('disabled', 0)->random(1)->first();
                     $modal
                         ->select($this->_selector_modal_filter_field_account_and_account_type, $account_to_select['id'])
                         ->assertSeeIn($this->_selector_modal_filter_field_account_and_account_type, $account_to_select['name']);
@@ -458,15 +458,12 @@ class FilterModalTest extends DuskTestCase {
      * @throws \Throwable
      */
     public function testFlipSwitch($switch_selector){
-        $accounts = $this->getApiAccounts();
-        $account_types = $this->getApiAccountTypes();
-
-        $this->browse(function(Browser $browser) use ($switch_selector, $accounts, $account_types){
+        $this->browse(function(Browser $browser) use ($switch_selector){
             $browser
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
                 ->openFilterModal()
-                ->with($this->_selector_modal_filter, function($modal) use ($switch_selector, $accounts, $account_types){
+                ->with($this->_selector_modal_filter, function(Browser $modal) use ($switch_selector){
                     $modal
                         ->assertVisible($switch_selector)
                         ->assertSeeIn($switch_selector, $this->_label_switch_disabled)
@@ -501,7 +498,7 @@ class FilterModalTest extends DuskTestCase {
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
                 ->openFilterModal()
-                ->with($this->_selector_modal_filter, function($modal) use ($init_switch_selector, $companion_switch_selector){
+                ->with($this->_selector_modal_filter, function(Browser $modal) use ($init_switch_selector, $companion_switch_selector){
                     $modal
                         ->assertVisible($init_switch_selector)
                         ->assertSeeIn($init_switch_selector, $this->_label_switch_disabled)
@@ -544,7 +541,7 @@ class FilterModalTest extends DuskTestCase {
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
                 ->openFilterModal()
-                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function($modal) use ($field_selector){
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function(Browser $modal) use ($field_selector){
                     $modal
                         ->type($field_selector, "rh48r7th72.9ewd3dadh1")
                         ->click($this->_selector_modal_filter_field_end_date)
@@ -558,7 +555,7 @@ class FilterModalTest extends DuskTestCase {
             $browser->visit(new HomePage())
                 ->waitForLoadingToStop()
                 ->openFilterModal()
-                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function ($modal){
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function (Browser $modal){
                     $tags = $this->getApiTags();
                     foreach($tags as $tag){
                         $selector_tag_checkbox = $this->_selector_modal_filter_field_tags.' '.$this->_partial_selector_filter_tag.$tag['id'];
@@ -583,7 +580,7 @@ class FilterModalTest extends DuskTestCase {
                 ->waitForLoadingToStop()
                 ->openFilterModal()
                 // modify all (or at least most) fields
-                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function($modal) use ($tags){
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function(Browser $modal) use ($tags){
                     $time_from_browser = $modal->getBrowserLocaleDate();
                     $start_date = $modal->processLocaleDateForTyping($time_from_browser);
 
@@ -615,7 +612,7 @@ class FilterModalTest extends DuskTestCase {
                 })
 
                 // click reset button
-                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_foot, function($modal){
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_foot, function(Browser $modal){
                     $modal
                         ->assertVisible($this->_selector_modal_filter_btn_reset)
                         ->click($this->_selector_modal_filter_btn_reset)
@@ -623,7 +620,7 @@ class FilterModalTest extends DuskTestCase {
                 })
 
                 // confirm all fields have been reset
-                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function($modal) use ($tags){
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function(Browser $modal) use ($tags){
                     $modal
                         ->assertInputValue($this->_selector_modal_filter_field_start_date, '')
                         ->assertInputValue($this->_selector_modal_filter_field_end_date, '')
@@ -681,7 +678,7 @@ class FilterModalTest extends DuskTestCase {
                 ->waitForLoadingToStop()
                 ->openFilterModal()
                 // modify all (or at least most) fields
-                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function($modal) use ($filter_param, &$filter_value){
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function(Browser $modal) use ($filter_param, &$filter_value){
                     switch($filter_param){
                         case $this->_selector_modal_filter_field_start_date:
                         case $this->_selector_modal_filter_field_end_date:
@@ -701,7 +698,7 @@ class FilterModalTest extends DuskTestCase {
                                 $modal->click($this->_selector_modal_filter_field_switch_account_and_account_type);
                                 $filter_values = $this->getApiAccountTypes();
                             }
-                            $filter_value = collect($filter_values)->random(1)->first();
+                            $filter_value = collect($filter_values)->where('disabled', false)->random(1)->first();
                             $modal->select($filter_param, $filter_value['id']);
 
                             if($is_account){
@@ -741,14 +738,14 @@ class FilterModalTest extends DuskTestCase {
                     }
                 })
 
-                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_foot, function($modal){
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_foot, function(Browser $modal){
                     $modal->click($this->_selector_modal_filter_btn_filter);
                 })
                 ->waitForLoadingToStop()
                 ->assertMissing($this->_selector_modal_filter)
 
                 // confirm only rows matching the filter parameters are shown
-                ->with($this->_selector_table.' '.$this->_selector_table_body, function($table) use ($filter_param, $filter_value){
+                ->with($this->_selector_table.' '.$this->_selector_table_body, function(Browser $table) use ($filter_param, $filter_value){
                     $table_rows = $table->elements('tr');
                     foreach($table_rows as $table_row){
                         switch($filter_param){
@@ -841,6 +838,46 @@ class FilterModalTest extends DuskTestCase {
                         }
                     }
             });
+        });
+    }
+
+    public function testClickFilterButtonToUpdateInstitutionsPanelActive(){
+        $this->browse(function(Browser $browser){
+            $filter_value = [];
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openFilterModal()
+                // modify all (or at least most) fields
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function(Browser $modal) use (&$filter_value){
+                    $accounts = $this->getApiAccounts();
+                    $filter_value = collect($accounts)->where('disabled', 0)->random(1)->first();
+                    $modal->select($this->_selector_modal_filter_field_account_and_account_type, $filter_value['id']);
+                })
+
+                ->with($this->_selector_modal_filter.' '.$this->_selector_modal_foot, function($modal){
+                    $modal->click($this->_selector_modal_filter_btn_filter);
+                })
+                ->waitForLoadingToStop()
+                ->assertMissing($this->_selector_modal_filter)
+
+                ->with($this->_selector_panel_institutions, function(Browser $panel) use ($filter_value){
+                    // TODO: confirm "Overview (filtered)" is visible
+                    // "overview" is NOT active
+                    $overview_classes = $panel->attribute($this->_selector_panel_institutions_overview, 'class');
+                    $this->assertNotContains($this->_class_is_active, $overview_classes);
+
+                    $panel
+                        ->click("#institution-".$filter_value['institution_id'].' a')
+                        ->pause('400');  // 0.4 seconds
+
+                    $account_classes = $panel->attribute('#account-'.$filter_value['id'].' '.$this->_selector_panel_institutions_accounts_account_name, 'class');
+                    $this->assertContains($this->_class_is_active, $account_classes);
+
+                    $selector = '#account-'.$filter_value['id'].' '.$this->_selector_panel_institutions_accounts_account_name.' span:first-child';
+                    $account_name = $panel->text($selector);
+                    $this->assertEquals($filter_value['name'], $account_name, "Could not find value at selector:".$panel->resolver->format($selector));
+                });
         });
     }
 

--- a/tests/Browser/FilterModalTest.php
+++ b/tests/Browser/FilterModalTest.php
@@ -29,7 +29,6 @@ class FilterModalTest extends DuskTestCase {
 
     public function setUp(){
         parent::setUp();
-        Artisan::call('db:seed', ['--class'=>'UiSampleDatabaseSeeder']);
 
         $this->faker = FakerFactory::create();
     }

--- a/tests/Browser/InstitutionsPanelTest.php
+++ b/tests/Browser/InstitutionsPanelTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Account;
+use App\Institution;
+use Facebook\WebDriver\WebDriverBy;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Laravel\Dusk\Browser;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Tests\Browser\Pages\HomePage;
+use Tests\DuskTestCase;
+use Tests\Traits\HomePageSelectors;
+
+class InstitutionsPanelTest extends DuskTestCase {
+
+    use HomePageSelectors;
+    use DatabaseMigrations;
+
+    public function testOverviewOptionIsVisibleAndActiveByDefault(){
+        $this->browse(function(Browser $browser){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->with($this->_selector_panel_institutions, function($panel){
+                    $panel
+                        ->assertSeeIn(".panel-heading", "Institutions")
+                        ->assertVisible($this->_selector_panel_institutions_overview)
+                        ->assertSeeIn($this->_selector_panel_institutions_overview, "Overview");
+
+                    $overview_class = $panel->attribute($this->_selector_panel_institutions_overview, 'class');
+                    $this->assertContains($this->_class_is_active, $overview_class);
+                });
+        });
+    }
+
+    public function testActiveInstitutionsAreVisibleWithAccountsAndClickingOnAnAccountFiltersEntries(){
+        $institutions_collection = $this->getInstitutionsCollection();
+        $accounts_collection = $this->getAccountsCollection($institutions_collection);
+        $account_types_collection = $this->getAccountTypesCollection();
+
+        $this->browse(function(Browser $browser) use ($institutions_collection, $accounts_collection, $account_types_collection){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->with($this->_selector_panel_institutions, function($panel) use ($institutions_collection, $accounts_collection, $account_types_collection){
+                    $active_institutions_collection = $institutions_collection
+                        ->where('active', true)
+                        ->sortBy('name');
+
+                    foreach($active_institutions_collection as $active_institution){
+                        $panel->with('#institution-'.$active_institution['id'], function($institution_node) use ($active_institution, $accounts_collection, $account_types_collection){
+                            // confirm "accordion" is closed
+                            $open_close_node_class = $institution_node->attribute($this->_selector_panel_institutions_institution_open_close, 'class');
+                            $this->assertContains('fa-chevron-down', $open_close_node_class);
+
+                            // confirm institution name is within collection
+                            $institutions_node_name = $institution_node->text($this->_selector_panel_institutions_institution_name);
+                            $this->assertEquals($active_institution['name'], $institutions_node_name);
+
+                            $institution_node
+                                // confirm accounts NOT visible
+                                ->assertMissing($this->_selector_panel_institutions_accounts)
+                                // click institutions node;
+                                ->click('')
+                                ->pause(400)    // 0.4 seconds
+                                // accounts now visible
+                                ->assertVisible($this->_selector_panel_institutions_accounts);
+
+                            // confirm "accordion" is open
+                            $open_close_node_class = $institution_node->attribute($this->_selector_panel_institutions_institution_open_close, 'class');
+                            $this->assertContains('fa-chevron-up', $open_close_node_class);
+
+                            $institution_accounts_collection = $accounts_collection
+                                ->where('disabled', false)
+                                ->where('institution_id', $active_institution['id'])
+                                ->sortBy('name');
+                            foreach($institution_accounts_collection as $institution_account){
+                                $institution_node->with($this->_selector_panel_institutions_accounts.' #account-'.$institution_account['id'], function($account_node) use ($institution_account, $account_types_collection){
+                                    $this->assertInstitutionPanelAccountNode($account_node, $institution_account, $account_types_collection);
+                                });
+                            }
+                        });
+                    }
+                });
+        });
+    }
+
+    public function testDisabledAccountsElementNotVisibleIfNoDisabledAccountsExist(){
+        $institutions_collection = $this->getInstitutionsCollection(false);
+        $institution_id = $institutions_collection->pluck('id')->random(1)->first();
+        DB::statement("TRUNCATE accounts");
+        factory(Account::class, 3)->create(['disabled'=>0, 'institution_id'=>$institution_id]);
+
+        $this->browse(function(Browser $browser){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->assertMissing("#closed-accounts");
+        });
+    }
+
+    public function testDisabledAccountsAreVisibleAndClickingOnADisabledAccountFiltersEntries(){
+        $institutions_collection = $this->getInstitutionsCollection(false);
+        $accounts_collection = $this->getAccountsCollection($institutions_collection);
+        $disabled_accounts_collection = $accounts_collection->where('disabled', true);
+        $account_types_collection = $this->getAccountTypesCollection();
+
+        $this->browse(function(Browser $browser) use ($disabled_accounts_collection, $account_types_collection){
+            $browser
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->assertVisible("#closed-accounts")
+                ->with("#closed-accounts", function($closed_accounts) use ($disabled_accounts_collection, $account_types_collection){
+                    // confirm the label says "closed accounts"
+                    $closed_accounts_label = $closed_accounts->text('span.name-label');
+                    $this->assertEquals("Closed Accounts", $closed_accounts_label);
+
+                    // confirm "accordion" is closed
+                    $open_close_node_class = $closed_accounts->attribute('span.panel-icon i', 'class');
+                    $this->assertContains('fa-chevron-up', $open_close_node_class);
+
+                    $closed_accounts
+                        // confirm accounts NOT visible
+                        ->assertMissing($this->_selector_panel_institutions_accounts)
+                        // click "closed accounts"
+                        ->click('')
+                        ->pause(400)    // 0.4 seconds
+                        // accounts now visible
+                        ->assertVisible($this->_selector_panel_institutions_accounts);
+
+                    // confirm "accordion" is open
+                    $open_close_node_class = $closed_accounts->attribute('span.panel-icon i', 'class');
+                    $this->assertContains('fa-chevron-down', $open_close_node_class);
+
+                    foreach($disabled_accounts_collection as $account_data){
+                        $closed_accounts->with($this->_selector_panel_institutions_accounts.' #account-'.$account_data['id'], function($account_node) use ($account_data, $account_types_collection){
+                            $this->assertInstitutionPanelAccountNode($account_node, $account_data, $account_types_collection, false);
+                        });
+                    }
+                });
+        });
+    }
+
+    /**
+     * @param Browser $account_node
+     * @param array $account_data
+     * @param Collection $account_types_collection
+     * @param boolean $has_tooltip
+     */
+    private function assertInstitutionPanelAccountNode($account_node, $account_data, $account_types_collection, $has_tooltip=true){
+        // confirm account name is within collection
+        $account_node_name = $account_node->text($this->_selector_panel_institutions_accounts_account_name.' span:first-child');
+        $this->assertContains($account_data['name'], $account_node_name);
+
+        $account_account_types = $account_types_collection->where('disabled', false)
+            ->where('account_id', $account_data['id']);
+
+        // hover over account element
+        $account_node->mouseover('');
+
+        if($has_tooltip){
+            // account-types tooltip appears to right
+            $account_node_tooltip_id = $account_node->attribute('', 'aria-describedby');    // get the tooltip element id
+            $account_node->assertVisible('#'.$account_node_tooltip_id);
+            $account_types_tooltip_text = $account_node->text('#'.$account_node_tooltip_id);
+            foreach($account_account_types as $account_account_type){
+                $this->assertContains($account_account_type['name'], $account_types_tooltip_text);
+            }
+        } else {
+            $account_css_prefix = $account_node->resolver->prefix;
+            $account_node->resolver->prefix = '';
+            $account_node->assertMissing('body .tooltip');
+            $account_node->resolver->prefix = $account_css_prefix;
+        }
+
+        // account is NOT "active"
+        $account_name_class = $account_node->attribute($this->_selector_panel_institutions_accounts_account_name, 'class');
+        $this->assertNotContains('is-active', $account_name_class);
+        $account_node->click('');
+        // wait for loading to finish
+        $account_css_prefix = $account_node->resolver->prefix;
+        $account_node->resolver->prefix = '';
+        $account_node->waitForLoadingToStop();
+        $account_node->resolver->prefix = $account_css_prefix;
+        // account is "active"
+        $account_name_class = $account_node->attribute($this->_selector_panel_institutions_accounts_account_name, 'class');
+        $this->assertContains('is-active', $account_name_class);
+        // "overview" is NOT active
+        $account_css_prefix = $account_node->resolver->prefix;
+        $account_node->resolver->prefix = '';
+        $overview_class = $account_node->attribute($this->_selector_panel_institutions.' '.$this->_selector_panel_institutions_overview, 'class');
+        $this->assertNotContains('is-active', $overview_class);
+        $account_node->resolver->prefix = $account_css_prefix;
+
+        // entries table has been updated with entries associated with account
+        $account_node->with($this->_selector_table.' '.$this->_selector_table_body, function ($table) use ($account_account_types){
+            $table_rows = $table->elements('tr');
+            foreach($table_rows as $table_row){
+                $row_entry_account_type = $table_row
+                    ->findElement(WebDriverBy::cssSelector($this->_selector_table_row_account_type))
+                    ->getText();
+                $this->assertContains($row_entry_account_type, $account_account_types->pluck('name')->all());
+            }
+        });
+    }
+
+    /**
+     * @param bool $include_inactive_institutions
+     * @return Collection
+     */
+    private function getInstitutionsCollection($include_inactive_institutions = true){
+        // make sure we have at least 1 "inactive" institution
+        $institutions = $this->getApiInstitutions();
+        $institutions_collection = collect($institutions);
+        if($include_inactive_institutions){
+            if($institutions_collection->where('active', false)->count() == 0){
+                $inactive_institution = factory(Institution::class, 1)->create(['active'=>false]);
+                $institutions_collection->push($inactive_institution);
+            }
+        } else {
+            $institutions_collection = $institutions_collection->where('active', true);
+        }
+        return $institutions_collection;
+    }
+
+    /**
+     * @param Collection $institutions_collection
+     * @param bool $include_disabled_accounts
+     * @return Collection
+     */
+    private function getAccountsCollection($institutions_collection, $include_disabled_accounts = true){
+        // make sure we have at least 1 "disabled" account
+        $accounts = $this->getApiAccounts();
+        $accounts_collection = collect($accounts);
+        if($include_disabled_accounts){
+            if($accounts_collection->where('disabled', true)->count() == 0){
+                $disabled_account = factory(Account::class, 1)->create(['disabled'=>true, 'institution_id'=>$institutions_collection->random(1)->pluck('id')->first()]);
+                $accounts_collection->push($disabled_account);
+            }
+        } else {
+            $accounts_collection = $accounts_collection->where('disabled', false);
+        }
+        return $accounts_collection;
+    }
+
+    /**
+     * @return Collection
+     */
+    private function getAccountTypesCollection(){
+        $account_types = $this->getApiAccountTypes();
+        return collect($account_types);
+    }
+
+}

--- a/tests/Browser/NavbarTest.php
+++ b/tests/Browser/NavbarTest.php
@@ -11,10 +11,14 @@ class NavbarTest extends DuskTestCase {
 
     use DatabaseMigrations;
 
+    const MOBILE_RESIZE_WIDTH_PX = 1000;
+    const RESIZE_HEIGHT_PX = 750;
+
     private $_selector_navbar = '@navbar';
     private $_selector_navbar_brand = ".navbar-brand";
     private $_selector_navbar_dropdown = ".navbar-dropdown";
     private $_selector_profile_link = "#profile-nav-link";
+    private $_selector_navbar_version = "#app-version";
 
     private $_label_add_entry = "Add Entry";
     private $_label_filter = "Filter";
@@ -23,6 +27,8 @@ class NavbarTest extends DuskTestCase {
     private $_label_stats = "Statistics";
     private $_label_settings = "Settings";
     private $_label_logout = "Logout";
+
+    // TODO: test for hamburger menu navbar
 
     public function testBrandImage(){
         $this->browse(function(Browser $browser){
@@ -73,18 +79,47 @@ class NavbarTest extends DuskTestCase {
             $browser
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
-                ->with($this->_selector_navbar, function($navbar){
-                    $navbar_dropdown_selector = $this->_selector_navbar_dropdown;
+                ->with($this->_selector_navbar, function(Browser $navbar){
                     $navbar
-                        ->assertMissing($navbar_dropdown_selector)
+                        ->assertMissing($this->_selector_navbar_dropdown)
                         ->click($this->_selector_profile_link)
-                        ->assertVisible($navbar_dropdown_selector)
-                        ->assertSeeIn($navbar_dropdown_selector, $this->_label_version)
-                        ->with($navbar_dropdown_selector, function($navbar_dropdown){
+                        ->pause(100)    // 0.1 seconds
+                        ->assertVisible($this->_selector_navbar_dropdown)
+                        ->with($this->_selector_navbar_dropdown, function(Browser $navbar_dropdown){
+                            $navbar_dropdown->assertSeeIn($this->_selector_navbar_version, $this->_label_version);
+                            $this->assertContains('has-text-info', $navbar_dropdown->attribute($this->_selector_navbar_version, 'class'));
                             $navbar_dropdown->assertSeeLink($this->_label_stats);
                             $navbar_dropdown->assertSeeLink($this->_label_settings);
                             $navbar_dropdown->assertSeeLink($this->_label_logout);
                         });
+                });
+        });
+    }
+
+    public function testBurgerMenuVisibleOnSmallerScreenWidth(){
+        $this->browse(function(Browser $browser){
+            $browser
+                ->resize(self::MOBILE_RESIZE_WIDTH_PX, self::RESIZE_HEIGHT_PX)
+                ->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->with($this->_selector_navbar, function(Browser $navbar){
+                    $navbar
+                        ->assertMissing('#profile-nav-link')
+                        ->assertMissing('.navbar-menu')
+                        ->assertMissing($this->_selector_navbar_dropdown)
+                        ->assertVisible('.navbar-burger')
+                        ->assertDontSee($this->_label_add_entry)
+                        ->assertDontSee($this->_label_transfer)
+                        ->assertDontSee($this->_label_filter)
+                        ->click('.navbar-burger')
+                        ->assertVisible('.navbar-menu')
+                        ->assertSee($this->_label_add_entry)
+                        ->assertSee($this->_label_transfer)
+                        ->assertSee($this->_label_filter)
+                        ->assertDontSee($this->_label_version)
+                        ->assertSeeLink($this->_label_stats)
+                        ->assertSeeLink($this->_label_settings)
+                        ->assertSeeLink($this->_label_logout);
                 });
         });
     }

--- a/tests/Browser/NotificationsTest.php
+++ b/tests/Browser/NotificationsTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Browser;
 
 use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Tests\Browser\Pages\HomePage;
 use Tests\DuskTestCase;
@@ -35,7 +34,6 @@ class NotificationsTest extends DuskTestCase {
 
     public function setUp(){
         parent::setUp();
-        Artisan::call('db:seed', ['--class'=>'UiSampleDatabaseSeeder']);
         $this->setDatabaseStateInjectionPermission(self::$ALLOW_INJECT_DATABASE_STATE_ON_EXCEPTION);
     }
 

--- a/tests/Browser/PaginationTest.php
+++ b/tests/Browser/PaginationTest.php
@@ -4,7 +4,6 @@ namespace Tests\Browser;
 
 use App\Entry;
 use App\Http\Controllers\Api\EntryController;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Tests\Browser\Pages\HomePage;
 use Tests\DuskTestCase;
@@ -24,11 +23,6 @@ class PaginationTest extends DuskTestCase {
     const ENTRY_COUNT_ONE = 10;     // number of entries needed to be generated for 1 page of results
     const ENTRY_COUNT_TWO = 40;     // number of entries needed to be generated for 2 pages of results
     const ENTRY_COUNT_THREE = 75;   // number of entries needed to be generated for 3 pages of results
-
-    public function setUp(){
-        parent::setUp();
-        Artisan::call('db:seed', ['--class'=>'UiSampleDatabaseSeeder']);
-    }
 
     public function testPaginationButtonsNotVisibleIfEntryCountLessThanPageMax(){
         DB::statement("TRUNCATE entries");

--- a/tests/Browser/PaginationTest.php
+++ b/tests/Browser/PaginationTest.php
@@ -20,12 +20,20 @@ class PaginationTest extends DuskTestCase {
     const PAGE_NUMBER_ONE = 1;
     const PAGE_NUMBER_TWO = 2;
 
-    const ENTRY_COUNT_ONE = 10;     // number of entries needed to be generated for 1 page of results
-    const ENTRY_COUNT_TWO = 40;     // number of entries needed to be generated for 2 pages of results
-    const ENTRY_COUNT_THREE = 75;   // number of entries needed to be generated for 3 pages of results
+    const ENTRY_COUNT_ONE = 10;                                                 // number of entries needed to be generated for 1 page of results
+    const ENTRY_COUNT_TWO = (EntryController::MAX_ENTRIES_IN_RESPONSE*2)-10;    // number of entries needed to be generated for 2 pages of results
+    const ENTRY_COUNT_THREE = (EntryController::MAX_ENTRIES_IN_RESPONSE*3)-25;  // number of entries needed to be generated for 3 pages of results
+
+    private $_account_types = [];
+
+    public function setUp(){
+        parent::setUp();
+        // clear the `entries` table, so we can test against an exact amount of entries.
+        DB::statement("TRUNCATE entries");
+        $this->_account_types = $this->getApiAccountTypes();
+    }
 
     public function testPaginationButtonsNotVisibleIfEntryCountLessThanPageMax(){
-        DB::statement("TRUNCATE entries");
         factory(Entry::class, self::ENTRY_COUNT_ONE)->create($this->entryOverrideAttributes());
         $entries = $this->getApiEntries();
         $this->assertLessThan(EntryController::MAX_ENTRIES_IN_RESPONSE, $entries['count']);
@@ -80,7 +88,6 @@ class PaginationTest extends DuskTestCase {
                 ->assertVisible($this->_selector_pagination_btn_prev)
                 ->assertMissing($this->_selector_pagination_btn_next);
             $this->assertEntriesDisplayed($browser, $entries_page2);
-
         });
     }
 
@@ -198,17 +205,19 @@ class PaginationTest extends DuskTestCase {
      * @param array $entries
      */
     private function assertEntriesDisplayed(Browser $browser, $entries){
-        foreach($entries as $entry){
-            $browser
-                ->assertSeeIn($this->_selector_table, $entry['entry_date'])
-                ->assertSeeIn($this->_selector_table, $entry['memo'])
-                ->assertSeeIn($this->_selector_table, $entry['entry_value']);
-        }
+        $browser->with($this->_selector_table_body, function(Browser $table) use ($entries){
+            foreach($entries as $entry){
+                $entry_row_selector = "#entry-".$entry['id'];
+                $table
+                    ->assertSeeIn($entry_row_selector.' '.$this->_selector_table_row_date, $entry['entry_date'])
+                    ->assertSeeIn($entry_row_selector.' '.$this->_selector_table_row_memo, $entry['memo'])
+                    ->assertSeeIn($entry_row_selector.' '.$this->_selector_table_row_value , $entry['entry_value']);
+            }
+        });
     }
 
     private function entryOverrideAttributes(){
-        $account_types = $this->getApiAccountTypes();
-        $account_type_id = collect($account_types)->pluck('id')->random(1)->first();
+        $account_type_id = collect($this->_account_types)->pluck('id')->random(1)->first();
         return ['disabled'=>0, 'account_type_id'=>$account_type_id];
     }
 

--- a/tests/Browser/PaginationTest.php
+++ b/tests/Browser/PaginationTest.php
@@ -17,9 +17,6 @@ class PaginationTest extends DuskTestCase {
     use DatabaseMigrations;
     use HomePageSelectors;
 
-    const RESIZE_WIDTH_PX = 1400;
-    const RESIZE_HEIGHT_PX = 2500;
-
     const PAGE_NUMBER_ZERO = 0;
     const PAGE_NUMBER_ONE = 1;
     const PAGE_NUMBER_TWO = 2;
@@ -43,7 +40,6 @@ class PaginationTest extends DuskTestCase {
             $browser
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
-                ->resize(self::RESIZE_WIDTH_PX, self::RESIZE_HEIGHT_PX)
                 ->assertMissing($this->_selector_pagination_btn_next)
                 ->assertMissing($this->_selector_pagination_btn_prev);
         });
@@ -58,7 +54,6 @@ class PaginationTest extends DuskTestCase {
             $browser
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
-                ->resize(self::RESIZE_WIDTH_PX, self::RESIZE_HEIGHT_PX)
                 ->assertMissing($this->_selector_pagination_btn_prev)
                 ->assertVisible($this->_selector_pagination_btn_next);
         });
@@ -78,7 +73,6 @@ class PaginationTest extends DuskTestCase {
             $browser
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
-                ->resize(self::RESIZE_WIDTH_PX, self::RESIZE_HEIGHT_PX)
                 ->assertVisible($this->_selector_pagination_btn_next)
                 ->click($this->_selector_pagination_btn_next)
                 ->waitForLoadingToStop()
@@ -106,7 +100,6 @@ class PaginationTest extends DuskTestCase {
             $browser
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
-                ->resize(self::RESIZE_WIDTH_PX, self::RESIZE_HEIGHT_PX)
                 ->assertVisible($this->_selector_pagination_btn_next);
 
             $this->assertEntriesDisplayed($browser, $entries);
@@ -130,7 +123,6 @@ class PaginationTest extends DuskTestCase {
             $browser
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
-                ->resize(self::RESIZE_WIDTH_PX, self::RESIZE_HEIGHT_PX)
                 ->click($this->_selector_pagination_btn_next)
                 ->waitForLoadingToStop();
 
@@ -178,7 +170,6 @@ class PaginationTest extends DuskTestCase {
             $browser
                 ->visit(new HomePage())
                 ->waitForLoadingToStop()
-                ->resize(self::RESIZE_WIDTH_PX, self::RESIZE_HEIGHT_PX)
                 ->click($this->_selector_pagination_btn_next)
                 ->waitForLoadingToStop();
 

--- a/tests/Browser/TransferModalTest.php
+++ b/tests/Browser/TransferModalTest.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\Api\EntryController;
 use Facebook\WebDriver\WebDriverBy;
 use Faker\Factory as FakerFactory;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Support\Facades\Artisan;
 use Tests\Browser\Pages\HomePage;
 use Tests\DuskTestCase;
 use Laravel\Dusk\Browser;
@@ -16,11 +15,6 @@ class TransferModalTest extends DuskTestCase {
 
     use DatabaseMigrations;
     use HomePageSelectors;
-
-    public function setUp(){
-        parent::setUp();
-        Artisan::call('db:seed', ['--class'=>'UiSampleDatabaseSeeder']);
-    }
 
     public function testTransferModalNotVisibleByDefault(){
         $this->browse(function(Browser $browser){

--- a/tests/Browser/TransferModalTest.php
+++ b/tests/Browser/TransferModalTest.php
@@ -511,21 +511,21 @@ class TransferModalTest extends DuskTestCase {
             $table_row_selector .= '.has-attachments';
         }
         $browser
-            ->with($table_row_selector, function($table_row) use ($transfer_entry_data, $entry_modal_date_input_value, $has_tags, $has_attachments){
+            ->with($table_row_selector, function(Browser $table_row) use ($transfer_entry_data, $entry_modal_date_input_value, $has_tags, $has_attachments){
                 $table_row
                     ->assertSeeIn($this->_selector_table_row_date, $entry_modal_date_input_value)
                     ->assertSeeIn($this->_selector_table_row_memo, $transfer_entry_data['memo'])
                     ->assertSeeIn($this->_selector_table_row_value, $transfer_entry_data['value'])
                     ->assertVisible($this->_selector_table_row_transfer_checkbox.' '.$this->_selector_table_is_checked_checkbox);
                 if($has_tags){
-                    $table_row->assertSee($transfer_entry_data['tag']);
+                    $table_row->assertSeeIn($this->_selector_table_row_tags, $transfer_entry_data['tag']);
                 }
                 if($has_attachments){
                     $table_row->assertVisible($this->_selector_table_row_attachment_checkbox.' '.$this->_selector_table_is_checked_checkbox);
                 }
             })
             ->openExistingEntryModal($table_row_selector)
-            ->with($this->_selector_modal_entry, function($modal) use ($transfer_entry_data, $entry_modal_date_input_value, $entry_switch_expense_label, $account_type_key, $has_tags, $has_attachments){
+            ->with($this->_selector_modal_entry, function(Browser $modal) use ($transfer_entry_data, $entry_modal_date_input_value, $entry_switch_expense_label, $account_type_key, $has_tags, $has_attachments){
                 $modal
                     ->assertInputValue($this->_selector_modal_entry_field_date, $entry_modal_date_input_value)
                     ->assertInputValue($this->_selector_modal_entry_field_value, $transfer_entry_data['value'])

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use App\Traits\Tests\StorageTestFiles;
+use Illuminate\Support\Facades\Artisan;
 use Laravel\Dusk\Browser;
 use Laravel\Dusk\TestCase as BaseTestCase;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
@@ -38,17 +39,33 @@ abstract class DuskTestCase extends BaseTestCase {
     }
 
     /**
-     * Sets the default browser width and height
-     *
      * @return void
      * @throws \Throwable
      */
     protected function setUp(){
+        parent::setUp();
+
+        $this->resizeBrowser();
+        $this->seedDatabase();
+    }
+
+    /**
+     * Sets the default browser width and height
+     *
+     * @throws \Throwable
+     */
+    protected function resizeBrowser(){
         $this->browse(function (Browser $browser){
             $browser->resize(self::RESIZE_WIDTH_PX, self::RESIZE_HEIGHT_PX);
         });
+    }
 
-        parent::setUp();
+    /**
+     * Seed the database by calling the artisan command:
+     *      artisan db:seed --class=UiSampleDatabaseSeeder
+     */
+    protected function seedDatabase(){
+        Artisan::call('db:seed', ['--class'=>'UiSampleDatabaseSeeder']);
     }
 
     /**

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -30,7 +30,7 @@ abstract class DuskTestCase extends BaseTestCase {
     /**
      * Create the RemoteWebDriver instance.
      *
-     * @return \Facebook\WebDriver\Remote\RemoteWebDriver
+     * @return RemoteWebDriver
      */
     protected function driver(){
         return RemoteWebDriver::create(

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use App\Traits\Tests\StorageTestFiles;
+use Laravel\Dusk\Browser;
 use Laravel\Dusk\TestCase as BaseTestCase;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
@@ -11,6 +12,9 @@ abstract class DuskTestCase extends BaseTestCase {
 
     use CreatesApplication;
     use StorageTestFiles;
+
+    const RESIZE_WIDTH_PX = 1400;
+    const RESIZE_HEIGHT_PX = 2500;
 
     /**
      * Prepare for Dusk test execution.
@@ -31,6 +35,20 @@ abstract class DuskTestCase extends BaseTestCase {
         return RemoteWebDriver::create(
              'http://selenium:4444/wd/hub', DesiredCapabilities::chrome(), 5000, 10000
         );
+    }
+
+    /**
+     * Sets the default browser width and height
+     *
+     * @return void
+     * @throws \Throwable
+     */
+    protected function setUp(){
+        $this->browse(function (Browser $browser){
+            $browser->resize(self::RESIZE_WIDTH_PX, self::RESIZE_HEIGHT_PX);
+        });
+
+        parent::setUp();
     }
 
     /**

--- a/tests/Traits/HomePageSelectors.php
+++ b/tests/Traits/HomePageSelectors.php
@@ -26,6 +26,16 @@ trait HomePageSelectors {
     private $_selector_modal_dropzone_error_message = ".dz-error-message";
     private $_selector_modal_dropzone_btn_remove = ".dz-remove";
 
+    // institutions panel
+    private $_selector_panel_institutions = "#institutions-panel-column";
+    private $_selector_panel_institutions_overview = "#overview";
+    private $_selector_panel_institutions_institution = ".institution-panel-institution";
+    private $_selector_panel_institutions_institution_open_close = ".institution-panel-institution-name span.panel-icon i";
+    private $_selector_panel_institutions_institution_name = ".institution-panel-institution-name span.name-label";
+    private $_selector_panel_institutions_accounts = ".institution-panel-institution-accounts";
+    private $_selector_panel_institutions_accounts_account = ".institutions-panel-account";
+    private $_selector_panel_institutions_accounts_account_name = ".institutions-panel-account-name";
+
     // entry-modal
     private $_selector_modal_entry = "@entry-modal";  // see Browser\Pages\HomePage.php
     private $_selector_modal_entry_btn_confirmed = "#entry-confirm";
@@ -148,6 +158,7 @@ trait HomePageSelectors {
     private $_color_filter_btn_tag_default = "#f5f5f5";
     private $_color_filter_btn_tag_active = "#209CEE";
 
+    private $_class_is_active = "is-active";
     private $_class_switch_core = ".v-switch-core";
     private $_class_icon_euro = "fa-euro-sign";
     private $_class_icon_dollar = "fa-dollar-sign";

--- a/tests/Traits/HomePageSelectors.php
+++ b/tests/Traits/HomePageSelectors.php
@@ -158,6 +158,8 @@ trait HomePageSelectors {
     private $_color_filter_btn_tag_default = "#f5f5f5";
     private $_color_filter_btn_tag_active = "#209CEE";
 
+    private $_class_is_income = "is-income";
+    private $_class_is_expense = "is-expense";
     private $_class_is_active = "is-active";
     private $_class_switch_core = ".v-switch-core";
     private $_class_icon_euro = "fa-euro-sign";

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -18,8 +18,6 @@ let webFontDirectory        = 'public/vue/webfonts';
 let resourceAssetsDirectory = 'resources/assets';
 
 mix.js('resources/assets/js/app.js', jsDirectory)
-    // bulma-accordion
-    .js(nodeDirectory+'/bulma-accordion/dist/bulma-accordion.min.js', jsDirectory+'/bulma-accordion.js')
     // dropzone
     .copy(nodeDirectory+'/vue2-dropzone/dist/vue2Dropzone.css', cssDirectory+'/vue-dropzone.css')
     // font-awesome


### PR DESCRIPTION
**Quality of Life Update:**
- Removed `bulma-accordion` node package. No longer using.
- Bumped `bulma` package version. Needed to for some features.
- Forced differing entry table row colors using `!important`.
- Replaced the `bulma-tooltip` with the `v-tooltip` package. Couldn't see the tooltip outside of the _Institutions Panel_ using the `bulma-tooltip` package.
- After a dev webpack build has completed, we display the current time.
- Heavily modified the existing _Institutions panel_.
  - Wrote appropriate tests.
- Entry table rows now have an id.
- Navbar is now fixed to top of page.
- There is a _burger menu_ button in the navbar that shows up on screens with a width < 1000px.
- Simplified laravel dusk test instructions within the `README.md`
- Now setting the default testing browser dimensions from within `tests\DuskTestCase::setUp()`.
- Browser resizing removed from `tests\Browser\PaginationTest` in favour of the default.
- Moved calling `artisan db:seed --class=UiSampleDatabaseSeeder` from the individual Dusk tests to the `Tests\DuskTestCase` class.
- Improved some other laravel dusk tests to correct some irregularities. This involved updating the testing database seeder.