### PR TITLE
support/show-accounts-as-disabled-in-gui

### DIFF
--- a/database/seeds/UiSampleDatabaseSeeder.php
+++ b/database/seeds/UiSampleDatabaseSeeder.php
@@ -38,6 +38,11 @@ class UiSampleDatabaseSeeder extends Seeder {
             $accounts = $this->addAccountToCollection($accounts, ['institution_id'=>$institution_id, 'disabled'=>false]);
         }
         $accounts = $this->addAccountToCollection($accounts, ['institution_id'=>$faker->randomElement($institution_ids), 'disabled'=>true]);
+        // See resources/assets/js/currency.js for list of supported currencies
+        $accounts = $this->addAccountToCollection($accounts, ['institution_id'=>$faker->randomElement($institution_ids), 'currency'=>'USD']);
+        $accounts = $this->addAccountToCollection($accounts, ['institution_id'=>$faker->randomElement($institution_ids), 'currency'=>'CAD']);
+        $accounts = $this->addAccountToCollection($accounts, ['institution_id'=>$faker->randomElement($institution_ids), 'currency'=>'EUR']);
+        $accounts = $this->addAccountToCollection($accounts, ['institution_id'=>$faker->randomElement($institution_ids), 'currency'=>'GBP']);
         $this->command->line(self::OUTPUT_PREFIX."Accounts seeded");
 
         // ***** ACCOUNT-TYPES *****

--- a/resources/assets/js/components/entry-modal.vue
+++ b/resources/assets/js/components/entry-modal.vue
@@ -61,7 +61,7 @@
                                 ></option>
                             </select>
                         </div></div>
-                        <div class="help has-text-info" v-bind:class="{'is-hidden': !hasAccountTypeBeenSelected}">
+                        <div id="entry-account-type-meta" class="help" v-bind:class="{'is-hidden': !hasAccountTypeBeenSelected, 'has-text-info': isAccountEnabled, 'has-text-grey-light': !isAccountEnabled}">
                             <p>
                                 <span class="has-text-weight-semibold has-padding-right">Account Name:</span>
                                 <span id="entry-account-type-meta-account-name" v-text="accountTypeMeta.accountName"></span>
@@ -207,6 +207,7 @@
                     accountName: "",
                     currencyClass:"fa-dollar-sign",
                     lastDigits: "",
+                    isEnabled: true
                 },
 
                 isDeletable: false,
@@ -254,6 +255,9 @@
             },
             hasAccountTypeBeenSelected: function(){
                 return this.entryData.account_type_id !== '';
+            },
+            isAccountEnabled: function(){
+                return this.accountTypeMeta.isEnabled;
             },
             getAttachmentUploadUrl: function(){
                 return this.dropzoneOptions.url;
@@ -511,6 +515,7 @@
                 this.accountTypeMeta.accountName = account.name;
                 let accountType = this.accountTypesObject.find(this.entryData.account_type_id);
                 this.accountTypeMeta.lastDigits = accountType.last_digits;
+                this.accountTypeMeta.isEnabled = !accountType.disabled && !account.disabled;
 
                 switch(account.currency){
                     case this.currency.euro.label:

--- a/resources/assets/js/components/transfer-modal.vue
+++ b/resources/assets/js/components/transfer-modal.vue
@@ -47,7 +47,7 @@
                                 <option v-bind:value="accountTypeMeta.externalAccountTypeId">[External account]</option>
                             </select>
                         </div></div>
-                        <div class="help has-text-info" v-bind:class="{'is-hidden': !canShowFromAccountTypeMeta}">
+                        <div id="transfer-from-account-type-meta"  class="help" v-bind:class="{'is-hidden': !canShowFromAccountTypeMeta, 'has-text-info': isAccountFromEnabled, 'has-text-grey-light': !isAccountFromEnabled}">
                             <p>
                                 <span class="has-text-weight-semibold has-padding-right">Account Name:</span>
                                 <span id="from-account-type-meta-account-name" v-text="accountTypeMeta.from.accountName"></span>
@@ -79,7 +79,7 @@
                                 <option v-bind:value="accountTypeMeta.externalAccountTypeId">[External account]</option>
                             </select>
                         </div></div>
-                        <div class="help has-text-info" v-bind:class="{'is-hidden': !canShowToAccountTypeMeta}">
+                        <div id="transfer-to-account-type-meta" class="help" v-bind:class="{'is-hidden': !canShowToAccountTypeMeta, 'has-text-info': isAccountToEnabled, 'has-text-grey-light': !isAccountToEnabled}">
                             <p>
                                 <span class="has-text-weight-semibold has-padding-right">Account Name:</span>
                                 <span id="to-account-type-meta-account-name" v-text="accountTypeMeta.to.accountName"></span>
@@ -172,14 +172,17 @@
                     default: {
                         accountName: "",
                         lastDigits: "",
+                        isEnabled: true
                     },
                     from: {
                         accountName: "",
                         lastDigits: "",
+                        isEnabled: true
                     },
                     to: {
                         accountName: "",
                         lastDigits: "",
+                        isEnabled: true
                     },
                     externalAccountTypeId: 0
                 },
@@ -218,6 +221,12 @@
             },
             canShowToAccountTypeMeta: function(){
                 return this.canShowAccountTypeMeta(this.transferData.to_account_type_id);
+            },
+            isAccountToEnabled: function(){
+                return this.accountTypeMeta.to.isEnabled;
+            },
+            isAccountFromEnabled: function(){
+                return this.accountTypeMeta.from.isEnabled;
             },
             currentPage: function(){
                 return Store.getters.currentPage;
@@ -381,6 +390,7 @@
                 this.accountTypeMeta[accountTypeSelect].accountName = account.name;
                 let accountType = this.accountTypesObject.find(this.transferData[accountTypeSelect+'_account_type_id']);
                 this.accountTypeMeta[accountTypeSelect].lastDigits = accountType.last_digits;
+                this.accountTypeMeta[accountTypeSelect].isEnabled = !account.disabled && !accountType.disabled;
             },
             resetData: function(){
                 this.dropzoneRef.removeAllFiles();

--- a/tests/Traits/HomePageSelectors.php
+++ b/tests/Traits/HomePageSelectors.php
@@ -66,10 +66,12 @@ trait HomePageSelectors {
     private $_selector_modal_transfer_field_value = "input#transfer-value";
     private $_selector_modal_transfer_field_from = "select#from-account-type";
     private $_selector_modal_transfer_field_from_is_loading = ".select.is-loading select#from-account-type";
+    private $_selector_modal_transfer_meta_from = "#transfer-from-account-type-meta";
     private $_selector_modal_transfer_meta_account_name_from = "#from-account-type-meta-account-name";
     private $_selector_modal_transfer_meta_last_digits_from = "#from-account-type-meta-last-digits";
     private $_selector_modal_transfer_field_to = "select#to-account-type";
     private $_selector_modal_transfer_field_to_is_loading = ".select.is-loading select#to-account-type";
+    private $_selector_modal_transfer_meta_to = "#transfer-to-account-type-meta";
     private $_selector_modal_transfer_meta_account_name_to = "#to-account-type-meta-account-name";
     private $_selector_modal_transfer_meta_last_digits_to = "#to-account-type-meta-last-digits";
     private $_selector_modal_transfer_field_memo = "#transfer-memo";

--- a/tests/Traits/HomePageSelectors.php
+++ b/tests/Traits/HomePageSelectors.php
@@ -40,6 +40,7 @@ trait HomePageSelectors {
     private $_selector_modal_entry_field_value = "input#entry-value";
     private $_selector_modal_entry_field_account_type = "select#entry-account-type";
     private $_selector_modal_entry_field_account_type_is_loading = ".select.is-loading select#entry-account-type";
+    private $_selector_modal_entry_meta = "#entry-account-type-meta";
     private $_selector_modal_entry_field_memo = "textarea#entry-memo";
     private $_selector_modal_entry_field_expense = "#entry-expense";
     private $_selector_modal_entry_field_tags_container_is_loading = ".field:nth-child(6) .control.is-loading";


### PR DESCRIPTION
Corrected bug where disabled accounts or account-types were not showing in the GUI correctly (text colour) when they were selected in the _entry-modal_ and _transfer-modal_.

Resolves #193 