### PR TITLE
feature/sanity-check-account-total-by-id

### DIFF
--- a/.docker/app.dockerfile
+++ b/.docker/app.dockerfile
@@ -33,7 +33,6 @@ RUN echo '#!/bin/bash\nphp /var/www/money-tracker/artisan "$@"' > /usr/local/bin
 
 # select a php.ini config file; we use php.ini-development as it has "display_errors = On"
 RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini \
-  && sed -i "s/;always_populate_raw_post_data = -1/always_populate_raw_post_data = -1/" $PHP_INI_DIR/php.ini \
   && sed -i "s/expose_php = On/expose_php = Off/" $PHP_INI_DIR/php.ini
 
 # set php error logging

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 APP_ENV=local
+APP_NAME="Money Tracker"
 APP_KEY=
 APP_DEBUG=true
 APP_LOG_LEVEL=debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,8 +99,7 @@ jobs:
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-get
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-post
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-delete
-    - install: cp .env.docker .env # only doing this here so `artisan app:version` tests don't fail`
-      script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite console
+    - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite console
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite web
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite unit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-get
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-post
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-delete
-    - before_script: cp .env.docker .env # only doing this here so `artisan app:version` tests don't fail`
+    - install: cp .env.docker .env # only doing this here so `artisan app:version` tests don't fail`
       script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite console
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite web
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,8 @@ jobs:
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-get
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-post
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-delete
-    - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite console
+    - before_script: cp .env.docker .env # only doing this here so `artisan app:version` tests don't fail`
+      script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite console
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite web
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite unit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,8 +99,9 @@ jobs:
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-get
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-post
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-delete
-    - install: cp. .env.docker .env
-      script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite console
+    - script:
+        - .docker/cmd/artisan config:clear # artisan app:version testing doesn't work well when configs have been cached
+        - docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite console
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite web
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite unit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ jobs:
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-post
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-delete
     - script:
-        - .docker/cmd/artisan config:clear # artisan app:version testing doesn't work well when configs have been cached
+        - .docker/cmd/artisan.sh config:clear # artisan app:version testing doesn't work well when configs have been cached
         - docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite console
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite web
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ before_script:
   # general application setup
   - .docker/cmd/artisan.sh key:generate
   - .docker/cmd/artisan.sh app:version `git describe`
-  - .docker/cmd/artisan.sh config:clear
   - .docker/cmd/artisan.sh cache:clear
   - .docker/cmd/artisan.sh view:clear
+  - .docker/cmd/artisan.sh config:cache
   - .docker/cmd/artisan.sh travis-ci --display-env
   - docker container exec -t app.money-tracker env
   # setup laravel log files

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,8 @@ jobs:
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-get
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-post
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite api-delete
-    - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite console
+    - install: cp. .env.docker .env
+      script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite console
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite web
     - script: docker container exec -t app.money-tracker vendor/bin/phpunit --testsuite unit
 

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--network-timout 600000

--- a/app/Console/Commands/AppVersion.php
+++ b/app/Console/Commands/AppVersion.php
@@ -34,40 +34,55 @@ class AppVersion extends Command {
      * @return mixed
      */
     public function handle(){
-        // make sure .env file exists
-        $dot_env_file_path = app()->environmentFilePath();
-        if(!File::exists($dot_env_file_path)){
-            $this->error(app()->environmentFile()." file does not exist.\nPlease create one before trying again.");
+        if(!$this->environmentFileExists()){
+            $this->error(basename($this->getEnvironmentFilePath())." file does not exist.\nPlease create one before trying again.");
             return;
         }
 
-        $version = $this->argument(self::ARG_NAME);
-        if(empty($version)){
+        $new_version = $this->argument(self::ARG_NAME);
+        if(empty($new_version)){
             $current_version = config(self::CONFIG_PARAM);  // getting config value from memory
             $current_version = empty($current_version) ? 'NOT YET SET' : $current_version;
             $this->info(sprintf(self::INFO_STRING_GET_VERSION, $current_version));
             return;
         }
 
-        $this->writeNewEnvironmentFileWith($dot_env_file_path, $version);
-        config([self::CONFIG_PARAM=>$version]);  // setting the config value in memory
-        $this->info(sprintf(self::INFO_STRING_SET_VERSION, $version));
+        $this->writeNewEnvironmentFileWith($new_version);
+        config([self::CONFIG_PARAM=>$new_version]);  // setting the config value in memory
+        $this->info(sprintf(self::INFO_STRING_SET_VERSION, $new_version));
         return;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getEnvironmentFilePath(){
+        return $this->laravel->environmentFilePath();
+    }
+
+    /**
+     * Makes sure that the (provided) environment file exists
+     *
+     * @param string $env_file_path
+     * @return bool
+     */
+    protected function environmentFileExists(){
+        return File::exists($this->getEnvironmentFilePath());
     }
 
     /**
      * Write a new environment file with the given key.
      *     Taken & modified from Illuminate\Foundation\Console\KeyGenerateCommand
      *
-     * @param string   $dot_env_file_path
-     * @param  string  $version
+     * @param string  $version
      * @return void
      */
-    protected function writeNewEnvironmentFileWith($dot_env_file_path, $version){
-        file_put_contents($dot_env_file_path, preg_replace(
+    protected function writeNewEnvironmentFileWith($version){
+        $env_file_path = $this->getEnvironmentFilePath();
+        file_put_contents($env_file_path, preg_replace(
             $this->versionReplacementPattern(),
             self::ENV_PARAM.'='.$version,
-            file_get_contents($dot_env_file_path)
+            file_get_contents($env_file_path)
         ));
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,10 +21,6 @@ class AppServiceProvider extends ServiceProvider {
      * @return void
      */
     public function register(){
-        // IDE Helper
-        if ($this->app->environment() !== 'production') {
-            $this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
-            $this->app->register(DuskServiceProvider::class);
-        }
+
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,6 +21,9 @@ class AppServiceProvider extends ServiceProvider {
      * @return void
      */
     public function register(){
-
+        if ($this->app->environment() !== 'production') {
+            // This still needs to be registered because laravel/dusk is not permitted to be discovered via composer
+            $this->app->register(DuskServiceProvider::class);
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     },
     "repositories": [{
         "type": "vcs",
-        "url": "https://github.com/eklundkristoffer/laravel-discord-webhook"
+        "url": "https://github.com/jdenoc/laravel-discord-webhook"
     }],
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -38,10 +38,8 @@
         }
     },
     "scripts": {
-        "post-root-package-install": [
-            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
-        ],
-        "post-create-project-cmd": [
+        "post-update-cmd": [
+            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\"",
             "@php artisan key:generate"
         ],
         "post-autoload-dump": [

--- a/tests/Feature/Console/AccountTotalSanityCheckTest.php
+++ b/tests/Feature/Console/AccountTotalSanityCheckTest.php
@@ -72,4 +72,23 @@ class AccountTotalSanityCheckTest extends TestCase {
         $this->assertContains(sprintf("Account %d not found", $account_id), $result_as_text);
     }
 
+    public function testSanityCheckIndividualAccountIdZeroNotFoundOutputtingToScreenAndWithoutNotifyingDiscord(){
+        Artisan::call("db:seed", ['--class'=>'UiSampleDatabaseSeeder']);
+        DB::statement("TRUNCATE accounts");
+
+        $account_id = 0;
+        Artisan::call($this->_command, array_merge(['accountId'=>$account_id], $this->_screen_only_notification_options));
+        $result_as_text = trim(Artisan::output());
+        $this->assertContains(sprintf("Account %d not found", $account_id), $result_as_text);
+    }
+
+    public function testSanityCheckAccountsNotFoundOutputtingToScreenAndWithoutNotifyingDiscord(){
+        Artisan::call("db:seed", ['--class'=>'UiSampleDatabaseSeeder']);
+        DB::statement("TRUNCATE accounts");
+
+        Artisan::call($this->_command, $this->_screen_only_notification_options);
+        $result_as_text = trim(Artisan::output());
+        $this->assertContains("No accounts found", $result_as_text);
+    }
+
 }

--- a/tests/Feature/Console/AccountTotalSanityCheckTest.php
+++ b/tests/Feature/Console/AccountTotalSanityCheckTest.php
@@ -66,7 +66,7 @@ class AccountTotalSanityCheckTest extends TestCase {
         Artisan::call("db:seed", ['--class'=>'UiSampleDatabaseSeeder']);
         DB::statement("TRUNCATE accounts");
 
-        $account_id = $this->faker->randomNumber(1);
+        $account_id = $this->faker->randomDigitNotNull;
         Artisan::call($this->_command, array_merge(['accountId'=>$account_id], $this->_screen_only_notification_options));
         $result_as_text = trim(Artisan::output());
         $this->assertContains(sprintf("Account %d not found", $account_id), $result_as_text);

--- a/tests/Feature/Console/AccountTotalSanityCheckTest.php
+++ b/tests/Feature/Console/AccountTotalSanityCheckTest.php
@@ -57,7 +57,6 @@ class AccountTotalSanityCheckTest extends TestCase {
             });
         $account->update(['total'=>$new_total]);
 
-//        Artisan::call($this->_command, ['accountId'=>$account->id, '--notify-screen'=>true, '--dont-notify-discord'=>true]);
         Artisan::call($this->_command, array_merge(['accountId'=>$account->id], $this->_screen_only_notification_options));
         $result_as_text = trim(Artisan::output());
         $this->assertContains(sprintf("Checking account ID:%d\n\tOK", $account->id), $result_as_text);

--- a/tests/Feature/Console/AccountTotalSanityCheckTest.php
+++ b/tests/Feature/Console/AccountTotalSanityCheckTest.php
@@ -2,19 +2,75 @@
 
 namespace Tests\Feature\Console;
 
+use App\Account;
+use App\AccountType;
+use App\Entry;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 use Illuminate\Support\Facades\Artisan;
 
-class AccountTotalSanityCheckTest extends TestCase{
+class AccountTotalSanityCheckTest extends TestCase {
+
+    use WithFaker;
 
     private $_command = 'sanity-check:account-total';
+    private $_screen_only_notification_options = ['--notify-screen'=>true, '--dont-notify-discord'=>true];
 
     public function testForceFailureOutputtingToScreenAndWithoutNotifyingDiscord(){
-        Artisan::call($this->_command, ['--force-failure'=>true, '--notify-screen'=>true, '--dont-notify-discord'=>true]);
-        
+        Artisan::call($this->_command, array_merge(['--force-failure'=>true], $this->_screen_only_notification_options));
+
         $result_as_text = trim(Artisan::output());
         $this->assertContains("Forcing Failure", $result_as_text);
         $this->assertContains("Sanity check has failed", $result_as_text);
+    }
+
+    public function testSanityCheckOutputtingToScreenAndWithoutNotifyingDiscord(){
+        $accounts = factory(Account::class, 3)->create(['disabled'=>true, 'total'=>0]);
+        $account_types = collect();
+        foreach($accounts as $account){
+            $account_type = factory(AccountType::class)->create(['account_id'=>$account->id, 'disabled'=>0]);
+            factory(Entry::class, 2)->create(['account_type_id'=>$account_type->id, 'disabled'=>0]);
+            $account_types->push($account_type);
+        }
+
+        Artisan::call($this->_command, $this->_screen_only_notification_options);
+        $result_as_text = trim(Artisan::output());
+        foreach($accounts as $account){
+            $this->assertContains(sprintf("Checking account ID:%d\n\tOK", $account->id), $result_as_text);
+        }
+    }
+
+    public function testSanityCheckIndividualAccountIdOutputtingToScreenAndWithoutNotifyingDiscord(){
+        Artisan::call("db:seed", ['--class'=>'UiSampleDatabaseSeeder']);
+
+        DB::statement("TRUNCATE entries");
+        $accounts = Account::where('disabled', 0);
+        $accounts->update(['total'=>0]);
+        $account = $accounts->get()->random();
+        $account_type = AccountType::where(['account_id'=>$account->id, 'disabled'=>0])->get()->random();
+        $entries = factory(Entry::class, 10)->create(['account_type_id'=>$account_type->id, 'disabled'=>0]);
+
+        $new_total = $entries->where('disabled', 0)
+            ->sum(function($entry){
+                return ($entry['expense'] ? -1 : 1) * $entry['entry_value'];
+            });
+        $account->update(['total'=>$new_total]);
+
+//        Artisan::call($this->_command, ['accountId'=>$account->id, '--notify-screen'=>true, '--dont-notify-discord'=>true]);
+        Artisan::call($this->_command, array_merge(['accountId'=>$account->id], $this->_screen_only_notification_options));
+        $result_as_text = trim(Artisan::output());
+        $this->assertContains(sprintf("Checking account ID:%d\n\tOK", $account->id), $result_as_text);
+    }
+
+    public function testSanityCheckIndividualAccountIdNotFoundOutputtingToScreenAndWithoutNotifyingDiscord(){
+        Artisan::call("db:seed", ['--class'=>'UiSampleDatabaseSeeder']);
+        DB::statement("TRUNCATE accounts");
+
+        $account_id = $this->faker->randomNumber(1);
+        Artisan::call($this->_command, array_merge(['accountId'=>$account_id], $this->_screen_only_notification_options));
+        $result_as_text = trim(Artisan::output());
+        $this->assertContains(sprintf("Account %d not found", $account_id), $result_as_text);
     }
 
 }


### PR DESCRIPTION
- Added functionality to the `artisan sanity-check:account-total` that allows it to accept an integer as an _account ID_ and allows the user to perf
- Re-adding `.yarnrc`. Needed for working around timeouts that yarn may have on certain systems.
- Removed modification of `always_populate_raw_post_data` from the `app.dockerfile` setup.
- Added `APP_NAME` to `.env.example`
- Updated documentation
- Removing registration of _non-production_ services. Laravel 5.5 does this with an artisan command during setup.
- Modified `composer.json` so that on `update` or `install` we create a `.env` file if it doesn't exist and generate an _application key_.

Resolves #227 