### PR TITLE
support/entries.disabled_stamp-not-updating

### DIFF
--- a/app/Entry.php
+++ b/app/Entry.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use App\Http\Controllers\Api\EntryController;
+use Carbon\Carbon;
 
 class Entry extends BaseModel {
 
@@ -80,6 +81,12 @@ class Entry extends BaseModel {
             $this->account_type()->first()->account()->first()->update_total($actual_entry_value);
         }
         return $saved_entry;
+    }
+
+    public function disable(){
+        $this->disabled = true;
+        $this->disabled_stamp = new Carbon();
+        $this->save();
     }
 
     public static function get_entry_with_tags_and_attachments($entry_id){

--- a/app/Http/Controllers/Api/EntryController.php
+++ b/app/Http/Controllers/Api/EntryController.php
@@ -116,8 +116,7 @@ class EntryController extends Controller {
         if(empty($entry)){
             return response('', HttpStatus::HTTP_NOT_FOUND);
         } else {
-            $entry->disabled = true;
-            $entry->save();
+            $entry->disable();
             return response('', HttpStatus::HTTP_NO_CONTENT);
         }
     }

--- a/tests/Feature/Api/Delete/DeleteEntryTest.php
+++ b/tests/Feature/Api/Delete/DeleteEntryTest.php
@@ -5,12 +5,15 @@ namespace Tests\Feature\Api;
 use App\Account;
 use App\AccountType;
 use App\Entry;
-use Faker\Factory as FakerFactory;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\WithFaker;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 
 class DeleteEntryTest extends TestCase {
+
+    use WithFaker;
 
     private $_base_uri = '/api/entry/';
 
@@ -33,12 +36,21 @@ class DeleteEntryTest extends TestCase {
         $this->assertEmpty($delete_response->getContent());
         $this->assertTrue(is_array($get_response2->json()));
         $this->assertEmpty($get_response2->json());
+
+        // confirm disabled_stamp and modified_stamp have been updated
+        $newly_disabled_entry = Entry::find($entry->id);
+        $this->assertTrue($newly_disabled_entry->disabled);
+        $this->assertNotEmpty($newly_disabled_entry->disabled_stamp);
+        $this->assertDateFormat($newly_disabled_entry->disabled_stamp, Carbon::ATOM, $newly_disabled_entry->disabled_stamp. "does not match format ".Carbon::ATOM);
+        $this->assertNotEmpty($entry->modified_stamp);
+        $this->assertNotEmpty($newly_disabled_entry->modified_stamp);
+        $this->assertDateFormat($newly_disabled_entry->modified_stamp, Carbon::ATOM, $newly_disabled_entry->modfied_stamp. "does not match format ".Carbon::ATOM);
+        $this->assertNotEquals($entry->modified_stamp, $newly_disabled_entry->modfied_stamp);
     }
 
     public function testMarkingEntryDeletedWhenEntryDoesNotExist(){
-        $faker = FakerFactory::create();
         // GIVEN
-        $entry_id = $faker->randomNumber();
+        $entry_id = $this->faker->randomNumber();
 
         // WHEN
         $get_response = $this->get($this->_base_uri.$entry_id);

--- a/tests/Feature/Api/ListEntriesBase.php
+++ b/tests/Feature/Api/ListEntriesBase.php
@@ -9,7 +9,7 @@ use App\Tag;
 use Carbon\Carbon;
 use Faker\Factory as FakerFactory;
 use Faker\Generator;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Tests\TestCase;
 
@@ -53,12 +53,16 @@ class ListEntriesBase extends TestCase {
      * @param bool $entry_disabled
      * @param array $override_entry_components
      * @return Entry
+     * @throws \Exception
      */
     protected function generate_entry_record($account_type_id, $entry_disabled, $override_entry_components=[]){
         $default_entry_data = ['account_type_id'=>$account_type_id, 'disabled'=>$entry_disabled];
         $new_entry_data = array_merge($default_entry_data, $override_entry_components);
         unset($new_entry_data['tags']);
         unset($new_entry_data['has_attachments']);
+        if($new_entry_data['disabled']){
+            $new_entry_data['disabled_stamp'] = new Carbon();
+        }
         $generated_entry = factory(Entry::class)->create($new_entry_data);
 
         if(!$entry_disabled){    // no sense cluttering up the database with test data for something that isn't supposed to appear anyway
@@ -94,6 +98,7 @@ class ListEntriesBase extends TestCase {
      * @param bool $randomly_mark_entries_disabled
      * @param bool $mark_entries_disabled
      * @return Collection
+     * @throws \Exception
      */
     protected function batch_generate_entries($generate_entry_count, $generated_account_type_id, $filter_details=[], $randomly_mark_entries_disabled=false, $mark_entries_disabled=false){
         $generated_entries = collect();


### PR DESCRIPTION
Modified code to update the `entries.disabled_stamp` when marking an entry _disabled_.

Resolves #230 