### PR TITLE
support/hide-disabled-accounttypes-in-tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,15 +160,13 @@ cd money-tracker/
 
 # setup composer packages & environment variables
 composer install
+php artisan app:name "Money Tracker"
 php artisan app:version `git describe`
 
 # ***OPTIONAL***
 # If you're working with PhpStorm, be sure to run the following command.
 # It will generate Laravel Facades that PhpStorm can use.
 composer ide-helper
-
-# set the application version
-php artisan app:version `git describe`
 
 # construct the database tables
 php artisan migrate
@@ -199,6 +197,7 @@ cp .env.example .env
 sed "s/APP_ENV=.*/APP_ENV=production/" .env
 composer install --no-dev
 php artisan app:version $MOST_RECENT_TAG
+php artisan app:name "Money Tracker"
 php artisan migrate
 
 # setup Yarn packages
@@ -216,20 +215,28 @@ From time to time, there will be new updates released. Such updates will contain
 # put site into maintenance mode
 php artisan down
 
+# fetch newest version
 git fetch --tags
 MOST_RECENT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
 git checkout -q tags/$MOST_RECENT_TAG
 php artisan app:version $MOST_RECENT_TAG
 
+# Database updates
+# Note: check update release notes.
+php artisan migrate 
+
 # New/Updates to composer/yarn packages
 # Note: check update release notes. 
 composer update --no-dev
 yarn install --prod
+
+# Build website from *.vue files
 yarn run build-prod
 
-# Database updates
-# Note: check update release notes.
-php artisan migrate 
+# clear cache
+php artisan view:clear
+php artisan config:clear
+php artisan config:cache
 
 # take site out of maintenance mode
 php artisan up

--- a/docker/app.dockerfile
+++ b/docker/app.dockerfile
@@ -7,12 +7,12 @@ RUN touch /etc/apache2/conf-available/servername.conf \
 
 # install php extensions
 RUN apt-get update \
-	&& apt-get upgrade -y \
-	&& apt-get install -y libmcrypt-dev mysql-client zlib1g-dev libicu-dev g++ --no-install-recommends \
-	&& docker-php-ext-configure intl \
-    && docker-php-ext-install mcrypt pdo_mysql zip intl \
-	&& pecl install xdebug-2.5.5 \
-    && docker-php-ext-enable xdebug
+  && apt-get upgrade -y \
+  && apt-get install -y libmcrypt-dev mysql-client zlib1g-dev libicu-dev g++ --no-install-recommends \
+  && docker-php-ext-configure intl \
+  && docker-php-ext-install mcrypt pdo_mysql zip intl \
+  && pecl install xdebug-2.5.5 \
+  && docker-php-ext-enable xdebug
 
 # enable mod_rewrite apache module
 RUN a2enmod rewrite
@@ -26,29 +26,33 @@ ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
 ENV APACHE_DOCUMENT_ROOT /var/www/money-tracker/public
 RUN mkdir -p $APACHE_DOCUMENT_ROOT \
-	&& chown -R "$APACHE_RUN_USER:$APACHE_RUN_GROUP" "${APACHE_DOCUMENT_ROOT}"
+  && chown -R "$APACHE_RUN_USER:$APACHE_RUN_GROUP" "${APACHE_DOCUMENT_ROOT}"
 
 # alias for php artisan
 # allows us to call artisan without prefixing it with "php"
 RUN echo '#!/bin/bash\nphp /var/www/money-tracker/artisan "$@"' > /usr/local/bin/artisan \
-    && chmod +x /usr/local/bin/artisan
+  && chmod +x /usr/local/bin/artisan
 
 # select a php.ini config file; we use php.ini-development as it has "display_errors = On"
 RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini \
-	&& sed -i "s/;always_populate_raw_post_data = -1/always_populate_raw_post_data = -1/" $PHP_INI_DIR/php.ini
+  && sed -i "s/;always_populate_raw_post_data = -1/always_populate_raw_post_data = -1/" $PHP_INI_DIR/php.ini \
+  && sed -i "s/expose_php = On/expose_php = Off/" $PHP_INI_DIR/php.ini
+
+# set php error logging
+RUN echo 'error_log = /dev/stderr' >> $PHP_INI_DIR/conf.d/php-error_log.ini
 
 # set php timezone
-RUN echo 'date.timezone = "UTC"' >> $PHP_INI_DIR/conf.d/php-timezone.ini
+RUN echo 'date.timezone = "UTC"' >> $PHP_INI_DIR/conf.d/php-date.timezone.ini
 
 # override some xdebug settings
 RUN XDEBUG_INI=`php --ini | grep xdebug | tr -d ,` \
-	&& echo "" >> $XDEBUG_INI \
-	&& echo "xdebug.coverage_enable=1" >> $XDEBUG_INI \
-	&& echo "xdebug.idekey=DOCKER" >> $XDEBUG_INI \
-	&& echo "xdebug.remote_autostart=1" >> $XDEBUG_INI \
-	&& echo "xdebug.remote_enable=1" >> $XDEBUG_INI \
-	&& echo "xdebug.remote_host=dockerhost" >> $XDEBUG_INI \
-	&& echo "xdebug.remote_port=9000" >> $XDEBUG_INI
+  && echo "" >> $XDEBUG_INI \
+  && echo "xdebug.coverage_enable=1" >> $XDEBUG_INI \
+  && echo "xdebug.idekey=DOCKER" >> $XDEBUG_INI \
+  && echo "xdebug.remote_autostart=1" >> $XDEBUG_INI \
+  && echo "xdebug.remote_enable=1" >> $XDEBUG_INI \
+  && echo "xdebug.remote_host=dockerhost" >> $XDEBUG_INI \
+  && echo "xdebug.remote_port=9000" >> $XDEBUG_INI
 
 # allow external access to port 9000 for xdebug
 EXPOSE 9000

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build-dev": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js && echo 'process completed @ ' `date`",
     "build-dev-watch": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "build-prod": "cross-env NODE_ENV=production  node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "build-prod": "cross-env NODE_ENV=production  node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js && echo 'process completed @ ' `date`"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.2.0",

--- a/resources/assets/js/accounts.js
+++ b/resources/assets/js/accounts.js
@@ -42,9 +42,3 @@ export class Accounts extends ObjectBaseClass {
         });
     }
 }
-
-// var accounts = {
-//     display: function(){
-//         institutionsPane.displayAccounts();
-//     }
-// };

--- a/resources/assets/js/components/institutions-panel-institution-account.vue
+++ b/resources/assets/js/components/institutions-panel-institution-account.vue
@@ -66,7 +66,9 @@
             accountTypeTooltipList: function(){
                 let accountTypes = new Accounts().getAccountTypes(this.id);
                 let tooltipList = "";
-                accountTypes.forEach(function(accountType){
+                accountTypes.filter(function(accountType){
+                    return accountType.hasOwnProperty('disabled') && !accountType.disabled;
+                }).forEach(function(accountType){
                     tooltipList += "&bull; "+accountType.name+" ("+accountType.last_digits+")<br/>"
                 });
                 return tooltipList.trim();


### PR DESCRIPTION
- Fixed bug where `disabled` account-types were appearing within the institutions panel account tooltip.
- `yarn run build-prod` command now displays a "process completed @ " date statement
- set php.ini config `expose_php` to `off` 
- set php.ini config `error_log` to `/dev/stderr`
- Updated the _update production_ instructions in README.md