### PR TITLE
feature/entry-modal-transfer-indicator

### DIFF
--- a/database/seeds/UiSampleDatabaseSeeder.php
+++ b/database/seeds/UiSampleDatabaseSeeder.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\EntryController;
 use Illuminate\Database\Seeder;
 
 class UiSampleDatabaseSeeder extends Seeder {
@@ -25,12 +26,12 @@ class UiSampleDatabaseSeeder extends Seeder {
         // ***** TAGS *****
         $tags = factory(App\Tag::class, self::COUNT_TAG)->create();
         $tag_ids = $tags->pluck('id')->toArray();
-        $this->command->line(self::OUTPUT_PREFIX."Tags seeded");
+        $this->command->line(self::OUTPUT_PREFIX."Tags seeded [".$tags->count()."]");
 
         // ***** INSTITUTIONS *****
         $institutions = factory(App\Institution::class, self::COUNT_INSTITUTION)->create(['active'=>1]);
         $institution_ids = $institutions->pluck('id')->toArray();
-        $this->command->line(self::OUTPUT_PREFIX."Institutions seeded");
+        $this->command->line(self::OUTPUT_PREFIX."Institutions seeded [".$institutions->count()."]");
 
         // ***** ACCOUNTS *****
         $accounts = collect();
@@ -43,7 +44,7 @@ class UiSampleDatabaseSeeder extends Seeder {
         $accounts = $this->addAccountToCollection($accounts, ['institution_id'=>$faker->randomElement($institution_ids), 'currency'=>'CAD']);
         $accounts = $this->addAccountToCollection($accounts, ['institution_id'=>$faker->randomElement($institution_ids), 'currency'=>'EUR']);
         $accounts = $this->addAccountToCollection($accounts, ['institution_id'=>$faker->randomElement($institution_ids), 'currency'=>'GBP']);
-        $this->command->line(self::OUTPUT_PREFIX."Accounts seeded");
+        $this->command->line(self::OUTPUT_PREFIX."Accounts seeded [".$accounts->count()."]");
 
         // ***** ACCOUNT-TYPES *****
         $account_types = collect();
@@ -52,7 +53,7 @@ class UiSampleDatabaseSeeder extends Seeder {
         }
         $account_types = $this->addAccountTypeToCollection($account_types, ['account_id'=>$accounts->where('disabled', false)->pluck('id')->random(), 'disabled'=>true], $faker);
         $account_types = $this->addAccountTypeToCollection($account_types, ['account_id'=>$accounts->where('disabled', true)->pluck('id')->random(), 'disabled'=>true], $faker);
-        $this->command->line(self::OUTPUT_PREFIX."Account-types seeded");
+        $this->command->line(self::OUTPUT_PREFIX."Account-types seeded [".$account_types->count()."]");
 
         // ***** ENTRIES *****
         $entries = collect();
@@ -60,7 +61,7 @@ class UiSampleDatabaseSeeder extends Seeder {
             $entries = $this->addEntryToCollection($entries, ['account_type_id'=>$account_type_id, 'disabled'=>false], $faker);
         }
         $entries = $this->addEntryToCollection($entries, ['account_type_id'=>$account_types->pluck('id')->random(), 'disabled'=>true], $faker);
-        $this->command->line(self::OUTPUT_PREFIX."Entries seeded");
+        $this->command->line(self::OUTPUT_PREFIX."Entries seeded [".$entries->count()."]");
 
         foreach($entries as $entry){
             if($faker->boolean){    // randomly assign tags to entries
@@ -72,8 +73,6 @@ class UiSampleDatabaseSeeder extends Seeder {
         $entries_not_disabled = $entries->where('disabled', 0);
         $entries_confirmed = $entries_not_disabled->where('confirm', 1);
         $entries_not_confirmed = $entries_not_disabled->where('confirm', 0);
-        $entry_income_ids = $entries_not_disabled->where('expense', 0)->pluck('id')->toArray();
-        $entry_expense_ids = $entries_not_disabled->where('expense', 1)->pluck('id')->toArray();
 
         // just in case we missed an entry necessary for testing, we're going to assign tags to random confirmed & unconfirmed entries
         $this->attachTagToEntry($faker, $tag_ids, $entries_not_confirmed->where('expense', 1)->random());
@@ -83,24 +82,30 @@ class UiSampleDatabaseSeeder extends Seeder {
         $this->command->line(self::OUTPUT_PREFIX."Randomly assigned tags to entries");
 
         // randomly select some entries and mark them as transfers
-        $transfer_to_entry_ids = $faker->randomElements($entry_income_ids, self::COUNT_ENTRY);
-        $transfer_from_entry_ids = $faker->randomElements($entry_expense_ids, self::COUNT_ENTRY);
+        $transfer_to_entries = $entries_not_disabled->where('expense', 0)->random(self::COUNT_ENTRY);
+        $transfer_from_entries = $entries_not_disabled->where('expense', 1)->random(self::COUNT_ENTRY);
         for($transfer_i=0; $transfer_i<self::COUNT_ENTRY; $transfer_i++){
-            $transfer_from_entry = $entries->where('id', $transfer_from_entry_ids[$transfer_i])->first();
-            $transfer_from_entry->transfer_entry_id = $transfer_to_entry_ids[$transfer_i];
+            $transfer_from_entry = $transfer_from_entries->get($transfer_i);
+            $transfer_to_entry = $transfer_to_entries->get($transfer_i);
+            $transfer_from_entry->transfer_entry_id = $transfer_to_entry->id;
             $transfer_from_entry->save();
-            $transfer_to_entry = $entries->where('id', $transfer_to_entry_ids[$transfer_i])->first();
-            $transfer_to_entry->transfer_entry_id = $transfer_from_entry_ids[$transfer_i];
+            $transfer_to_entry->transfer_entry_id = $transfer_from_entry->id;
             $transfer_to_entry->save();
         }
+        $external_transfer_entry = $entries_not_disabled->where('transfer_entry_id', null)
+            ->sortByDesc('entry_date')->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)[0]->random();
+        $external_transfer_entry->transfer_entry_id = EntryController::TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID;
+        $external_transfer_entry->save();
         $this->command->line(self::OUTPUT_PREFIX."Randomly marked entries as transfers");
 
         // assign attachments to entries. if entry is a "transfer", then add an attachment of the same name to its counterpart
         for($attachment_i=0; $attachment_i<self::COUNT_ATTACHMENT; $attachment_i++){
             // income entries
-            $this->assignAttachmentToEntry($faker, $entry_income_ids, $transfer_to_entry_ids, $entries);
+            $entry_income_ids = $entries_not_disabled->where('expense', 0)->pluck('id')->toArray();
+            $this->assignAttachmentToEntry($faker, $entry_income_ids, $transfer_to_entries->pluck('id')->toArray(), $entries);
             // expense entries
-            $this->assignAttachmentToEntry($faker, $entry_expense_ids, $transfer_from_entry_ids, $entries);
+            $entry_expense_ids = $entries_not_disabled->where('expense', 1)->pluck('id')->toArray();
+            $this->assignAttachmentToEntry($faker, $entry_expense_ids, $transfer_from_entries->pluck('id')->toArray(), $entries);
         }
         $this->command->line(self::OUTPUT_PREFIX."Randomly assigned Attachments to entries");
 
@@ -108,28 +113,28 @@ class UiSampleDatabaseSeeder extends Seeder {
         $this->assignAttachmentToEntry(
             $faker,
             $entries_confirmed->where('expense', 0)->pluck('id')->toArray(),
-            $transfer_to_entry_ids,
+            $transfer_to_entries->pluck('id')->toArray(),
             $entries
         );
         // income unconfirmed
         $this->assignAttachmentToEntry(
             $faker,
             $entries_not_confirmed->where('expense', 0)->pluck('id')->toArray(),
-            $transfer_to_entry_ids,
+            $transfer_to_entries->pluck('id')->toArray(),
             $entries
         );
         // expense confirmed
         $this->assignAttachmentToEntry(
             $faker,
             $entries_confirmed->where('expense', 1)->pluck('id')->toArray(),
-            $transfer_from_entry_ids,
+            $transfer_from_entries->pluck('id')->toArray(),
             $entries
         );
         // expense unconfirmed
         $this->assignAttachmentToEntry(
             $faker,
             $entries_not_confirmed->where('expense', 1)->pluck('id')->toArray(),
-            $transfer_from_entry_ids,
+            $transfer_from_entries->pluck('id')->toArray(),
             $entries
         );
         $this->command->line(self::OUTPUT_PREFIX."Assigned Attachments to all varieties of entries");

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -103,22 +103,23 @@ new Vue({
     computed:{
         keymap: function(){
             return {
+                // FIXME: hotkey already used for something else on windows
                 'ctrl+esc': function(){ // close modal
                     switch(Store.getters.currentModal){
                         case Store.getters.STORE_MODAL_ENTRY:
-                            console.log('entry:ctrl+esc');
+                            console.debug('entry:ctrl+esc');
                             this.$eventHub.broadcast(this.$eventHub.EVENT_ENTRY_MODAL_CLOSE);
                             break;
                         case Store.getters.STORE_MODAL_TRANSFER:
-                            console.log('transfer:ctrl+esc');
+                            console.debug('transfer:ctrl+esc');
                             this.$eventHub.broadcast(this.$eventHub.EVENT_TRANSFER_MODAL_CLOSE);
                             break;
                         case Store.getters.STORE_MODAL_FILTER:
-                            console.log('filter:ctrl+esc');
+                            console.debug('filter:ctrl+esc');
                             this.$eventHub.broadcast(this.$eventHub.EVENT_FILTER_MODAL_CLOSE);
                             break;
                         default:
-                            console.log("ctrl+esc");
+                            console.debug("ctrl+esc");
                     }
                 }.bind(this)
             };

--- a/resources/assets/js/components/entry-modal.vue
+++ b/resources/assets/js/components/entry-modal.vue
@@ -3,7 +3,15 @@
         <div class="modal-background"></div>
         <div class="modal-card">
             <header class="modal-card-head">
-                <p class="modal-card-title">Entry: <span v-if="entryData.id" v-text="entryData.id"></span><span v-else>new</span></p>
+                <p class="modal-card-title">
+                    Entry: <span v-if="entryData.id" v-text="entryData.id"></span><span v-else>new</span>
+                    <button type="button" id="entry-transfer-btn" class="button is-small is-outlined"
+                        v-if="isTransfer"
+                        v-on:click="primeDataForModal(entryData.transfer_entry_id)"
+                    >
+                        <span class="icon is-small"><i class="fas fa-exchange-alt"></i></span>
+                    </button>
+                </p>
                 <input type="hidden" name="entry-id" id="entry-id" v-model="entryData.id" />
 
                 <div class="control">
@@ -224,6 +232,7 @@
                     memo: "",
                     expense: true,
                     confirm: false,
+                    transfer_entry_id: null,
                     tags: [],
                     attachments: []
                 },
@@ -249,6 +258,9 @@
             },
             isConfirmed: function(){
                 return this.entryData.confirm && this.entryData.id;
+            },
+            isTransfer: function(){
+                return _.isNumber(this.entryData.transfer_entry_id);
             },
             areAccountTypesSet: function(){
                 return this.listAccountTypes.length > 0;

--- a/resources/assets/js/components/entry-modal.vue
+++ b/resources/assets/js/components/entry-modal.vue
@@ -7,6 +7,7 @@
                     Entry: <span v-if="entryData.id" v-text="entryData.id"></span><span v-else>new</span>
                     <button type="button" id="entry-transfer-btn" class="button is-small is-outlined"
                         v-if="isTransfer"
+                        v-bind:disabled="isExternalTransfer"
                         v-on:click="primeDataForModal(entryData.transfer_entry_id)"
                     >
                         <span class="icon is-small"><i class="fas fa-exchange-alt"></i></span>
@@ -261,6 +262,9 @@
             },
             isTransfer: function(){
                 return _.isNumber(this.entryData.transfer_entry_id);
+            },
+            isExternalTransfer: function(){
+                return _.isEqual(this.entryData.transfer_entry_id, 0);
             },
             areAccountTypesSet: function(){
                 return this.listAccountTypes.length > 0;

--- a/resources/assets/js/entries.js
+++ b/resources/assets/js/entries.js
@@ -32,7 +32,6 @@ export class Entries extends ObjectBaseClass {
         }
         requestParameters.sort = this.sort;
 
-        console.log("URL:"+this.uri+pageNumber+";\nfilter:"+JSON.stringify(requestParameters));
         return Axios.post(this.uri+pageNumber, requestParameters)
             .then(this.axiosSuccess.bind(this))
             .catch(this.axiosFailure.bind(this));
@@ -74,39 +73,6 @@ export class Entries extends ObjectBaseClass {
 }
 
 // var entries = {
-//     value: [],
-//     total: 0,
-
-//     display: function(){
-//         entries.clearDisplay();
-//         var isEntryInFuture = function(entryDate){
-//             var millisecondsPerMinute = 60000;
-//             var timezoneOffset = new Date().getTimezoneOffset()*millisecondsPerMinute;
-//             return Date.parse(entryDate)+timezoneOffset > Date.now();
-//         };
-//         $.each(entries.value, function(index, entryObject){
-//             entryObject.isEntryInFuture = isEntryInFuture(entryObject.entry_date);
-//             var displayTags = '';
-//             $.each(entryObject.tags, function(id, tagId){
-//                 displayTags += '<span class="label label-default entry-tag">'+tags.getNameById(tagId)+'</span>';
-//             });
-//             $('#entries-display-pane tbody').append(
-//                 '<tr class="'+(!entryObject.confirm ? 'warning' : (entryObject.expense ? '' : 'success'))+(entryObject.isEntryInFuture ? ' text-muted':'')+'">' +
-//                 '<td class="check-col" data-toggle="modal" data-target="#entry-modal" onclick="entry.load('+entryObject.id+');">' +
-//                 "\t"+'<span class="glyphicon glyphicon-pencil"></span>' +
-//                 '</td>' +
-//                 '<td>'+entryObject.entry_date+'</td>' +
-//                 '<td>'+entryObject.memo+'</td>' +
-//                 '<td class="value-col">'+(entryObject.expense ? '' : '$'+entryObject.entry_value)+'</td>' +
-//                 '<td class="value-col">'+(entryObject.expense ? '$'+entryObject.entry_value : '')+'</td>' +
-//                 '<td>'+accountTypes.getNameById(entryObject.account_type_id)+'</td>' +
-//                 '<td><span class="glyphicon glyphicon-'+(entryObject.has_attachments ? 'check' : 'unchecked')+'" aria-hidden="true"></span></td>' +
-//                 '<td>'+displayTags+'</td>' +
-//                 '</tr>'
-//             );
-//         });
-//     },
-
 //     ajaxCompleteProcessing: function(){
 //         $('.is-filtered').toggle(filterModal.active);
 //         entries.display();
@@ -114,5 +80,4 @@ export class Entries extends ObjectBaseClass {
 //         paginate.display.next(paginate.current < Math.ceil(entries.total/50)-1);
 //         loading.end();
 //     },
-
 // };

--- a/resources/assets/js/entry.js
+++ b/resources/assets/js/entry.js
@@ -67,7 +67,11 @@ export class Entry extends ObjectBaseClass {
             let entryIndex = entries.findIndex(function(entry){
                 return entry.id === newValue.id;
             });
-            entries[entryIndex] = newValue;
+            if(entryIndex !== -1){
+                entries[entryIndex] = newValue;
+            } else {
+                entries[newValue.id] = newValue;
+            }
             Store.dispatch('setStateOf', {type:this.storeType, value:entries});
         }
     }
@@ -152,20 +156,3 @@ export class Entry extends ObjectBaseClass {
     }
 
 }
-
-//     completeEntryUpdate: function(){
-//         // re-display institutes-pane contents
-//         institutionsPane.clear();
-//         institutionsPane.displayInstitutions();
-//         accounts.load();
-//         institutionsPane.displayAccountTypes();
-//
-//         var intervalSetAccountActive = setInterval(function(){
-//             // need to wait for the accounts to be re-displayed
-//             if(institutionsPane.accountsDisplayed){
-//                 var accountId = ($.isEmptyObject(paginate.filterState)) ? '' : paginate.filterState.account;
-//                 institutionsPane.setActiveState(accountId);
-//                 clearInterval(intervalSetAccountActive);    // stops interval from running again
-//             }
-//         }, 50);
-//     }

--- a/resources/assets/js/objectBaseClass.js
+++ b/resources/assets/js/objectBaseClass.js
@@ -9,7 +9,6 @@ export class ObjectBaseClass {
     }
 
     fetch(){
-        console.log(this.uri);
         return Axios.get(this.uri)
             .then(this.axiosSuccess.bind(this))
             .catch(this.axiosFailure.bind(this));

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -29,6 +29,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
     private $_class_white_text = "has-text-white";
     private $_class_light_grey_text = "has-text-grey-light";
     private $_class_has_attachments = "has-attachments";
+    private $_class_is_transfer = "is-transfer";
     private $_class_has_tags = "has-tags";
     private $_class_existing_attachment = "existing-attachment";
 
@@ -526,6 +527,84 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                 ->with($this->_selector_modal_body, function(Browser $modal_body) use ($selector_bool){
                     $entry_expense_switch_text = $modal_body->text($this->_selector_modal_entry_field_expense);
                     $this->assertEquals(($selector_bool?$this->_label_expense_switch_income:$this->_label_expense_switch_expense), $entry_expense_switch_text);
+                });
+        });
+    }
+
+    public function testExistingTransferEntryHasEntryButton(){
+        $this->browse(function(Browser $browser){
+            $entry_selector = $this->randomEntrySelector(['is_transfer'=>true]);
+
+            $entry_id = str_replace("#entry-", "", $entry_selector);
+            $entry_data = $this->getApiEntry($entry_id);
+            $transfer_entry_data = $this->getApiEntry($entry_data['transfer_entry_id']);
+            $this->assertEquals($entry_id, $entry_data['id']);
+            $this->assertEquals($entry_data['transfer_entry_id'], $transfer_entry_data['id']);
+            $this->assertEquals($transfer_entry_data['transfer_entry_id'], $entry_data['id']);
+            $entry_selector .= '.'.$this->_class_is_transfer;
+
+            $browser->visit(new HomePage())
+                ->waitForLoadingToStop()
+                ->openExistingEntryModal($entry_selector)
+                ->with($this->_selector_modal_entry, function(Browser $entry_modal) use ($entry_id){
+                    $entry_modal->with($this->_selector_modal_head, function(Browser $modal_head) use ($entry_id){
+                        $modal_entry_id = $modal_head->value($this->_selector_modal_entry_field_entry_id);
+                        $this->assertNotEmpty($modal_entry_id);
+                        $this->assertEquals($entry_id, $modal_entry_id);
+
+                        $modal_head
+                            ->assertVisible($this->_selector_modal_entry_btn_transfer)
+                            ->click($this->_selector_modal_entry_btn_transfer);
+                    });
+                })
+                ->waitForLoadingToStop()
+                ->assertVisible($this->_selector_modal_entry)
+                ->with($this->_selector_modal_entry, function(Browser $entry_modal) use ($transfer_entry_data){
+                    $entry_modal
+                        ->with($this->_selector_modal_body, function(Browser $modal_body) use ($transfer_entry_data){
+                            $expense_switch_label = $transfer_entry_data['expense'] ? $this->_label_expense_switch_expense : $this->_label_expense_switch_income;
+
+                            $modal_body
+                                ->assertInputValue($this->_selector_modal_entry_field_date, $transfer_entry_data['entry_date'])
+                                ->assertInputValue($this->_selector_modal_entry_field_value, $transfer_entry_data['entry_value'])
+                                ->assertSelected($this->_selector_modal_entry_field_account_type, $transfer_entry_data['account_type_id'])
+                                ->assertInputValue($this->_selector_modal_entry_field_memo, $transfer_entry_data['memo'])
+                                ->assertSeeIn($this->_selector_modal_entry_field_expense, $expense_switch_label);
+                        })
+                        ->with($this->_selector_modal_head, function(Browser $modal_head) use ($transfer_entry_data){
+                            $modal_entry_id = $modal_head->value($this->_selector_modal_entry_field_entry_id);
+                            $this->assertNotEmpty($modal_entry_id);
+                            $this->assertEquals($transfer_entry_data['id'], $modal_entry_id);
+
+                            $modal_head
+                                ->assertDontSee($this->_label_entry_new)
+                                ->assertVisible($this->_selector_modal_entry_btn_transfer)
+                                ->click($this->_selector_modal_entry_btn_transfer);
+                        });
+                })
+                ->waitForLoadingToStop()
+                ->assertVisible($this->_selector_modal_entry)
+                ->with($this->_selector_modal_entry, function(Browser $entry_modal) use ($entry_data){
+                    $entry_modal
+                        ->with($this->_selector_modal_body, function(Browser $modal_body) use ($entry_data){
+                            $expense_switch_label = $entry_data['expense'] ? $this->_label_expense_switch_expense : $this->_label_expense_switch_income;
+
+                            $modal_body
+                                ->assertInputValue($this->_selector_modal_entry_field_date, $entry_data['entry_date'])
+                                ->assertInputValue($this->_selector_modal_entry_field_value, $entry_data['entry_value'])
+                                ->assertSelected($this->_selector_modal_entry_field_account_type, $entry_data['account_type_id'])
+                                ->assertInputValue($this->_selector_modal_entry_field_memo, $entry_data['memo'])
+                                ->assertSeeIn($this->_selector_modal_entry_field_expense, $expense_switch_label);
+                        })
+                        ->with($this->_selector_modal_head, function(Browser $modal_head) use ($entry_data){
+                            $modal_entry_id = $modal_head->value($this->_selector_modal_entry_field_entry_id);
+                            $this->assertNotEmpty($modal_entry_id);
+                            $this->assertEquals($entry_data['id'], $modal_entry_id);
+
+                            $modal_head
+                                ->assertDontSee($this->_label_entry_new)
+                                ->assertVisible($this->_selector_modal_entry_btn_transfer);
+                        });
                 });
         });
     }

--- a/tests/Browser/EntryModalNewEntryTest.php
+++ b/tests/Browser/EntryModalNewEntryTest.php
@@ -434,15 +434,15 @@ class EntryModalNewEntryTest extends DuskTestCase {
                         ->assertVisible($this->_selector_modal_entry_field_upload)
                         ->attach($this->_selector_modal_entry_dropzone_hidden_file_input, $upload_file_path)
                         ->waitFor($this->_selector_modal_entry_dropzone_upload_thumbnail, HomePage::WAIT_SECONDS)
-                        ->with($this->_selector_modal_entry_dropzone_upload_thumbnail, function($upload_thumbnail) use ($upload_file_path){
+                        ->with($this->_selector_modal_entry_dropzone_upload_thumbnail, function(Browser $upload_thumbnail) use ($upload_file_path){
                             $upload_thumbnail
                                 ->waitUntilMissing($this->_selector_modal_dropzone_progress, HomePage::WAIT_SECONDS)
                                 ->assertMissing($this->_selector_modal_dropzone_error_mark)
                                 ->mouseover("") // hover over current element
-                                ->assertSee(basename($upload_file_path))
+                                ->assertSeeIn('.dz-filename', basename($upload_file_path))
                                 ->assertMissing($this->_selector_modal_dropzone_error_message)
                                 ->assertVisible($this->_selector_modal_dropzone_btn_remove)
-                                ->assertSee($this->_label_btn_dropzone_remove_file)
+                                ->assertSeeIn($this->_selector_modal_dropzone_btn_remove, $this->_label_btn_dropzone_remove_file)
                                 ->click($this->_selector_modal_dropzone_btn_remove);
                         })
                         ->assertMissing($this->_selector_modal_entry_dropzone_upload_thumbnail);

--- a/tests/Browser/EntryModalNewEntryTest.php
+++ b/tests/Browser/EntryModalNewEntryTest.php
@@ -439,7 +439,8 @@ class EntryModalNewEntryTest extends DuskTestCase {
                                 ->waitUntilMissing($this->_selector_modal_dropzone_progress, HomePage::WAIT_SECONDS)
                                 ->assertMissing($this->_selector_modal_dropzone_error_mark)
                                 ->mouseover("") // hover over current element
-                                ->assertSeeIn('.dz-filename', basename($upload_file_path))
+                                ->waitUntilMissing($this->_selector_modal_dropzone_success_mark, HomePage::WAIT_SECONDS)
+                                ->assertSeeIn($this->_selector_modal_dropzone_label_filename, basename($upload_file_path))
                                 ->assertMissing($this->_selector_modal_dropzone_error_message)
                                 ->assertVisible($this->_selector_modal_dropzone_btn_remove)
                                 ->assertSeeIn($this->_selector_modal_dropzone_btn_remove, $this->_label_btn_dropzone_remove_file)

--- a/tests/Traits/HomePageSelectors.php
+++ b/tests/Traits/HomePageSelectors.php
@@ -36,6 +36,7 @@ trait HomePageSelectors {
     private $_selector_modal_entry = "@entry-modal";  // see Browser\Pages\HomePage.php
     private $_selector_modal_entry_btn_confirmed = "#entry-confirm";
     private $_selector_modal_entry_btn_confirmed_label = "#entry-confirm + label";
+    private $_selector_modal_entry_btn_transfer = "#entry-transfer-btn";
     private $_selector_modal_entry_field_entry_id = "#entry-id";
     private $_selector_modal_entry_field_date="input#entry-date";
     private $_selector_modal_entry_field_value = "input#entry-value";

--- a/tests/Traits/HomePageSelectors.php
+++ b/tests/Traits/HomePageSelectors.php
@@ -19,6 +19,7 @@ trait HomePageSelectors {
     private $_selector_modal_dropzone_progress = ".dz-progress";
     private $_selector_modal_dropzone_error_mark = ".dz-error-mark";
     private $_selector_modal_dropzone_error_message = ".dz-error-message";
+    private $_selector_modal_dropzone_label_filename = '.dz-filename';
     private $_selector_modal_dropzone_btn_remove = ".dz-remove";
 
     // institutions panel

--- a/tests/Traits/HomePageSelectors.php
+++ b/tests/Traits/HomePageSelectors.php
@@ -18,6 +18,7 @@ trait HomePageSelectors {
     private $_selector_modal_dropzone_upload_thumbnail = ".dz-complete:last-child";
     private $_selector_modal_dropzone_progress = ".dz-progress";
     private $_selector_modal_dropzone_error_mark = ".dz-error-mark";
+    private $_selector_modal_dropzone_success_mark = ".dz-success-mark";
     private $_selector_modal_dropzone_error_message = ".dz-error-message";
     private $_selector_modal_dropzone_label_filename = '.dz-filename';
     private $_selector_modal_dropzone_btn_remove = ".dz-remove";


### PR DESCRIPTION
- Corrected bug in test where attachment filename was **NOT** asserting visible (even if it was visible).
- Added a button to the entry-modal to indicate that an entry is a transfer entry and allow the user to switch to the corresponding transfer entry.

Resolves #192 