### PR TITLE
support/gather-all-stats-data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ git:
 
 # trusty instance & sudo are needed so we can utilise docker
 dist: trusty
-sudo: required
 
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -334,3 +334,4 @@ php artisan dusk --stop-on-failure
 - [Laravel Dusk](https://laravel.com/docs/5.5/dusk)
 - [Travis CI](https://docs.travis-ci.com/user/languages/php/)
 - [git](https://git-scm.com/doc)
+- [ChartJs](https://www.chartjs.org/)

--- a/app/Entry.php
+++ b/app/Entry.php
@@ -185,7 +185,7 @@ class Entry extends BaseModel {
                     // RIGHT JOIN entry_tags
                     //   ON entry_tags.entry_id=entries.id
                     //   AND entry_tags.tag_id IN ($tags)
-                    $tag_ids = (is_array($filters[$filter_name])) ? $filter_constraint : [$filter_constraint];
+                    $tag_ids = (is_array($filter_constraint)) ? $filter_constraint : [$filter_constraint];
                     $entries_query->rightJoin('entry_tags', function($join) use ($tag_ids){
                         $join->on('entry_tags.entry_id', '=', 'entries.id')
                             ->whereIn('entry_tags.tag_id', $tag_ids);

--- a/app/Traits/Tests/Dusk/AccountOrAccountTypeTogglingSelector.php
+++ b/app/Traits/Tests/Dusk/AccountOrAccountTypeTogglingSelector.php
@@ -116,10 +116,9 @@ trait AccountOrAccountTypeTogglingSelector {
     /**
      * @param Browser $browser
      * @param string|int $selector_value
-     * @param string $selector_option
      */
-    public function selectAccountOrAccountTypeValue(Browser $browser, $selector_value, $selector_option=''){
-        $browser->with($this->getAccountOrAccountTypeTogglingSelectorComponentId($this->_id_label), function(Browser $component) use ($selector_value, $selector_option){
+    public function selectAccountOrAccountTypeValue(Browser $browser, $selector_value){
+        $browser->with($this->getAccountOrAccountTypeTogglingSelectorComponentId($this->_id_label), function(Browser $component) use ($selector_value){
             $component
                 // make sure accounts have finished loading
                 ->waitUntilMissing(self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT_LOADING, self::$WAIT_SECONDS)

--- a/app/Traits/Tests/Dusk/BatchFilterEntries.php
+++ b/app/Traits/Tests/Dusk/BatchFilterEntries.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Traits\Tests\Dusk;
+
+use App\Http\Controllers\Api\EntryController;
+use Illuminate\Support\Collection;
+
+trait BatchFilterEntries {
+
+    /**
+     * @param string $start_date
+     * @param string $end_date
+     * @param int|string $account_or_account_type_id
+     * @param bool $is_switch_toggled
+     * @param Collection|null $tags
+     * @return Collection
+     */
+    private function getBatchedFilteredEntries($start_date, $end_date, $account_or_account_type_id, $is_switch_toggled, $tags=null){
+        $filter_data = [
+            EntryController::FILTER_KEY_START_DATE=>$start_date,
+            EntryController::FILTER_KEY_END_DATE=>$end_date,
+        ];
+
+        if(!empty($account_or_account_type_id)){
+            if($is_switch_toggled){
+                $filter_data[EntryController::FILTER_KEY_ACCOUNT_TYPE] = $account_or_account_type_id;
+            } else {
+                $filter_data[EntryController::FILTER_KEY_ACCOUNT] = $account_or_account_type_id;
+            }
+        }
+
+        if(!is_null($tags)){
+            $filter_data[EntryController::FILTER_KEY_TAGS] = $tags->pluck('id')->toArray();
+        }
+
+        $entries = $this->getApiEntries(0, $filter_data);
+        if(empty($entries)){
+            throw new \UnexpectedValueException("Entries not available with filter ".print_r($filter_data, true));
+        }
+
+        $total_pages = intval( ceil($entries['count']/EntryController::MAX_ENTRIES_IN_RESPONSE) );
+        $entries_collection = collect($this->removeCountFromApiResponse($entries));
+
+        for($i=1; $i<$total_pages; $i++){
+            $entries_collection = $entries_collection->merge(collect($this->removeCountFromApiResponse($this->getApiEntries($i, $filter_data))));
+        }
+        $this->assertCount($entries['count'], $entries_collection);
+
+        return $entries_collection;
+    }
+
+}

--- a/app/Traits/Tests/Dusk/Navbar.php
+++ b/app/Traits/Tests/Dusk/Navbar.php
@@ -23,8 +23,6 @@ trait Navbar {
     private static $SELECTOR_MODAL_TRANSFER = '#transfer-modal';
     private static $SELECTOR_MODAL_FILTER = '#filter-modal';
 
-//_selector_navbar_entry_modal
-
     /**
      * @param Browser $navbar
      */

--- a/app/Traits/Tests/Dusk/StatsSidePanel.php
+++ b/app/Traits/Tests/Dusk/StatsSidePanel.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Traits\Tests\Dusk;
+
+use Laravel\Dusk\Browser;
+
+trait StatsSidePanel {
+
+    private static $SELECTOR_STATS_SIDE_PANEL = ".panel";
+    private static $SELECTOR_STATS_SIDE_PANEL_HEADING = '.panel-heading:first-child';
+    private static $SELECTOR_STATS_SIDE_PANEL_OPTION_SUMMARY = ".panel-heading+.panel-block";
+    private static $SELECTOR_STATS_SIDE_PANEL_OPTION_TRENDING = ".panel-block:nth-child(3)";
+    private static $SELECTOR_STATS_SIDE_PANEL_OPTION_TAGS = ".panel-block:nth-child(4)";
+    private static $SELECTOR_STATS_SIDE_PANEL_ACTIVE_OPTION = ".panel-block.is-active";
+
+    private static $LABEL_STATS_SIDE_PANEL_HEADING = "Stats";
+    private static $LABEL_STATS_SIDE_PANEL_OPTION_SUMMARY = "Summary";
+    private static $LABEL_STATS_SIDE_PANEL_OPTION_TRENDING = "Trending";
+    private static $LABEL_STATS_SIDE_PANEL_OPTION_TAGS = "Tags";
+
+    public function assertStatsSidePanelHeading(Browser $browser){
+        $browser
+            ->with(self::$SELECTOR_STATS_SIDE_PANEL, function(Browser $side_panel){
+                $side_panel
+                    ->assertVisible(self::$SELECTOR_STATS_SIDE_PANEL_HEADING)
+                    ->assertSeeIn(self::$SELECTOR_STATS_SIDE_PANEL_HEADING, self::$LABEL_STATS_SIDE_PANEL_HEADING);
+            });
+    }
+
+    public function clickStatsSidePanelOptionSummary(Browser $browser){
+        $this->clickStatsSidePanelOption($browser, self::$SELECTOR_STATS_SIDE_PANEL_OPTION_SUMMARY);
+    }
+
+    public function clickStatsSidePanelOptionTrending(Browser $browser){
+        $this->clickStatsSidePanelOption($browser, self::$SELECTOR_STATS_SIDE_PANEL_OPTION_TRENDING);
+    }
+
+    public function clickStatsSidePanelOptionTags(Browser $browser){
+        $this->clickStatsSidePanelOption($browser, self::$SELECTOR_STATS_SIDE_PANEL_OPTION_TAGS);
+    }
+
+    private function clickStatsSidePanelOption(Browser $browser, $option_selector){
+        $browser
+            ->with(self::$SELECTOR_STATS_SIDE_PANEL, function(Browser $side_panel) use ($option_selector){
+                $side_panel->click($option_selector);
+            });
+    }
+
+    public function assertStatsSidePanelOptionIsActive(Browser $browser, $label){
+        if(!in_array($label, $this->statsSidePanelOptionLabels())){
+            throw new \InvalidArgumentException("Label '".$label."' provided is not a valid stats side panel option");
+        }
+        
+        $browser
+            ->with(self::$SELECTOR_STATS_SIDE_PANEL, function(Browser $side_panel) use ($label){
+                $side_panel->assertSeeIn(self::$SELECTOR_STATS_SIDE_PANEL_ACTIVE_OPTION, $label);
+            });
+    }
+
+    /**
+     * @return array
+     */
+    private function statsSidePanelOptionLabels(){
+        return [
+            self::$LABEL_STATS_SIDE_PANEL_OPTION_SUMMARY,
+            self::$LABEL_STATS_SIDE_PANEL_OPTION_TRENDING,
+            self::$LABEL_STATS_SIDE_PANEL_OPTION_TAGS
+        ];
+    }
+
+}

--- a/database/seeds/UiSampleDatabaseSeeder.php
+++ b/database/seeds/UiSampleDatabaseSeeder.php
@@ -18,7 +18,7 @@ class UiSampleDatabaseSeeder extends Seeder {
     const COUNT_ENTRY = 5;
     const COUNT_INSTITUTION = 2;
     const COUNT_MIN = 1;
-    const COUNT_TAG = 5;
+    const COUNT_TAG = 10;
 
     const YEAR_IN_DAYS = 365;
 
@@ -91,8 +91,6 @@ class UiSampleDatabaseSeeder extends Seeder {
         $this->attachTagToEntry($tag_ids, $entries_not_confirmed->where('expense', 0)->random());
         $this->attachTagToEntry($tag_ids, $entries_confirmed->where('expense', 1)->random());
         $this->attachTagToEntry($tag_ids, $entries_confirmed->where('expense', 0)->random());
-        // to extra safe, we're assigning all the tags to the most recent entry
-        $this->attachTagToEntry($tag_ids, $entries_not_disabled->sortByDesc('entry_date')->first(), true);
         $this->command->line(self::OUTPUT_PREFIX."Randomly assigned tags to entries");
 
         // randomly select some entries and mark them as transfers
@@ -211,7 +209,7 @@ class UiSampleDatabaseSeeder extends Seeder {
         if($attach_all){
             $entry_tag_ids = $tag_ids;
         } else {
-            $entry_tag_ids = $this->faker->randomElements($tag_ids, $this->faker->numberBetween(self::COUNT_MIN, self::COUNT_TAG));
+            $entry_tag_ids = $this->faker->randomElements($tag_ids, $this->faker->numberBetween(self::COUNT_MIN, self::COUNT_TAG/2));
         }
         $entry->tags()->attach($entry_tag_ids);
     }

--- a/database/seeds/UiSampleDatabaseSeeder.php
+++ b/database/seeds/UiSampleDatabaseSeeder.php
@@ -105,8 +105,12 @@ class UiSampleDatabaseSeeder extends Seeder {
             $transfer_to_entry->entry_value = $transfer_from_entry->entry_value;
             $transfer_to_entry->save();
         }
-        $external_transfer_entry = $entries_not_disabled->where('transfer_entry_id', null)
-            ->sortByDesc('entry_date')->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)[0]->random();
+        $external_transfer_entry = $entries_not_disabled
+            ->sortByDesc('entry_date')
+            ->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)
+            ->first()
+            ->where('transfer_entry_id', null)
+            ->random();
         $external_transfer_entry->transfer_entry_id = EntryController::TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID;
         $external_transfer_entry->save();
         $this->command->line(self::OUTPUT_PREFIX."Randomly marked entries as transfers");

--- a/database/seeds/UiSampleDatabaseSeeder.php
+++ b/database/seeds/UiSampleDatabaseSeeder.php
@@ -91,6 +91,8 @@ class UiSampleDatabaseSeeder extends Seeder {
         $this->attachTagToEntry($tag_ids, $entries_not_confirmed->where('expense', 0)->random());
         $this->attachTagToEntry($tag_ids, $entries_confirmed->where('expense', 1)->random());
         $this->attachTagToEntry($tag_ids, $entries_confirmed->where('expense', 0)->random());
+        // to extra safe, we're assigning all the tags to the most recent entry
+        $this->attachTagToEntry($tag_ids, $entries_not_disabled->sortByDesc('entry_date')->first(), true);
         $this->command->line(self::OUTPUT_PREFIX."Randomly assigned tags to entries");
 
         // randomly select some entries and mark them as transfers
@@ -203,9 +205,14 @@ class UiSampleDatabaseSeeder extends Seeder {
     /**
      * @param int[] $tag_ids
      * @param App\Entry $entry
+     * @param bool $attach_all
      */
-    private function attachTagToEntry($tag_ids, $entry){
-        $entry_tag_ids = $this->faker->randomElements($tag_ids, $this->faker->numberBetween(self::COUNT_MIN, self::COUNT_TAG));
+    private function attachTagToEntry($tag_ids, $entry, $attach_all=false){
+        if($attach_all){
+            $entry_tag_ids = $tag_ids;
+        } else {
+            $entry_tag_ids = $this->faker->randomElements($tag_ids, $this->faker->numberBetween(self::COUNT_MIN, self::COUNT_TAG));
+        }
         $entry->tags()->attach($entry_tag_ids);
     }
 

--- a/resources/assets/js/components/stats/stats-nav.vue
+++ b/resources/assets/js/components/stats/stats-nav.vue
@@ -36,15 +36,15 @@
         mixins: [statsNavMixin],
         methods:{
             showSummaryChart: function(){
-                this.makeChartVisible('summary');
+                this.makeChartVisible(this.chartNameSummary);
                 this.$eventHub.broadcast(this.$eventHub.EVENT_STATS_SUMMARY);
             },
             showTrendingChart: function(){
-                this.makeChartVisible('trending');
+                this.makeChartVisible(this.chartNameTrending);
                 this.$eventHub.broadcast(this.$eventHub.EVENT_STATS_TRENDING);
             },
             showTagsChart: function(){
-                this.makeChartVisible('tags');
+                this.makeChartVisible(this.chartNameTags);
                 this.$eventHub.broadcast(this.$eventHub.EVENT_STATS_TAGS);
             },
         },

--- a/resources/assets/js/components/stats/stats.vue
+++ b/resources/assets/js/components/stats/stats.vue
@@ -18,13 +18,13 @@
         components: {SummaryChart, TagsChart, TrendingChart},
         created: function(){
             this.$eventHub.listen(this.$eventHub.EVENT_STATS_SUMMARY, function(){
-                this.makeChartVisible('summary');
+                this.makeChartVisible(this.chartNameSummary);
             }.bind(this));
             this.$eventHub.listen(this.$eventHub.EVENT_STATS_TRENDING, function(){
-                this.makeChartVisible('trending');
+                this.makeChartVisible(this.chartNameTrending);
             }.bind(this));
             this.$eventHub.listen(this.$eventHub.EVENT_STATS_TAGS, function(){
-                this.makeChartVisible('tags');
+                this.makeChartVisible(this.chartNameTags);
             }.bind(this));
         }
     }

--- a/resources/assets/js/components/stats/summary-chart.vue
+++ b/resources/assets/js/components/stats/summary-chart.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div id="stats-summary">
         <section id="stats-form-summary" class="section">
             <account-account-type-toggling-selector
                 id="summary-chart"
@@ -141,7 +141,7 @@
                     });
 
                 // tally up values for total
-                this.rawEntriesData.forEach(function(datum){
+                this.largeBatchEntryData.forEach(function(datum){
                     let accountCurrency = this.getAccountCurrencyFromAccountTypeId(datum.account_type_id);
                     if(datum.expense){
                         total[accountCurrency].expense += parseFloat(datum.entry_value);
@@ -162,7 +162,8 @@
         },
         methods: {
             filteredEntries: function(isExpense){
-                return this.rawEntriesData.filter(function(datum){ return datum.expense === isExpense; });
+                // return this.rawEntriesData.filter(function(datum){ return datum.expense === isExpense; });
+                return this.largeBatchEntryData.filter(function(datum){ return datum.expense === isExpense; });
             },
 
             getAccountCurrencyFromAccountTypeId: function(accountTypeId){
@@ -171,7 +172,6 @@
             },
 
             displayData: function(){
-                this.dataLoaded = false;
                 this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_SHOW);
 
                 let chartDataFilterParameters = {
@@ -185,7 +185,7 @@
                     chartDataFilterParameters.account_type = this.accountOrAccountTypeId;
                 }
 
-                this.fetchData(chartDataFilterParameters);
+                this.multiPageDataFetch(chartDataFilterParameters);
             },
 
             resetAccountTypesSelector: function(){

--- a/resources/assets/js/components/stats/tags-chart.vue
+++ b/resources/assets/js/components/stats/tags-chart.vue
@@ -135,7 +135,7 @@
                         }.bind(this));
                     }.bind(this), Object.create(null));
 
-                return Object.values(standardisedChartData);
+                return _.sortBy(Object.values(standardisedChartData), function(o){ return o.x;});
             }
         },
         methods: {

--- a/resources/assets/js/components/stats/tags-chart.vue
+++ b/resources/assets/js/components/stats/tags-chart.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div id="stats-tags">
         <section id="stats-form-tags"  class="section">
             <account-account-type-toggling-selector
                 id="tags-chart"
@@ -75,7 +75,7 @@
         },
         computed: {
             chartData: function(){
-                let chartData = this.standardiseData();
+                let chartData = this.standardiseData;
                 let chartBgColors = [];
                 for(let i=0; i<chartData.length; i++){
                     chartBgColors.push(this.randomColor());
@@ -110,17 +110,12 @@
 
             getBulmaCalendar: function(){
                 return this.$refs.tagsStatsChartBulmaCalendar;
-            }
-        },
-        methods: {
-            setChartTitle: function(startDate, endDate){
-                this.chartConfig.titleText = "Tags ["+startDate+" - "+endDate+"]";
             },
 
             standardiseData: function(){
                 let standardisedChartData = {};
 
-                this.rawEntriesData
+                this.largeBatchEntryData
                     .forEach(function(entryDatum){
                         let tempDatum = _.cloneDeep(entryDatum);
                         if(tempDatum.tags.length === 0){
@@ -141,10 +136,14 @@
                     }.bind(this), Object.create(null));
 
                 return Object.values(standardisedChartData);
+            }
+        },
+        methods: {
+            setChartTitle: function(startDate, endDate){
+                this.chartConfig.titleText = "Tags ["+startDate+" - "+endDate+"]";
             },
 
             makeRequest: function(){
-                this.dataLoaded = false;
                 this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_SHOW);
 
                 let chartDataFilterParameters = {
@@ -163,7 +162,7 @@
                 }
 
                 this.setChartTitle(chartDataFilterParameters.start_date, chartDataFilterParameters.end_date);
-                this.fetchData(chartDataFilterParameters);
+                this.multiPageDataFetch(chartDataFilterParameters);
             },
         },
         mounted: function(){

--- a/resources/assets/js/components/stats/trending-chart.vue
+++ b/resources/assets/js/components/stats/trending-chart.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div id="stats-trending">
         <section id="stats-form-trending" class="section">
             <account-account-type-toggling-selector
                 id="trending-chart"
@@ -141,7 +141,7 @@
         methods: {
             standardiseData: function(isExpense){
                 let standardisedChartData = [];
-                this.rawEntriesData
+                this.largeBatchEntryData
                     .filter(function(chartDatum){ return chartDatum.expense === isExpense })
                     .map(function(filteredChartDatum){
                         // extract entry_date and entry_value
@@ -185,7 +185,6 @@
             },
 
             displayData: function(){
-                this.dataLoaded = false;
                 this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_SHOW);
 
                 let chartDataFilterParameters = {
@@ -201,7 +200,7 @@
 
                 this.setChartTitle(chartDataFilterParameters.start_date, chartDataFilterParameters.end_date);
                 this.setChartTimeUnit(chartDataFilterParameters.start_date, chartDataFilterParameters.end_date);
-                this.fetchData(chartDataFilterParameters);
+                this.multiPageDataFetch(chartDataFilterParameters);
             },
         },
         mounted: function(){

--- a/resources/assets/js/mixins/entries-object-mixin.js
+++ b/resources/assets/js/mixins/entries-object-mixin.js
@@ -4,11 +4,14 @@ import {Entries} from "../entries";
 export const entriesObjectMixin = {
     data: function(){
         return {
+            dataLoaded: false,
             entriesObject: new Entries(),
+            largeBatchEntryData: [],
         }
     },
 
     computed: {
+        MAX_ENTRY_COUNT: function(){ return 50; },
         rawEntriesData: function(){
             return this.entriesObject.retrieve;
         },
@@ -19,15 +22,48 @@ export const entriesObjectMixin = {
 
     methods: {
         fetchData: function(filterParameters){
+            this.dataLoaded = false;
             this.entriesObject
                 .fetch(0, filterParameters)
                 .then(function(notification){
                     this.$eventHub.broadcast(this.$eventHub.EVENT_NOTIFICATION, notification);
                 }.bind(this))
-                .finally(function(){
-                    this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_HIDE);
-                    this.dataLoaded = true;
-                }.bind(this));
+                .finally(this.dataHasBeenFetched);
         },
+        multiPageDataFetch: function(filterParameters={}){
+            // reset for a new request
+            this.dataLoaded = false;
+            this.largeBatchEntryData = [];
+
+            // init data from page 0
+            this.largeBatchEntryData = this.rawEntriesData;
+            this.chainBatchRequest(0, filterParameters);
+        },
+        dataHasBeenFetched: function(){
+            this.dataLoaded = true;
+            this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_HIDE);
+        },
+        chainBatchRequest: function(fetchCount, filterParameters, totalPageCount=null){
+            this.entriesObject
+                .fetch(fetchCount, filterParameters)
+                .then(function(notification){
+                    // fire off a notification if needed
+                    this.$eventHub.broadcast(this.$eventHub.EVENT_NOTIFICATION, notification);
+
+                    this.largeBatchEntryData = this.largeBatchEntryData.concat(this.rawEntriesData);
+
+                    fetchCount++;
+                    if(totalPageCount == null){
+                        totalPageCount = Math.ceil(this.entriesObject.count/this.MAX_ENTRY_COUNT);
+                    }
+
+                    if(fetchCount < totalPageCount){
+                        this.chainBatchRequest(fetchCount, filterParameters, totalPageCount)
+                    } else {
+                        this.dataLoaded = true;
+                        this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_HIDE);
+                    }
+                }.bind(this))
+        }
     }
 };

--- a/resources/assets/js/mixins/stats-nav-mixin.js
+++ b/resources/assets/js/mixins/stats-nav-mixin.js
@@ -4,9 +4,17 @@ export const statsNavMixin = {
             isVisibleChart: {
                 summary: true,
                 trending: false,
-                tags: false
+                tags: false,
+                distribution: false
             }
         }
+    },
+
+    computed: {
+        chartNameSummary: function(){ return 'summary' },
+        chartNameTrending: function(){ return 'trending' },
+        chartNameTags: function(){ return 'tags' },
+        chartNameDistribution: function(){ return 'distribution' }
     },
 
     methods:{

--- a/tests/Browser/StatsSummaryTest.php
+++ b/tests/Browser/StatsSummaryTest.php
@@ -3,9 +3,10 @@
 namespace Tests\Browser;
 
 use App\Traits\Tests\Dusk\AccountOrAccountTypeTogglingSelector as DuskTraitAccountOrAccountTypeTogglingSelector;
-use App\Traits\Tests\Dusk\BatchFilterEntries as DuskBatchFilterEntries;
+use App\Traits\Tests\Dusk\BatchFilterEntries as DuskTraitBatchFilterEntries;
 use App\Traits\Tests\Dusk\BulmaDatePicker as DuskTraitBulmaDatePicker;
 use App\Traits\Tests\Dusk\Loading as DuskTraitLoading;
+use App\Traits\Tests\Dusk\StatsSidePanel as DuskTraitStatsSidePanel;
 use Facebook\WebDriver\WebDriverBy;
 use Illuminate\Support\Collection;
 use Tests\Browser\Pages\StatsPage;
@@ -24,18 +25,15 @@ use Throwable;
 class StatsSummaryTest extends DuskTestCase {
 
     use DuskTraitAccountOrAccountTypeTogglingSelector;
-    use DuskBatchFilterEntries;
+    use DuskTraitBatchFilterEntries;
     use DuskTraitBulmaDatePicker;
     use DuskTraitLoading;
+    use DuskTraitStatsSidePanel;
 
     private static $SELECTOR_STATS_FORM_SUMMARY = "#stats-form-summary";
     private static $SELECTOR_BUTTON_GENERATE = '.generate-stats';
     private static $SELECTOR_STATS_RESULTS_AREA = '.stats-results-summary';
-    private static $SELECTOR_SIDE_PANEL = '.panel';
-    private static $SELECTOR_SIDE_PANEL_HEADING = '.panel-heading:first-child';
-    private static $SELECTOR_SIDE_PANEL_OPTION_SUMMARY = '.panel-heading+.panel-block';
 
-    private static $LABEL_OPTION_SUMMARY = 'Summary';
     private static $LABEL_GENERATE_TABLE_BUTTON = "Generate Tables";
     private static $LABEL_NO_STATS_DATA = 'No data available';
 
@@ -54,17 +52,9 @@ class StatsSummaryTest extends DuskTestCase {
         $this->browse(function(Browser $browser) {
             $browser
                 ->visit(new StatsPage())
-                ->assertVisible(self::$SELECTOR_SIDE_PANEL)
-                ->within(self::$SELECTOR_SIDE_PANEL, function(Browser $sidepanel){
-                    $sidepanel
-                        ->assertVisible(self::$SELECTOR_SIDE_PANEL_HEADING)
-                        ->assertSeeIn(self::$SELECTOR_SIDE_PANEL_HEADING, "Stats")
-                        ->assertVisible(self::$SELECTOR_SIDE_PANEL_OPTION_SUMMARY)
-                        ->assertSeeIn(self::$SELECTOR_SIDE_PANEL_OPTION_SUMMARY, self::$LABEL_OPTION_SUMMARY);
-
-                    $classes = $sidepanel->attribute(self::$SELECTOR_SIDE_PANEL_OPTION_SUMMARY, 'class');
-                    $this->assertContains('is-active', $classes);
-                });
+                ->assertVisible(self::$SELECTOR_STATS_SIDE_PANEL);
+            $this->assertStatsSidePanelHeading($browser);
+            $this->assertStatsSidePanelOptionIsActive($browser, self::$LABEL_STATS_SIDE_PANEL_OPTION_SUMMARY);;
         });
     }
 

--- a/tests/Browser/StatsTagsTest.php
+++ b/tests/Browser/StatsTagsTest.php
@@ -38,7 +38,6 @@ class StatsTagsTest extends DuskTestCase {
     private static $SELECTOR_STATS_RESULTS_AREA = '.stats-results-tags';
     private static $SELECTOR_CHART_TAGS = 'canvas#bar-chart';
 
-    private static $LABEL_OPTION_TAGS = "Tags";
     private static $LABEL_GENERATE_CHART_BUTTON = 'Generate Chart';
     private static $LABEL_NO_STATS_DATA = 'No data available';
 
@@ -170,7 +169,7 @@ class StatsTagsTest extends DuskTestCase {
      *
      * @throws Throwable
      *
-     * @group stats-trending-1
+     * @group stats-tags-1
      * test (see provider)/25
      */
     public function testGenerateTagsChart($datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $tag_count){
@@ -285,7 +284,7 @@ class StatsTagsTest extends DuskTestCase {
                 $account_type_id = $account_types->pluck('id')->random();
         }
 
-        $disabled_entry = factory(Entry::class)->create(['account_type_id'=>$account_type_id, 'disabled'=>$is_entry_disabled]);
+        $disabled_entry = factory(Entry::class)->create(['account_type_id'=>$account_type_id, 'disabled'=>$is_entry_disabled, 'entry_date'=>date('Y-m-d')]);
         foreach($tags->pluck('id')->all() as $tag_id){
             $disabled_entry->tags()->attach($tag_id);
         }

--- a/tests/Browser/StatsTagsTest.php
+++ b/tests/Browser/StatsTagsTest.php
@@ -216,7 +216,7 @@ class StatsTagsTest extends DuskTestCase {
                         $datepicker_end = date('Y-m-t');
                     }
 
-                    $this->createEntryWithAllTags($are_disabled_select_options_available, $is_switch_toggled, $account_or_account_type_id, $account_types, $tags);
+                    $this->createEntryWithAllTags($is_switch_toggled, $account_or_account_type_id, $account_types, $tags);
                     $form->click(self::$SELECTOR_BUTTON_GENERATE);
                 });
 
@@ -259,6 +259,8 @@ class StatsTagsTest extends DuskTestCase {
                 $standardised_chart_data[$key]['y'] = round($standardised_chart_data[$key]['y'], 2);
             }
         }
+        $x_col = array_column($standardised_chart_data, 'x');
+        array_multisort($x_col, SORT_ASC, $standardised_chart_data);
         return array_values($standardised_chart_data);
     }
 
@@ -267,13 +269,12 @@ class StatsTagsTest extends DuskTestCase {
      * It's a waste of resources to do that for every test when most tests don't need that kind of data.
      * So instead for these tests, we'll create a disabled with all the tags
      *
-     * @param bool $is_entry_disabled
      * @param bool $is_account_type_rather_than_account_toggled
      * @param int $account_or_account_type_id
      * @param Collection $account_types
      * @param Collection $tags
      */
-    private function createEntryWithAllTags($is_entry_disabled, $is_account_type_rather_than_account_toggled, $account_or_account_type_id, $account_types, $tags){
+    private function createEntryWithAllTags($is_account_type_rather_than_account_toggled, $account_or_account_type_id, $account_types, $tags){
         if(!empty($account_or_account_type_id)){
             if($is_account_type_rather_than_account_toggled){
                 $account_type_id = $account_or_account_type_id;
@@ -284,7 +285,7 @@ class StatsTagsTest extends DuskTestCase {
             $account_type_id = $account_types->pluck('id')->random();
         }
 
-        $disabled_entry = factory(Entry::class)->create(['account_type_id'=>$account_type_id, 'disabled'=>$is_entry_disabled, 'entry_date'=>date('Y-m-d', strtotime('-1 day'))]);
+        $disabled_entry = factory(Entry::class)->create(['account_type_id'=>$account_type_id, 'disabled'=>false, 'entry_date'=>date('Y-m-d', strtotime('-1 day'))]);
         foreach($tags->pluck('id')->all() as $tag_id){
             $disabled_entry->tags()->attach($tag_id);
         }

--- a/tests/Browser/StatsTagsTest.php
+++ b/tests/Browser/StatsTagsTest.php
@@ -281,10 +281,10 @@ class StatsTagsTest extends DuskTestCase {
                 $account_type_id = $account_types->where('account_id', $account_or_account_type_id)->pluck('id')->first();
             }
         } else {
-                $account_type_id = $account_types->pluck('id')->random();
+            $account_type_id = $account_types->pluck('id')->random();
         }
 
-        $disabled_entry = factory(Entry::class)->create(['account_type_id'=>$account_type_id, 'disabled'=>$is_entry_disabled, 'entry_date'=>date('Y-m-d')]);
+        $disabled_entry = factory(Entry::class)->create(['account_type_id'=>$account_type_id, 'disabled'=>$is_entry_disabled, 'entry_date'=>date('Y-m-d', strtotime('-1 day'))]);
         foreach($tags->pluck('id')->all() as $tag_id){
             $disabled_entry->tags()->attach($tag_id);
         }

--- a/tests/Browser/StatsTagsTest.php
+++ b/tests/Browser/StatsTagsTest.php
@@ -278,10 +278,12 @@ class StatsTagsTest extends DuskTestCase {
      */
     private function createDisabledEntryWithTags($is_account_type_rather_than_account_toggled, $account_or_account_type_id, $account_types, $tags){
         if(!$is_account_type_rather_than_account_toggled){
-            $account_types->where('account_id', $account_or_account_type_id);
+            $account_type_id = $account_types->where('account_id', $account_or_account_type_id);
+        } else {
+            $account_type_id = $account_or_account_type_id;
         }
 
-        $disabled_entry = factory(Entry::class)->create(['account_type_id'=>$account_or_account_type_id, 'disabled'=>true]);
+        $disabled_entry = factory(Entry::class)->create(['account_type_id'=>$account_type_id, 'disabled'=>true]);
         $disabled_entry->tags()->attach($tags->pluck('id')->all());
     }
 

--- a/tests/Browser/StatsTagsTest.php
+++ b/tests/Browser/StatsTagsTest.php
@@ -4,7 +4,7 @@ namespace Tests\Browser;
 
 use App\Entry;
 use App\Traits\Tests\Dusk\AccountOrAccountTypeTogglingSelector as DuskTraitAccountOrAccountTypeTogglingSelector;
-use App\Traits\Tests\Dusk\BatchFilterEntries as DuskBatchFilterEntries;
+use App\Traits\Tests\Dusk\BatchFilterEntries as DuskTraitBatchFilterEntries;
 use App\Traits\Tests\Dusk\BulmaDatePicker as DuskTraitBulmaDatePicker;
 use App\Traits\Tests\Dusk\Loading as DuskTraitLoading;
 use App\Traits\Tests\Dusk\StatsSidePanel as DuskTraitStatsSidePanel;
@@ -27,7 +27,7 @@ class StatsTagsTest extends DuskTestCase {
 
     use DuskTraitLoading;
     use DuskTraitAccountOrAccountTypeTogglingSelector;
-    use DuskBatchFilterEntries;
+    use DuskTraitBatchFilterEntries;
     use DuskTraitBulmaDatePicker;
     use DuskTraitTagsInput;
     use DuskTraitStatsSidePanel;
@@ -277,14 +277,16 @@ class StatsTagsTest extends DuskTestCase {
      * @param Collection $tags
      */
     private function createDisabledEntryWithTags($is_account_type_rather_than_account_toggled, $account_or_account_type_id, $account_types, $tags){
-        if(!$is_account_type_rather_than_account_toggled){
-            $account_type_id = $account_types->where('account_id', $account_or_account_type_id);
-        } else {
+        if($is_account_type_rather_than_account_toggled){
             $account_type_id = $account_or_account_type_id;
+        } else {
+            $account_type_id = $account_types->where('account_id', $account_or_account_type_id)->pluck('id')->first();
         }
 
         $disabled_entry = factory(Entry::class)->create(['account_type_id'=>$account_type_id, 'disabled'=>true]);
-        $disabled_entry->tags()->attach($tags->pluck('id')->all());
+        foreach($tags->pluck('id')->all() as $tag_id){
+            $disabled_entry->tags()->attach($tag_id);
+        }
     }
 
 }

--- a/tests/Browser/StatsTagsTest.php
+++ b/tests/Browser/StatsTagsTest.php
@@ -7,6 +7,7 @@ use App\Traits\Tests\Dusk\AccountOrAccountTypeTogglingSelector as DuskTraitAccou
 use App\Traits\Tests\Dusk\BatchFilterEntries as DuskBatchFilterEntries;
 use App\Traits\Tests\Dusk\BulmaDatePicker as DuskTraitBulmaDatePicker;
 use App\Traits\Tests\Dusk\Loading as DuskTraitLoading;
+use App\Traits\Tests\Dusk\StatsSidePanel as DuskTraitStatsSidePanel;
 use App\Traits\Tests\Dusk\TagsInput as DuskTraitTagsInput;
 use Illuminate\Support\Collection;
 use Tests\Browser\Pages\StatsPage;
@@ -29,13 +30,12 @@ class StatsTagsTest extends DuskTestCase {
     use DuskBatchFilterEntries;
     use DuskTraitBulmaDatePicker;
     use DuskTraitTagsInput;
+    use DuskTraitStatsSidePanel;
 
     private static $SELECTOR_STATS_TAGS = "#stats-tags";
     private static $SELECTOR_STATS_FORM_TAGS = "#stats-form-tags";
     private static $SELECTOR_BUTTON_GENERATE = '.generate-stats';
     private static $SELECTOR_STATS_RESULTS_AREA = '.stats-results-tags';
-    private static $SELECTOR_SIDE_PANEL = '.panel';
-    private static $SELECTOR_SIDE_PANEL_OPTION_TAGS = '.panel-block:nth-child(4)';
     private static $SELECTOR_CHART_TAGS = 'canvas#bar-chart';
 
     private static $LABEL_OPTION_TAGS = "Tags";
@@ -59,18 +59,10 @@ class StatsTagsTest extends DuskTestCase {
         $this->browse(function(Browser $browser) {
             $browser
                 ->visit(new StatsPage())
-                ->assertVisible(self::$SELECTOR_SIDE_PANEL)
-                ->with(self::$SELECTOR_SIDE_PANEL, function(Browser $side_panel){
-                    $class_is_active = 'is-active';
-                    $classes = $side_panel->attribute(self::$SELECTOR_SIDE_PANEL_OPTION_TAGS, 'class');
-                    $this->assertNotContains($class_is_active, $classes);
-
-                    $side_panel
-                        ->assertSeeIn(self::$SELECTOR_SIDE_PANEL_OPTION_TAGS, self::$LABEL_OPTION_TAGS)
-                        ->click(self::$SELECTOR_SIDE_PANEL_OPTION_TAGS);
-                    $classes = $side_panel->attribute(self::$SELECTOR_SIDE_PANEL_OPTION_TAGS, 'class');
-                    $this->assertContains($class_is_active, $classes);
-                });
+                ->assertVisible(self::$SELECTOR_STATS_SIDE_PANEL);
+            $this->assertStatsSidePanelOptionIsActive($browser, self::$LABEL_STATS_SIDE_PANEL_OPTION_SUMMARY);
+            $this->clickStatsSidePanelOptionTags($browser);
+            $this->assertStatsSidePanelOptionIsActive($browser, self::$LABEL_STATS_SIDE_PANEL_OPTION_TAGS);
         });
     }
 
@@ -84,12 +76,10 @@ class StatsTagsTest extends DuskTestCase {
         $accounts = $this->getApiAccounts();
 
         $this->browse(function(Browser $browser) use ($accounts){
-            $browser
-                ->visit(new StatsPage())
-                ->with(self::$SELECTOR_SIDE_PANEL, function(Browser $side_panel){
-                    $side_panel->click(self::$SELECTOR_SIDE_PANEL_OPTION_TAGS);
-                })
+            $browser->visit(new StatsPage());
+            $this->clickStatsSidePanelOptionTags($browser);
 
+            $browser
                 ->assertVisible(self::$SELECTOR_STATS_TAGS)
                 ->with(self::$SELECTOR_STATS_TAGS, function(Browser $stats_tags) use ($accounts){
                     $stats_tags
@@ -123,11 +113,10 @@ class StatsTagsTest extends DuskTestCase {
      */
     public function testDefaultDataResultsArea(){
         $this->browse(function(Browser $browser){
+            $browser->visit(new StatsPage());
+            $this->clickStatsSidePanelOptionTags($browser);
+
             $browser
-                ->visit(new StatsPage())
-                ->with(self::$SELECTOR_SIDE_PANEL, function(Browser $side_panel){
-                    $side_panel->click(self::$SELECTOR_SIDE_PANEL_OPTION_TAGS);
-                })
                 ->assertVisible(self::$SELECTOR_STATS_TAGS)
                 ->with(self::$SELECTOR_STATS_TAGS, function(Browser $stats_tags){
                     $stats_tags
@@ -193,12 +182,10 @@ class StatsTagsTest extends DuskTestCase {
             $account_or_account_type_id = null;
             $form_tags = null;
 
-            $browser
-                ->visit(new StatsPage())
-                ->with(self::$SELECTOR_SIDE_PANEL, function(Browser $side_panel){
-                    $side_panel->click(self::$SELECTOR_SIDE_PANEL_OPTION_TAGS);
-                })
+            $browser->visit(new StatsPage());
+            $this->clickStatsSidePanelOptionTags($browser);
 
+            $browser
                 ->assertVisible(self::$SELECTOR_STATS_FORM_TAGS)
                 ->with(self::$SELECTOR_STATS_FORM_TAGS, function(Browser $form) use ($is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $accounts, $account_types, &$account_or_account_type_id, $tag_count, $tags, &$form_tags, &$datepicker_start, &$datepicker_end){
                     if($are_disabled_select_options_available){


### PR DESCRIPTION
- Fixed bug where only the first batch of entries (_50_) were being processed by the `/stats` page charts.
- Added a link to chart.js documentation in the `README.md`

Resolves #241 