### PR TITLE
support/fix-account-total-updating

### DIFF
--- a/resources/assets/js/components/entries-table.vue
+++ b/resources/assets/js/components/entries-table.vue
@@ -15,7 +15,6 @@
                 </tr>
             </thead>
             <tbody>
-                <!-- TODO: update entry transfers are a thing -->
                 <entries-table-entry-row
                     v-for="entry in listOfEntries"
                     v-bind:key="entry.id"

--- a/resources/assets/js/components/entry-modal.vue
+++ b/resources/assets/js/components/entry-modal.vue
@@ -502,6 +502,7 @@
                         }
                         this.closeModal();
                         if(deleteResult.deleted){
+                            this.$eventHub.broadcast(this.$eventHub.EVENT_ACCOUNT_UPDATE);
                             this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_TABLE_UPDATE, this.currentPage);
                             // don't need to broadcast an event to hide the loading modal here
                             // already taken care of at the end of the entry-table update event process

--- a/resources/assets/js/components/transfer-modal.vue
+++ b/resources/assets/js/components/transfer-modal.vue
@@ -381,6 +381,7 @@
                             {type: notification.type, message: notification.message}
                         );
                     }
+                    this.$eventHub.broadcast(this.$eventHub.EVENT_ACCOUNT_UPDATE);
                     this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_TABLE_UPDATE, this.currentPage);
                     this.closeModal();
                 }.bind(this));

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -594,9 +594,9 @@ class EntryModalExistingEntryTest extends DuskTestCase {
 
                 ->with($this->_selector_modal_foot, function($modal_foot){
                     $modal_foot
-                            ->assertMissing($this->_selector_modal_entry_btn_delete)   // delete button
-                            ->assertMissing($this->_selector_modal_entry_btn_lock)     // lock/unlock button
-                            ->assertVisible($this->_selector_modal_entry_btn_save);    // save button
+                        ->assertMissing($this->_selector_modal_entry_btn_delete)   // delete button
+                        ->assertMissing($this->_selector_modal_entry_btn_lock)     // lock/unlock button
+                        ->assertVisible($this->_selector_modal_entry_btn_save);    // save button
                 })
                 ->assertEntryModalSaveButtonIsDisabled();
         });

--- a/tests/Browser/FilterModalTest.php
+++ b/tests/Browser/FilterModalTest.php
@@ -7,7 +7,6 @@ use App\AccountType;
 use Facebook\WebDriver\WebDriverBy;
 use Faker\Factory as FakerFactory;
 use Faker\Generator;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Tests\Browser\Pages\HomePage;
 use Tests\DuskTestCase;

--- a/tests/Browser/UpdateAccountTotalTest.php
+++ b/tests/Browser/UpdateAccountTotalTest.php
@@ -159,6 +159,34 @@ class UpdateAccountTotalTest extends DuskTestCase {
         });
     }
 
+    public function testOpenExistingEntryAndDeleteIt(){
+        $this->browse(function(Browser $browser){
+            $browser->visit(new HomePage())->waitForLoadingToStop();
+
+            // take note of account total
+            $this->assertAccountTotal($browser, $this->_institution_id, $this->_account['id'], $this->_account['total'], true);
+
+            // delete an existing entry
+            $entry = $this->getEntry();
+            $entry_selector = "#entry-".$entry['id'];
+
+            $browser
+                ->openExistingEntryModal($entry_selector)
+                ->with($this->_selector_modal_entry, function($entry_modal){
+                    $entry_modal
+                        ->assertVisible($this->_selector_modal_entry_btn_delete)
+                        ->click($this->_selector_modal_entry_btn_delete);
+                })
+                ->waitForLoadingToStop()
+                ->waitUntilMissing($this->_selector_modal_entry, HomePage::WAIT_SECONDS)
+            ;
+
+            // confirm account total updated
+            $new_account_total = $this->_account['total'] - ($entry['expense'] == 1 ?-1:1)*$entry['entry_value'];
+            $this->assertAccountTotal($browser, $this->_institution_id, $this->_account['id'], $new_account_total);
+        });
+    }
+
     /**
      * @param Browser $browser
      * @param int $institution_id

--- a/tests/Browser/UpdateAccountTotalTest.php
+++ b/tests/Browser/UpdateAccountTotalTest.php
@@ -16,7 +16,7 @@ use Tests\Traits\HomePageSelectors;
  *
  * @package Tests\Browser
  *
- * @group entry-modal
+ * @group navigation
  * @group modal
  * @group home
  */

--- a/tests/Browser/UpdateAccountTotalTest.php
+++ b/tests/Browser/UpdateAccountTotalTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Browser;
 
 use App\Entry;
+use App\Http\Controllers\Api\EntryController;
+use Faker\Factory as FakerFactory;
 use Tests\Browser\Pages\HomePage;
 use Tests\DuskTestCase;
 use Laravel\Dusk\Browser;
@@ -34,7 +36,7 @@ class UpdateAccountTotalTest extends DuskTestCase {
         $institutions_collection = collect($institutions);
         $this->_institution_id = $institutions_collection->where('active', true)->pluck('id')->random();
 
-        $account = $this->getAccount();
+        $account = $this->getAccount($this->_institution_id, true);
 
         $account_types = $this->getApiAccountTypes();
         $account_types_collection = collect($account_types);
@@ -103,7 +105,7 @@ class UpdateAccountTotalTest extends DuskTestCase {
             $this->assertAccountTotal($browser, $this->_institution_id, $this->_account['id'], $this->_account['total'], true);
 
             // update an existing entry
-            $entry = $this->getEntry();
+            $entry = $this->getEntry($this->_account_type_id);
             $entry_selector = "#entry-".$entry['id'];
 
             $switch_text = '';
@@ -136,7 +138,7 @@ class UpdateAccountTotalTest extends DuskTestCase {
             $this->assertAccountTotal($browser, $this->_institution_id, $this->_account['id'], $this->_account['total'], true);
 
             // update an existing entry
-            $entry = $this->getEntry();
+            $entry = $this->getEntry($this->_account_type_id);
             $entry_selector = "#entry-".$entry['id'];
 
             $new_value = 10.00;
@@ -167,7 +169,7 @@ class UpdateAccountTotalTest extends DuskTestCase {
             $this->assertAccountTotal($browser, $this->_institution_id, $this->_account['id'], $this->_account['total'], true);
 
             // delete an existing entry
-            $entry = $this->getEntry();
+            $entry = $this->getEntry($this->_account_type_id);
             $entry_selector = "#entry-".$entry['id'];
 
             $browser
@@ -184,6 +186,114 @@ class UpdateAccountTotalTest extends DuskTestCase {
             // confirm account total updated
             $new_account_total = $this->_account['total'] - ($entry['expense'] == 1 ?-1:1)*$entry['entry_value'];
             $this->assertAccountTotal($browser, $this->_institution_id, $this->_account['id'], $new_account_total);
+        });
+    }
+
+    public function providerUpdateAccountTotalsWithNewTransferEntries(){
+        return [
+            // [$is_from_account_external, $is_to_account_external]
+            'neither account is external'=>[false, false],
+            '"to" account is external'=>[false, true],
+            '"from" account is external'=>[true, false]
+            // there will NEVER be a [true, true] option. there can not be two "external" accounts
+        ];
+    }
+
+    /**
+     * @dataProvider providerUpdateAccountTotalsWithNewTransferEntries
+     * @param bool $is_from_account_external
+     * @param bool $is_to_account_external
+     *
+     * @throws \Throwable
+     */
+    public function testUpdateAccountTotalsWithNewTransferEntries($is_from_account_external, $is_to_account_external){
+        $account = [];
+        if(!$is_from_account_external && !$is_to_account_external){
+            $account['from'] = $this->_account;
+            $account['from']['account_type_id'] = $this->_account_type_id;
+
+            do{
+                $account_types = $this->getApiAccountTypes();
+                $account_types_collection = collect($account_types);
+                $account_type = $account_types_collection
+                    ->where('disabled', false)
+                    ->where('account_id','!=', $account['from']['id'])
+                    ->random();
+                $account['to'] = $this->getAccount($account_type['account_id']);
+            } while($account['to']['disabled']);
+            $account['to']['account_type_id'] = $account_type['id'];
+
+        } elseif($is_to_account_external){
+            $account['to']['id'] = 0;
+            $account['to']['account_type_id'] = EntryController::TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID;
+            $account['from'] = $this->_account;
+            $account['from']['account_type_id'] = $this->_account_type_id;
+        } elseif($is_from_account_external){
+            $account['from']['id'] = 0;
+            $account['from']['account_type_id'] = EntryController::TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID;
+            $account['to'] = $this->_account;
+            $account['to']['account_type_id'] = $this->_account_type_id;
+        }
+
+        $this->browse(function(Browser $browser) use ($is_from_account_external, $is_to_account_external, $account){
+            $browser->visit(new HomePage())->waitForLoadingToStop();
+
+            // take note of "to" account total
+            if(!$is_to_account_external){
+                $this->assertAccountTotal($browser, $account['to']['institution_id'], $account['to']['id'], $account['to']['total'], true);
+            }
+
+            // take note of the "from" account total
+            if(!$is_from_account_external){
+                if($is_to_account_external){
+                    $init_institution = true;
+                } elseif($account['to']['institution_id'] == $account['from']['institution_id']) {
+                    $init_institution = false;
+                } else {
+                    $init_institution = true;
+                }
+                $this->assertAccountTotal($browser, $account['from']['institution_id'], $account['from']['id'], $account['from']['total'], $init_institution);
+            }
+
+            // generate some test values
+            $faker = FakerFactory::create();
+            $transfer_entry_data = [
+                'memo'=>"Test transfer - save - ".$faker->uuid,
+                'value'=>$faker->randomFloat(2, 0, 100),
+                'from_account_type_id'=>($account['from']['account_type_id']),
+                'to_account_type_id'=>($account['to']['account_type_id']),
+            ];
+            // get locale date string from browser
+            $browser_locale_date = $browser->getBrowserLocaleDate();
+            $browser_locale_date_for_typing = $browser->processLocaleDateForTyping($browser_locale_date);
+
+            $browser->openTransferModal()
+                ->with($this->_selector_modal_transfer, function(Browser $modal) use ($transfer_entry_data, $browser_locale_date_for_typing){
+                    $modal
+                        ->type($this->_selector_modal_transfer_field_date, $browser_locale_date_for_typing)
+                        ->type($this->_selector_modal_transfer_field_value, $transfer_entry_data['value'])
+                        ->waitUntilMissing($this->_selector_modal_transfer_field_from_is_loading)
+                        ->select($this->_selector_modal_transfer_field_from, $transfer_entry_data['from_account_type_id'])
+                        ->waitUntilMissing($this->_selector_modal_transfer_field_to_is_loading)
+                        ->select($this->_selector_modal_transfer_field_to, $transfer_entry_data['to_account_type_id'])
+                        ->type($this->_selector_modal_transfer_field_memo, $transfer_entry_data['memo']);
+                })
+                ->with($this->_selector_modal_transfer, function(Browser $modal){
+                    $modal->click($this->_selector_modal_transfer_btn_save);
+                })
+                ->waitForLoadingToStop()
+                ->assertMissing($this->_selector_modal_transfer);
+
+            if(!$is_from_account_external){
+                // considered expense
+                $new_account_total = $account['from']['total']+(-1*$transfer_entry_data['value']);
+                $this->assertAccountTotal($browser, $account['from']['institution_id'], $account['from']['id'], $new_account_total);
+            }
+            if(!$is_to_account_external){
+                // considered income
+                $new_account_total = $account['to']['total']+(1*$transfer_entry_data['value']);
+                $this->assertAccountTotal($browser, $account['to']['institution_id'], $account['to']['id'], $new_account_total);
+            }
         });
     }
 
@@ -213,21 +323,30 @@ class UpdateAccountTotalTest extends DuskTestCase {
         });
     }
 
-    private function getAccount($id=null){
+    /**
+     * @param int $id
+     * @param bool $is_institution_id
+     * @return array
+     */
+    private function getAccount($id, $is_institution_id=false){
         $accounts = $this->getApiAccounts();
         $accounts_collection = collect($accounts);
-        if(is_null($id)){
-            return $accounts_collection->where('disabled', false)->where('institution_id', $this->_institution_id)->random();
+        if($is_institution_id){
+            return $accounts_collection->where('disabled', false)->where('institution_id', $id)->random();
         } else {
             return $accounts_collection->where('id', $id)->first();
         }
     }
 
-    private function getEntry(){
+    /**
+     * @param int $account_type_id
+     * @return array
+     */
+    private function getEntry($account_type_id){
         $entries = $this->getApiEntries();
         unset($entries['count']);
         $entries_collection = collect($entries);
-        return $entries_collection->where('account_type_id', $this->_account_type_id)->where('confirm', 0)->random();
+        return $entries_collection->where('account_type_id', $account_type_id)->where('confirm', 0)->random();
     }
 
 }


### PR DESCRIPTION
- Fixed a bug where deleting an entry didn't cause the account total to update.
- Fixed a bug where creating transfer entries cause the account total to not update in the GUI

Resolves #191 