### PR TITLE
support/database-seeder-improvements

### DIFF
--- a/app/Traits/Tests/InjectDatabaseStateIntoException.php
+++ b/app/Traits/Tests/InjectDatabaseStateIntoException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Traits;
+namespace App\Traits\Tests;
 
 use App\Account;
 use App\AccountType;

--- a/database/seeds/UiSampleDatabaseSeeder.php
+++ b/database/seeds/UiSampleDatabaseSeeder.php
@@ -116,29 +116,37 @@ class UiSampleDatabaseSeeder extends Seeder {
 
         // income confirmed
         $this->assignAttachmentToEntry(
-            $entries_confirmed->where('expense', 0)->pluck('id')
-                ->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)->shift()->random(),
+            $entries_confirmed
+                ->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)->shift()
+                ->where('expense', 0)->pluck('id')
+                ->random(),
             $transfer_to_entries->pluck('id')->toArray(),
             $entries
         );
         // income unconfirmed
         $this->assignAttachmentToEntry(
-            $entries_not_confirmed->where('expense', 0)->pluck('id')
-                ->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)->shift()->random(),
+            $entries_not_confirmed
+                ->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)->shift()
+                ->where('expense', 0)->pluck('id')
+                ->random(),
             $transfer_to_entries->pluck('id')->toArray(),
             $entries
         );
         // expense confirmed
         $this->assignAttachmentToEntry(
-            $entries_confirmed->where('expense', 1)->pluck('id')
-                ->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)->shift()->random(),
+            $entries_confirmed
+                ->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)->shift()
+                ->where('expense', 1)->pluck('id')
+                ->random(),
             $transfer_from_entries->pluck('id')->toArray(),
             $entries
         );
         // expense unconfirmed
         $this->assignAttachmentToEntry(
-            $entries_not_confirmed->where('expense', 1)->pluck('id')
-                ->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)->shift()->random(),
+            $entries_not_confirmed
+                ->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)->shift()
+                ->where('expense', 1)->pluck('id')
+                ->random(),
             $transfer_from_entries->pluck('id')->toArray(),
             $entries
         );

--- a/database/seeds/UiSampleDatabaseSeeder.php
+++ b/database/seeds/UiSampleDatabaseSeeder.php
@@ -94,6 +94,7 @@ class UiSampleDatabaseSeeder extends Seeder {
             $transfer_from_entry->transfer_entry_id = $transfer_to_entry->id;
             $transfer_from_entry->save();
             $transfer_to_entry->transfer_entry_id = $transfer_from_entry->id;
+            $transfer_to_entry->entry_value = $transfer_from_entry->entry_value;
             $transfer_to_entry->save();
         }
         $external_transfer_entry = $entries_not_disabled->where('transfer_entry_id', null)

--- a/tests/Browser/NotificationsTest.php
+++ b/tests/Browser/NotificationsTest.php
@@ -340,6 +340,9 @@ class NotificationsTest extends DuskTestCase {
     /**
      * @dataProvider providerNotificationSaveExistingEntry4XX
      *
+     * @param int $http_status
+     * @param string $error_response_message
+     *
      * @throws \Throwable
      *
      * @group notifications-1

--- a/tests/Browser/NotificationsTest.php
+++ b/tests/Browser/NotificationsTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\DB;
 use Tests\Browser\Pages\HomePage;
 use Tests\DuskWithMigrationsTestCase as DuskTestCase;
 use Laravel\Dusk\Browser;
-use Tests\Traits\InjectDatabaseStateIntoException;
+use App\Traits\Tests\InjectDatabaseStateIntoException;
 
 /**
  * Class NotificationsTest

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use App\Traits\Tests\LogTestName;
 use App\Traits\Tests\StorageTestFiles;
 use Laravel\Dusk\Browser;
 use Laravel\Dusk\TestCase as BaseTestCase;
@@ -13,7 +12,6 @@ abstract class DuskTestCase extends BaseTestCase {
 
     use CreatesApplication;
     use StorageTestFiles;
-    use LogTestName;
 
     const RESIZE_WIDTH_PX = 1400;
     const RESIZE_HEIGHT_PX = 2500;
@@ -68,7 +66,11 @@ abstract class DuskTestCase extends BaseTestCase {
     protected function setUpTraits(){
         $uses = array_flip(class_uses_recursive(static::class));
 
-        if (isset($uses[LogTestName::class])){
+        if(isset($uses[\Tests\Traits\InjectDatabaseStateIntoException::class])){
+            $this->prepareFailureExceptionForDatabaseInjection();
+        }
+
+        if (isset($uses[\App\Traits\Tests\LogTestName::class])){
             $this->runTestNameLogging($this->getName());
         }
 

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -66,7 +66,7 @@ abstract class DuskTestCase extends BaseTestCase {
     protected function setUpTraits(){
         $uses = array_flip(class_uses_recursive(static::class));
 
-        if(isset($uses[\Tests\Traits\InjectDatabaseStateIntoException::class])){
+        if(isset($uses[\App\Traits\Tests\InjectDatabaseStateIntoException::class])){
             $this->prepareFailureExceptionForDatabaseInjection();
         }
 

--- a/tests/Feature/Api/Delete/DeleteAccountTypeTest.php
+++ b/tests/Feature/Api/Delete/DeleteAccountTypeTest.php
@@ -4,12 +4,15 @@ namespace Tests\Feature\Api;
 
 use App\Account;
 use App\AccountType;
+use App\Traits\Tests\InjectDatabaseStateIntoException;
 use Faker\Factory as FakerFactory;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 
 class DeleteAccountTypeTest extends TestCase {
+
+    use InjectDatabaseStateIntoException;
 
     private $_disable_account_type_uri = '/api/account-type/';
     private $_get_account_uri = '/api/account/';

--- a/tests/Feature/Api/Post/PostEntriesTest.php
+++ b/tests/Feature/Api/Post/PostEntriesTest.php
@@ -6,9 +6,12 @@ use App\AccountType;
 use App\Entry;
 use App\Tag;
 use App\Http\Controllers\Api\EntryController;
+use App\Traits\Tests\InjectDatabaseStateIntoException;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 
 class PostEntriesTest extends ListEntriesBase {
+
+    use InjectDatabaseStateIntoException;
 
     public function setUp(){
         parent::setUp();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\Traits\InjectDatabaseStateIntoException;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Foundation\Testing\TestResponse;
 use Illuminate\Http\Response;
@@ -13,14 +12,8 @@ abstract class TestCase extends BaseTestCase {
 
     use CreatesApplication;
     use RefreshDatabase;
-    use InjectDatabaseStateIntoException;
-
-    private $_database_state = '';
 
     public function tearDown(){
-        if($this->isDatabaseStateInjectionAllowed()){
-            $this->_database_state = $this->getDatabaseState();
-        }
         $this->truncateDatabaseTables();
         parent::tearDown();
     }
@@ -81,18 +74,6 @@ abstract class TestCase extends BaseTestCase {
             }
             DB::table($table)->truncate();
         }
-    }
-
-    /**
-     * @param \Exception|\Throwable $unsuccessful_test_exception
-     * @throws \Exception
-     * @throws \Throwable
-     */
-    public function onNotSuccessfulTest($unsuccessful_test_exception){
-        $exception_message_to_inject = "Database state on failure:\n".$this->_database_state;
-        $unsuccessful_test_exception = $this->injectMessageIntoException($unsuccessful_test_exception, $exception_message_to_inject);
-
-        parent::onNotSuccessfulTest($unsuccessful_test_exception); // this needs to occur at the end of the method, or things won't get output.
     }
 
 }

--- a/tests/Unit/InjectDatabaseStateIntoExceptionTest.php
+++ b/tests/Unit/InjectDatabaseStateIntoExceptionTest.php
@@ -8,11 +8,12 @@
 
 namespace Tests\Unit;
 
+use App\Traits\Tests\InjectDatabaseStateIntoException;
 use Tests\TestCase;
 
 class InjectDatabaseStateIntoExceptionTest extends TestCase {
 
-    // NOTE: InjectDatabaseStateIntoException trait has already been included by the TestCase class
+    use InjectDatabaseStateIntoException;
 
     public function testSettingValidInjectionPermission(){
         $current_state = $this->isDatabaseStateInjectionAllowed();


### PR DESCRIPTION
- When seeding transfer entries, we now make sure that `entry_values` are the same.
- Seeding entries with attachments is now applied to the first 50 _non-disabled_ entries instead of the first 50 _non-disabled expense_ entries.
- Migrated code related to the `InjectDatabaseStateIntoException` trait out of `tests\Browser\DuskTestCase.php` and `tests\Browser\TestCase.php`.
- Moved the `InjectDatabaseStateIntoException` trait.
