### PR TITLE
feature/stats-distribution-chart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ stages:
   - "e2e-tests: entry-modal"
   - "e2e-tests: filter-modal"
   - "e2e-tests: transfer-modal"
+  - "e2e-tests: stats"
 
 jobs:
   include:
@@ -131,6 +132,7 @@ jobs:
     - stage: "e2e-tests: stats"
       script: .docker/cmd/artisan.sh dusk --group stats-summary --stop-on-failure
     - script: .docker/cmd/artisan.sh dusk --group stats-trending --stop-on-failure
+    - script: .docker/cmd/artisan.sh dusk --group stats-distribution --stop-on-failure
     - script: .docker/cmd/artisan.sh dusk --group stats-tags --stop-on-failure
 
 # $WEBHOOK_URL should be set in travis-ci settings

--- a/app/Traits/Tests/AssertElementColor.php
+++ b/app/Traits/Tests/AssertElementColor.php
@@ -13,9 +13,8 @@ trait AssertElementColor {
      * @param Browser $browser
      * @param string $element_selector
      * @param string $expected_colour
-     * @param string $element_pseudo_selector
      */
-    public function assertElementColor(Browser $browser, $element_selector, $expected_colour, $element_pseudo_selector = ''){
+    public function assertElementColor(Browser $browser, $element_selector, $expected_colour){
         $this->assertElementColour($browser, $element_selector, $expected_colour);
     }
 
@@ -23,18 +22,22 @@ trait AssertElementColor {
      * @param Browser $browser
      * @param string $element_selector
      * @param string $expected_colour
-     * @param string $element_pseudo_selector
      */
-    public function assertElementColour(Browser $browser, $element_selector, $expected_colour, $element_pseudo_selector = ''){
-        $element_hex_colour = $browser->script(['css_color = window.getComputedStyle(document.querySelector("'.$element_selector.'"), "'.$element_pseudo_selector.'").getPropertyValue("background-color");', 'rgb = css_color.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/);', 'if(rgb === null){
+    public function assertElementColour(Browser $browser, $element_selector, $expected_colour){
+        $element_hex_colour_script_output = $browser->script([
+            'css_color = window.getComputedStyle(document.querySelector("'.$element_selector.'"), null).getPropertyValue("background-color");',
+            'rgb = css_color.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/);',
+            'if(rgb === null){
                 hex = css_color;    // assuming that the CSS color returned is HEX
             } else {
                 r = (parseInt(rgb[1]) < 16 ? "0" : "")+parseInt(rgb[1]).toString(16);
                 g = (parseInt(rgb[2]) < 16 ? "0" : "")+parseInt(rgb[2]).toString(16);
                 b = (parseInt(rgb[3]) < 16 ? "0" : "")+parseInt(rgb[3]).toString(16);
                 hex = "#"+r+g+b;
-            }', 'return hex;']);
-
-        PHPUnit::assertEquals(strtoupper($expected_colour), strtoupper($element_hex_colour[3]), "Expected colour [$expected_colour] does not match actual colour [".$element_hex_colour[3]."] of element [$element_selector]");
+            }',
+            'return hex;'
+        ]);
+        $element_hex_colour = end($element_hex_colour_script_output);
+        PHPUnit::assertEquals(strtoupper($expected_colour), strtoupper($element_hex_colour), "Expected colour [$expected_colour] does not match actual colour [".$element_hex_colour."] of element [$element_selector]");
     }
 }

--- a/app/Traits/Tests/Dusk/AccountOrAccountTypeTogglingSelector.php
+++ b/app/Traits/Tests/Dusk/AccountOrAccountTypeTogglingSelector.php
@@ -15,7 +15,9 @@ trait AccountOrAccountTypeTogglingSelector {
     private static $SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT = ".select-account-or-account-types-id";
     private static $SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT_LOADING = ".is-loading .select-account-or-account-types-id";
 
-    private $_id_label;
+    private static $LABEL_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_TOGGLE_DEFAULT = "Account";
+
+    private $_account_or_account_type_toggling_selector_label_id;
     private $_disable_checkbox_checked = false;
 
     /**
@@ -53,19 +55,19 @@ trait AccountOrAccountTypeTogglingSelector {
     public function assertDefaultStateOfAccountOrAccountTypeTogglingSelectorComponent(Browser $browser, $accounts){
         $browser
             // component
-            ->assertVisible($this->getAccountOrAccountTypeTogglingSelectorComponentId($this->_id_label))
-            ->with($this->getAccountOrAccountTypeTogglingSelectorComponentId($this->_id_label), function(Browser $component) use ($accounts){
+            ->assertVisible($this->getAccountOrAccountTypeTogglingSelectorComponentId($this->_account_or_account_type_toggling_selector_label_id))
+            ->with($this->getAccountOrAccountTypeTogglingSelectorComponentId($this->_account_or_account_type_toggling_selector_label_id), function(Browser $component) use ($accounts){
                 $label_select_option_default = "[ ALL ]";
                 $class_switch_core = ".v-switch-core";
                 $color_switch_default = "#B5B5B5";
 
                 // account/account-type - switch
                 $component
-                    ->assertVisible($this->getSwitchAccountAndAccountTypeId($this->_id_label))
-                    ->assertSeeIn($this->getSwitchAccountAndAccountTypeId($this->_id_label), "Account");
+                    ->assertVisible($this->getSwitchAccountAndAccountTypeId($this->_account_or_account_type_toggling_selector_label_id))
+                    ->assertSeeIn($this->getSwitchAccountAndAccountTypeId($this->_account_or_account_type_toggling_selector_label_id), self::$LABEL_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_TOGGLE_DEFAULT);
                 $this->assertElementColour(
                     $component,
-                    $this->getSwitchAccountAndAccountTypeId($this->_id_label).' '.$class_switch_core, $color_switch_default
+                    $this->getSwitchAccountAndAccountTypeId($this->_account_or_account_type_toggling_selector_label_id).' '.$class_switch_core, $color_switch_default
                 );
 
                 // account/account-type - select
@@ -82,9 +84,9 @@ trait AccountOrAccountTypeTogglingSelector {
 
                 // disable checkbox
                 if(collect($accounts)->where('disabled', true)->count() > 0){
-                    $component->assertVisible($this->getCheckboxShowDisabledAccountOrAccountType($this->_id_label));
+                    $component->assertVisible($this->getCheckboxShowDisabledAccountOrAccountType($this->_account_or_account_type_toggling_selector_label_id));
                 } else {
-                    $component->assertMissing($this->getCheckboxShowDisabledAccountOrAccountType($this->_id_label));
+                    $component->assertMissing($this->getCheckboxShowDisabledAccountOrAccountType($this->_account_or_account_type_toggling_selector_label_id));
                 }
             });
     }
@@ -93,9 +95,9 @@ trait AccountOrAccountTypeTogglingSelector {
      * @param Browser $browser
      */
     public function toggleAccountOrAccountTypeSwitch(Browser $browser){
-        $browser->with($this->getAccountOrAccountTypeTogglingSelectorComponentId($this->_id_label), function(Browser $component){
+        $browser->with($this->getAccountOrAccountTypeTogglingSelectorComponentId($this->_account_or_account_type_toggling_selector_label_id), function(Browser $component){
             // account/account-type - switch
-            $component->click($this->getSwitchAccountAndAccountTypeId($this->_id_label));
+            $component->click($this->getSwitchAccountAndAccountTypeId($this->_account_or_account_type_toggling_selector_label_id));
         });
     }
 
@@ -103,12 +105,12 @@ trait AccountOrAccountTypeTogglingSelector {
      * @param Browser $browser
      */
     public function toggleShowDisabledAccountOrAccountTypeCheckbox(Browser $browser){
-        $browser->with($this->getAccountOrAccountTypeTogglingSelectorComponentId($this->_id_label), function(Browser $component){
+        $browser->with($this->getAccountOrAccountTypeTogglingSelectorComponentId($this->_account_or_account_type_toggling_selector_label_id), function(Browser $component){
             $component
                 // make sure accounts have finished loading
                 ->waitUntilMissing(self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT_LOADING, self::$WAIT_SECONDS)
                 // show disabled checkbox
-                ->click($this->getCheckboxShowDisabledAccountOrAccountType($this->_id_label));
+                ->click($this->getCheckboxShowDisabledAccountOrAccountType($this->_account_or_account_type_toggling_selector_label_id));
             $this->_disable_checkbox_checked = !$this->_disable_checkbox_checked;
         });
     }
@@ -118,7 +120,7 @@ trait AccountOrAccountTypeTogglingSelector {
      * @param string|int $selector_value
      */
     public function selectAccountOrAccountTypeValue(Browser $browser, $selector_value){
-        $browser->with($this->getAccountOrAccountTypeTogglingSelectorComponentId($this->_id_label), function(Browser $component) use ($selector_value){
+        $browser->with($this->getAccountOrAccountTypeTogglingSelectorComponentId($this->_account_or_account_type_toggling_selector_label_id), function(Browser $component) use ($selector_value){
             $component
                 // make sure accounts have finished loading
                 ->waitUntilMissing(self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT_LOADING, self::$WAIT_SECONDS)

--- a/app/Traits/Tests/Dusk/BatchFilterEntries.php
+++ b/app/Traits/Tests/Dusk/BatchFilterEntries.php
@@ -8,31 +8,61 @@ use Illuminate\Support\Collection;
 trait BatchFilterEntries {
 
     /**
+     * @param array $filter_data
      * @param string $start_date
      * @param string $end_date
-     * @param int|string $account_or_account_type_id
-     * @param bool $is_switch_toggled
-     * @param Collection|null $tags
-     * @return Collection
+     * @return array
      */
-    private function getBatchedFilteredEntries($start_date, $end_date, $account_or_account_type_id, $is_switch_toggled, $tags=null){
-        $filter_data = [
-            EntryController::FILTER_KEY_START_DATE=>$start_date,
-            EntryController::FILTER_KEY_END_DATE=>$end_date,
-        ];
+    private function generateFilterArrayElementDatepicker($filter_data, $start_date, $end_date){
+        $filter_data[EntryController::FILTER_KEY_START_DATE] = $start_date;
+        $filter_data[EntryController::FILTER_KEY_END_DATE] = $end_date;
+        return $filter_data;
+    }
 
+    /**
+     * @param array $filter_data
+     * @param bool $is_account_switch_toggled
+     * @param int|null $account_or_account_type_id
+     * @return mixed
+     */
+    private function generateFilterArrayElementAccountOrAccountypeId($filter_data, $is_account_switch_toggled, $account_or_account_type_id){
         if(!empty($account_or_account_type_id)){
-            if($is_switch_toggled){
+            if($is_account_switch_toggled){
                 $filter_data[EntryController::FILTER_KEY_ACCOUNT_TYPE] = $account_or_account_type_id;
             } else {
                 $filter_data[EntryController::FILTER_KEY_ACCOUNT] = $account_or_account_type_id;
             }
         }
+        return $filter_data;
+    }
 
+    /**
+     * @param array $filter_data
+     * @param bool $is_expense
+     * @return array
+     */
+    private function generateFilterArrayElementExpense($filter_data, $is_expense){
+        $filter_data[EntryController::FILTER_KEY_EXPENSE] = $is_expense;
+        return $filter_data;
+    }
+
+    /**
+     * @param array $filter_data
+     * @param Collection|null $tags
+     * @return mixed
+     */
+    private function generateFilterArrayElementTags($filter_data, $tags){
         if(!is_null($tags)){
             $filter_data[EntryController::FILTER_KEY_TAGS] = $tags->pluck('id')->toArray();
         }
+        return $filter_data;
+    }
 
+    /**
+     * @param array $filter_data
+     * @return Collection
+     */
+    private function getBatchedFilteredEntries($filter_data){
         $entries = $this->getApiEntries(0, $filter_data);
         if(empty($entries)){
             throw new \UnexpectedValueException("Entries not available with filter ".print_r($filter_data, true));

--- a/app/Traits/Tests/Dusk/BulmaColors.php
+++ b/app/Traits/Tests/Dusk/BulmaColors.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Traits\Tests\Dusk;
+
+/**
+ * Trait BulmaColors
+ * @link https://bulma.io/documentation/overview/colors/
+ *
+ * @package App\Traits\Tests\Dusk
+ */
+trait BulmaColors {
+
+    public static $COLOR_WHITE_HEX = "#FFFFFF";
+    public static $COLOR_BLACK_HEX = "#0a0a0a";
+    public static $COLOR_LIGHT_HEX = "#F5F5F5";
+    public static $COLOR_DARK_HEX = "#363636";
+    public static $COLOR_PRIMARY_HEX = "#00D1B2";
+    public static $COLOR_LINK_HEX = "#3273DC";
+    public static $COLOR_INFO_HEX = "#209CEE";
+    public static $COLOR_SUCCESS_HEX = "#48C774";
+    public static $COLOR_WARNING_HEX = "#FFDD57";
+    public static $COLOR_DANGER_HEX = "#FF3860";
+    public static $COLOR_BLACK_BIS_HEX = "#121212";
+    public static $COLOR_BLACK_TER_HEX = "#242424";
+    public static $COLOR_GREY_DARKER_HEX = "#363636";
+    public static $COLOR_GREY_DARK_HEX = "#4A4A4A";
+    public static $COLOR_GREY_LIGHT_HEX = "#B5B5B5";
+    public static $COLOR_GREY_LIGHTER_HEX = "#DBDBDB";
+    public static $COLOR_WHITE_TER_HEX = "#F5F5F5";
+    public static $COLOR_WHITE_BIS_HEX = "#FAFAFA";
+
+}

--- a/app/Traits/Tests/Dusk/StatsSidePanel.php
+++ b/app/Traits/Tests/Dusk/StatsSidePanel.php
@@ -10,12 +10,14 @@ trait StatsSidePanel {
     private static $SELECTOR_STATS_SIDE_PANEL_HEADING = '.panel-heading:first-child';
     private static $SELECTOR_STATS_SIDE_PANEL_OPTION_SUMMARY = ".panel-heading+.panel-block";
     private static $SELECTOR_STATS_SIDE_PANEL_OPTION_TRENDING = ".panel-block:nth-child(3)";
-    private static $SELECTOR_STATS_SIDE_PANEL_OPTION_TAGS = ".panel-block:nth-child(4)";
+    private static $SELECTOR_STATS_SIDE_PANEL_OPTION_DISTRIBUTION = ".panel-block:nth-child(4)";
+    private static $SELECTOR_STATS_SIDE_PANEL_OPTION_TAGS = ".panel-block:nth-child(5)";
     private static $SELECTOR_STATS_SIDE_PANEL_ACTIVE_OPTION = ".panel-block.is-active";
 
     private static $LABEL_STATS_SIDE_PANEL_HEADING = "Stats";
     private static $LABEL_STATS_SIDE_PANEL_OPTION_SUMMARY = "Summary";
     private static $LABEL_STATS_SIDE_PANEL_OPTION_TRENDING = "Trending";
+    private static $LABEL_STATS_SIDE_PANEL_OPTION_DISTRIBUTION = "Distribution";
     private static $LABEL_STATS_SIDE_PANEL_OPTION_TAGS = "Tags";
 
     public function assertStatsSidePanelHeading(Browser $browser){
@@ -33,6 +35,10 @@ trait StatsSidePanel {
 
     public function clickStatsSidePanelOptionTrending(Browser $browser){
         $this->clickStatsSidePanelOption($browser, self::$SELECTOR_STATS_SIDE_PANEL_OPTION_TRENDING);
+    }
+
+    public function clickStatsSidePanelOptionDistribution(Browser $browser){
+        $this->clickStatsSidePanelOption($browser, self::$SELECTOR_STATS_SIDE_PANEL_OPTION_DISTRIBUTION);
     }
 
     public function clickStatsSidePanelOptionTags(Browser $browser){
@@ -64,6 +70,7 @@ trait StatsSidePanel {
         return [
             self::$LABEL_STATS_SIDE_PANEL_OPTION_SUMMARY,
             self::$LABEL_STATS_SIDE_PANEL_OPTION_TRENDING,
+            self::$LABEL_STATS_SIDE_PANEL_OPTION_DISTRIBUTION,
             self::$LABEL_STATS_SIDE_PANEL_OPTION_TAGS
         ];
     }

--- a/app/Traits/Tests/Dusk/ToggleButton.php
+++ b/app/Traits/Tests/Dusk/ToggleButton.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Traits\Tests\Dusk;
+
+use App\Traits\Tests\AssertElementColor;
+use App\Traits\Tests\WaitTimes;
+use Laravel\Dusk\Browser;
+
+trait ToggleButton {
+
+    use AssertElementColor;
+    use WaitTimes;
+
+    private static $SELECTOR_TOGGLE_BUTTON_SWITCH_CORE = ".v-switch-core";
+
+    /**
+     * @param Browser $browser
+     * @param string $selector
+     * @param string $label
+     * @param string|null $color
+     */
+    public function assertToggleButtonState(Browser $browser, $selector, $label, $color=null){
+        $browser
+            ->assertVisible($selector)
+            ->assertSeeIn($selector, $label);
+        if(!is_null($color)){
+            $element_selector = $browser->resolver->format($selector);
+            $this->assertElementColour($browser, $element_selector.' '.self::$SELECTOR_TOGGLE_BUTTON_SWITCH_CORE, $color);
+        }
+    }
+
+    public function toggleToggleButton(Browser $browser, $selector){
+        $browser
+            ->click($selector)
+            ->pause(self::$WAIT_HALF_SECOND_IN_MILLISECONDS);   // wait for transition to complete
+    }
+
+}

--- a/app/Traits/Tests/InjectDatabaseStateIntoException.php
+++ b/app/Traits/Tests/InjectDatabaseStateIntoException.php
@@ -74,6 +74,9 @@ trait InjectDatabaseStateIntoException {
                 case \SebastianBergmann\Comparator\ComparisonFailure::class:
                     return new  $exception_name($original_exception->getExpected(), $original_exception->getActual(), $original_exception->getExpectedAsString(), $original_exception->getActualAsString(), false, $new_exception_message);
 
+                case \PHPUnit\Framework\ExpectationFailedException::class:
+                    return new $exception_name($new_exception_message, $original_exception->getComparisonFailure(), $original_exception);
+
                 case \ErrorException::class:
                     return new $exception_name($new_exception_message, $original_exception->getCode(), $original_exception->getSeverity(), $original_exception->getFile(), $original_exception->getLine(), $original_exception);
 

--- a/resources/assets/js/components/account-account-type-toggling-selector.vue
+++ b/resources/assets/js/components/account-account-type-toggling-selector.vue
@@ -7,8 +7,8 @@
                     v-bind:id="getIdForToggleSwitch"
                     v-model="propToggle"
                     v-bind:value="propToggle"
-                    v-bind:labels="{checked: toggleButtonProperties.label.checked, unchecked: toggleButtonProperties.label.unchecked}"
-                    v-bind:color="{checked: toggleButtonProperties.colors.checked, unchecked: toggleButtonProperties.colors.unchecked}"
+                    v-bind:labels="toggleButtonProperties.label"
+                    v-bind:color="toggleButtonProperties.colors"
                     v-bind:height="toggleButtonProperties.height"
                     v-bind:width="toggleButtonProperties.width"
                     v-bind:sync="true"
@@ -49,6 +49,7 @@
     import _ from "lodash";
     import {accountsObjectMixin} from "../mixins/accounts-object-mixin";
     import {accountTypesObjectMixin} from "../mixins/account-types-object-mixin";
+    import {bulmaColorsMixin} from "../mixins/bulma-colors-mixin";
     import {ToggleButton} from 'vue-js-toggle-button'
 
     export default {
@@ -56,7 +57,7 @@
         components: {
             ToggleButton
         },
-        mixins: [accountsObjectMixin, accountTypesObjectMixin],
+        mixins: [accountsObjectMixin, accountTypesObjectMixin, bulmaColorsMixin],
         props: {
             id: {type: String, required: true},
             accountOrAccountTypeToggled: {type: Boolean, default: true},
@@ -67,13 +68,6 @@
                 selectedToggleSwitch: {
                     account: true,
                     accountType: false
-                },
-
-                toggleButtonProperties: {
-                    label: {checked: "Account", unchecked: "Account Type"},
-                    colors: {checked: '#B5B5B5', unchecked: '#B5B5B5'},
-                    height: 36,
-                    width: 140,
                 },
 
                 propToggle: this.accountOrAccountTypeToggled,
@@ -92,7 +86,7 @@
             propToggle: function(newValue, oldValue){
                 this.resetAccountOrAccountTypeSelectValue();
                 this.$emit('update-toggle', newValue);
-            }
+            },
         },
         computed: {
             listProcessedAccountOrAccountTypes: function(){
@@ -125,8 +119,16 @@
             },
             getIdForToggleSwitch: function(){
                 return 'toggle-account-and-account-types-for-'+this.id;
-            }
+            },
 
+            toggleButtonProperties: function(){
+                return {
+                    label: {checked: "Account", unchecked: "Account Type"},
+                    colors: {checked: this.colorGreyLight, unchecked: this.colorGreyLight},
+                    height: 36,
+                    width: 140,
+                };
+            },
         },
         methods: {
             processListOfObjects: function(listOfObjects, canShowDisabled=true){

--- a/resources/assets/js/components/entry-modal.vue
+++ b/resources/assets/js/components/entry-modal.vue
@@ -199,10 +199,11 @@
     import { ToggleButton } from 'vue-js-toggle-button';
     import VoerroTagsInput from '@voerro/vue-tagsinput';
     import vue2Dropzone from 'vue2-dropzone';
+    import {bulmaColorsMixin} from "../mixins/bulma-colors-mixin";
 
     export default {
         name: "entry-modal",
-        mixins: [accountsObjectMixin, accountTypesObjectMixin, tagsObjectMixin],
+        mixins: [accountsObjectMixin, accountTypesObjectMixin, bulmaColorsMixin, tagsObjectMixin],
         components: {
             EntryModalAttachment,
             ToggleButton,
@@ -238,13 +239,6 @@
                     transfer_entry_id: null,
                     tags: [],
                     attachments: []
-                },
-
-                toggleButtonProperties: {
-                    colors: {checked: '#ffcc00', unchecked: '#00d1b2'},
-                    height: 40,
-                    labels: {checked: 'Expense', unchecked: 'Income'},
-                    width: 200,
                 },
             }
         },
@@ -324,8 +318,16 @@
                 return document.querySelector("meta[name='csrf-token']").getAttribute('content');
             },
             orderedAttachments: function(){
-                return _.orderBy(this.entryData.attachments, 'name')
-            }
+                return _.orderBy(this.entryData.attachments, 'name');
+            },
+            toggleButtonProperties: function(){
+                return {
+                    colors: {checked: this.colorWarning, unchecked: this.colorPrimary},
+                    height: 40,
+                    labels: {checked: 'Expense', unchecked: 'Income'},
+                    width: 200,
+                };
+            },
         },
         methods: {
             decimaliseEntryValue: function(){

--- a/resources/assets/js/components/filter-modal.vue
+++ b/resources/assets/js/components/filter-modal.vue
@@ -209,6 +209,7 @@
     import {Currency} from "../currency";
     import {accountsObjectMixin} from "../mixins/accounts-object-mixin";
     import {accountTypesObjectMixin} from "../mixins/account-types-object-mixin";
+    import {bulmaColorsMixin} from "../mixins/bulma-colors-mixin";
     import {tagsObjectMixin} from "../mixins/tags-object-mixin";
     import {ToggleButton} from 'vue-js-toggle-button';
     import AccountAccountTypeTogglingSelector from "./account-account-type-toggling-selector";
@@ -216,7 +217,7 @@
 
     export default {
         name: "filter-modal",
-        mixins: [accountsObjectMixin, accountTypesObjectMixin, tagsObjectMixin],
+        mixins: [accountsObjectMixin, accountTypesObjectMixin, bulmaColorsMixin, tagsObjectMixin],
         components: {
             AccountAccountTypeTogglingSelector,
             ToggleButton,
@@ -250,13 +251,6 @@
                     minValue: "",
                     maxValue: ""
                 },
-
-                toggleButtonProperties: {
-                    labels: {checked: 'Enabled', unchecked: 'Disabled'},
-                    colors: {checked: '#209CEE', unchecked: '#B5B5B5'},
-                    height: 40,
-                    width: 200,
-                },
             }
         },
         computed: {
@@ -273,6 +267,14 @@
 
                 let currencyCode = _.isNull(account) ? '' : account.currency;
                 return this.currencyObject.getClassFromCode(currencyCode);
+            },
+            toggleButtonProperties: function(){
+                return {
+                    labels: {checked: 'Enabled', unchecked: 'Disabled'},
+                    colors: {checked: this.colorInfo, unchecked: this.colorGreyLight},
+                    height: 40,
+                    width: 200,
+                };
             },
         },
         methods: {

--- a/resources/assets/js/components/stats/chart-defaults/pie-chart.vue
+++ b/resources/assets/js/components/stats/chart-defaults/pie-chart.vue
@@ -1,0 +1,21 @@
+<script>
+    import { Pie } from 'vue-chartjs';
+
+    export default {
+        name: "pie-chart",
+        extends: Pie,
+        props: {
+            chartData: {
+                type: Object,
+                default: null
+            },
+            options: {
+                type: Object,
+                default: null
+            }
+        },
+        mounted () {
+            this.renderChart(this.chartData, this.options)
+        }
+    }
+</script>

--- a/resources/assets/js/components/stats/distribution-chart.vue
+++ b/resources/assets/js/components/stats/distribution-chart.vue
@@ -54,10 +54,11 @@
     import {statsChartMixin} from "../../mixins/stats-chart-mixin";
     import {tagsObjectMixin} from "../../mixins/tags-object-mixin";
     import {ToggleButton} from 'vue-js-toggle-button';
+    import {bulmaColorsMixin} from "../../mixins/bulma-colors-mixin";
 
     export default {
         name: "distribution-chart",
-        mixins: [entriesObjectMixin, statsChartMixin, tagsObjectMixin],
+        mixins: [bulmaColorsMixin, entriesObjectMixin, statsChartMixin, tagsObjectMixin],
         components: {AccountAccountTypeTogglingSelector, bulmaCalendar, PieChart, ToggleButton},
         data: function(){
             return {
@@ -67,13 +68,6 @@
                 expenseOrIncomeToggle: true,
                 accountOrAccountTypeToggle: true,
                 accountOrAccountTypeId: '',
-
-                toggleButtonProperties: {
-                    colors: {checked: '#B5B5B5', unchecked: '#B5B5B5'},
-                    labels: {checked: 'Expense', unchecked: 'Income'},
-                    height: 40,
-                    width: 475,
-                },
             }
         },
         computed: {
@@ -125,7 +119,15 @@
                     }.bind(this), Object.create(null));
 
                 return _.sortBy(Object.values(standardisedChartData), function(o){ return o.x;});
-            }
+            },
+            toggleButtonProperties: function(){
+                return {
+                    colors: {checked: this.colorGreyLight, unchecked: this.colorGreyLight},
+                    labels: {checked: 'Expense', unchecked: 'Income'},
+                    height: 40,
+                    width: 475,
+                };
+            },
         },
         methods: {
             setChartTitle: function(isExpense, startDate, endDate){

--- a/resources/assets/js/components/stats/distribution-chart.vue
+++ b/resources/assets/js/components/stats/distribution-chart.vue
@@ -1,0 +1,168 @@
+<template>
+    <div id="stats-distribution">
+        <section id="stats-form-distribution" class="section">
+            <account-account-type-toggling-selector
+                id="distribution-chart"
+                v-bind:account-or-account-type-id="accountOrAccountTypeId"
+                v-bind:account-or-account-type-toggled="accountOrAccountTypeToggle"
+                v-on:update-select="accountOrAccountTypeId = $event"
+                v-on:update-toggle="accountOrAccountTypeToggle = $event"
+            ></account-account-type-toggling-selector>
+
+            <div class="field"><div class="control">
+                <toggle-button
+                    id="distribution-expense-or-income"
+                    v-model="expenseOrIncomeToggle"
+                    v-bind:value="expenseOrIncomeToggle"
+                    v-bind:labels="toggleButtonProperties.labels"
+                    v-bind:color="toggleButtonProperties.colors"
+                    v-bind:height="toggleButtonProperties.height"
+                    v-bind:width="toggleButtonProperties.width"
+                    v-bind:sync="true"
+                />
+            </div></div>
+
+            <div class="field">
+                <bulma-calendar
+                    ref="distributionStatsChartBulmaCalendar"
+                ></bulma-calendar>
+            </div>
+
+            <div class="field"><div class="control">
+                <button class="button is-primary generate-stats" v-on:click="makeRequest"><i class="fas fa-chart-pie"></i>Generate Chart</button>
+            </div></div>
+        </section>
+        <hr/>
+        <section v-if="areEntriesAvailable" class="section stats-results-distribution">
+            <pie-chart
+                v-if="dataLoaded"
+                v-bind:chart-data="this.chartData"
+                v-bind:options="this.chartOptions"
+            >Your browser does not support the canvas element.</pie-chart>
+        </section>
+        <section v-else class="section has-text-centered has-text-weight-semibold is-size-6 stats-results-distribution">
+            No data available
+        </section>
+    </div>
+</template>
+
+<script>
+    import AccountAccountTypeTogglingSelector from "../account-account-type-toggling-selector";
+    import bulmaCalendar from "../bulma-calendar";
+    import PieChart from './chart-defaults/pie-chart';
+    import {entriesObjectMixin} from "../../mixins/entries-object-mixin";
+    import {statsChartMixin} from "../../mixins/stats-chart-mixin";
+    import {tagsObjectMixin} from "../../mixins/tags-object-mixin";
+    import {ToggleButton} from 'vue-js-toggle-button';
+
+    export default {
+        name: "distribution-chart",
+        mixins: [entriesObjectMixin, statsChartMixin, tagsObjectMixin],
+        components: {AccountAccountTypeTogglingSelector, bulmaCalendar, PieChart, ToggleButton},
+        data: function(){
+            return {
+                chartConfig: {
+                    titleText: "Generated data"
+                },
+                expenseOrIncomeToggle: true,
+                accountOrAccountTypeToggle: true,
+                accountOrAccountTypeId: '',
+
+                toggleButtonProperties: {
+                    colors: {checked: '#B5B5B5', unchecked: '#B5B5B5'},
+                    labels: {checked: 'Expense', unchecked: 'Income'},
+                    height: 40,
+                    width: 475,
+                },
+            }
+        },
+        computed: {
+            getBulmaCalendar: function(){
+                return this.$refs.distributionStatsChartBulmaCalendar;
+            },
+            chartData: function(){
+                let chartData = this.standardiseData;
+                let chartBgColors = [];
+                for(let i=0; i<chartData.length; i++){
+                    chartBgColors.push(this.randomColor());
+                }
+
+                return {
+                    labels: chartData.map(function(d){ return d.x }),
+                    datasets: [{
+                        data: chartData.map(function(d){ return d.y }),
+                        backgroundColor: chartBgColors
+                    }]
+                };
+            },
+            chartOptions: function(){
+                return {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    title: {
+                        display: true,
+                        text: this.chartConfig.titleText
+                    },
+                }
+            },
+            standardiseData: function(){
+                let standardisedChartData = [];
+
+                this.largeBatchEntryData
+                    .forEach(function(entryDatum){
+                        let tempDatum = _.cloneDeep(entryDatum);
+                        if(tempDatum.tags.length === 0){
+                            tempDatum.tags.push(0);
+                        }
+                        tempDatum.tags.forEach(function(tag){
+                            let key = (tag === 0) ? 'untagged' : this.tagsObject.getNameById(tag);
+                            if(!standardisedChartData.hasOwnProperty(key)){
+                                standardisedChartData[key] = {x: key, y: 0}
+                            }
+                            standardisedChartData[key].y += parseFloat(tempDatum.entry_value);
+                            standardisedChartData[key].y = _.round(standardisedChartData[key].y, 2);
+                        }.bind(this));
+                    }.bind(this), Object.create(null));
+
+                return _.sortBy(Object.values(standardisedChartData), function(o){ return o.x;});
+            }
+        },
+        methods: {
+            setChartTitle: function(isExpense, startDate, endDate){
+                this.chartConfig.titleText = (isExpense ? "Expense" : "Income")
+                    +" Distribution ["+startDate+" - "+endDate+"]";
+            },
+
+            makeRequest: function(){
+                this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_SHOW);
+
+                let chartDataFilterParameters = {
+                    start_date: this.getBulmaCalendar.calendarStartDate(),
+                    end_date: this.getBulmaCalendar.calendarEndDate(),
+                };
+
+                chartDataFilterParameters.expense = this.expenseOrIncomeToggle;
+
+                if(this.accountOrAccountTypeToggle === true){
+                    chartDataFilterParameters.account = this.accountOrAccountTypeId;
+                } else {
+                    chartDataFilterParameters.account_type = this.accountOrAccountTypeId;
+                }
+
+                this.setChartTitle(chartDataFilterParameters.expense, chartDataFilterParameters.start_date, chartDataFilterParameters.end_date);
+                this.multiPageDataFetch(chartDataFilterParameters);
+            },
+        },
+        mounted: function(){
+            this.getBulmaCalendar.setBulmaCalendarDateRange(this.currentMonthStartDate, this.currentMonthEndDate);
+        }
+    }
+</script>
+
+<style lang="scss" scoped>
+    @import '../../../sass/stats-chart';
+
+    .vue-js-switch#distribution-expense-or-income{
+        font-size: 1rem;
+    }
+</style>

--- a/resources/assets/js/components/stats/stats-nav.vue
+++ b/resources/assets/js/components/stats/stats-nav.vue
@@ -18,6 +18,14 @@
             </span> Trending
         </a>
         <a class="panel-block"
+           v-on:click="showDistributionChart"
+           v-bind:class="{'is-active': isVisibleChart.distribution}"
+        >
+            <span class="panel-icon">
+                <i class="fas fa-chart-pie" aria-hidden="true"></i>
+            </span> Distribution
+        </a>
+        <a class="panel-block"
             v-on:click="showTagsChart"
             v-bind:class="{'is-active': isVisibleChart.tags}"
             >
@@ -47,6 +55,10 @@
                 this.makeChartVisible(this.chartNameTags);
                 this.$eventHub.broadcast(this.$eventHub.EVENT_STATS_TAGS);
             },
+            showDistributionChart: function(){
+                this.makeChartVisible(this.chartNameDistribution);
+                this.$eventHub.broadcast(this.$eventHub.EVENT_STATS_DISTRIBUTION);
+            }
         },
         mounted: function(){
             // check which chart is supposed to be visible, then broadcast which chart should be visible

--- a/resources/assets/js/components/stats/stats.vue
+++ b/resources/assets/js/components/stats/stats.vue
@@ -2,11 +2,13 @@
     <div id="stats-display">
         <summary-chart v-show="isVisibleChart.summary"></summary-chart>
         <trending-chart v-show="isVisibleChart.trending"></trending-chart>
+        <distribution-chart v-show="isVisibleChart.distribution"></distribution-chart>
         <tags-chart v-show="isVisibleChart.tags"></tags-chart>
     </div>
 </template>
 
 <script>
+    import DistributionChart from "./distribution-chart";
     import SummaryChart from "./summary-chart";
     import TrendingChart from "./trending-chart";
     import TagsChart from "./tags-chart";
@@ -15,7 +17,7 @@
     export default {
         name: "stats",
         mixins: [statsNavMixin],
-        components: {SummaryChart, TagsChart, TrendingChart},
+        components: {DistributionChart, SummaryChart, TagsChart, TrendingChart},
         created: function(){
             this.$eventHub.listen(this.$eventHub.EVENT_STATS_SUMMARY, function(){
                 this.makeChartVisible(this.chartNameSummary);
@@ -25,6 +27,9 @@
             }.bind(this));
             this.$eventHub.listen(this.$eventHub.EVENT_STATS_TAGS, function(){
                 this.makeChartVisible(this.chartNameTags);
+            }.bind(this));
+            this.$eventHub.listen(this.$eventHub.EVENT_STATS_DISTRIBUTION, function(){
+                this.makeChartVisible(this.chartNameDistribution);
             }.bind(this));
         }
     }

--- a/resources/assets/js/components/stats/summary-chart.vue
+++ b/resources/assets/js/components/stats/summary-chart.vue
@@ -16,7 +16,7 @@
             </div>
 
             <div class="field"><div class="control">
-                <button class="button is-primary generate-stats" v-on:click="displayData"><i class="fas fa-chart-bar"></i>Generate Tables</button>
+                <button class="button is-primary generate-stats" v-on:click="displayData"><i class="fas fa-table"></i>Generate Tables</button>
             </div></div>
         </section>
         <hr />

--- a/resources/assets/js/components/stats/trending-chart.vue
+++ b/resources/assets/js/components/stats/trending-chart.vue
@@ -159,6 +159,7 @@
                             standardisedChartData.push(this[key]);
                         }
                         this[key].y += datum.y;
+                        this[key].y = _.round(datum.y, 2);
                     }, Object.create(null));
 
                 return standardisedChartData;

--- a/resources/assets/js/components/stats/trending-chart.vue
+++ b/resources/assets/js/components/stats/trending-chart.vue
@@ -16,7 +16,7 @@
             </div>
 
             <div class="field"><div class="control">
-                <button class="button is-primary generate-stats" v-on:click="displayData"><i class="fas fa-chart-bar"></i>Generate Chart</button>
+                <button class="button is-primary generate-stats" v-on:click="displayData"><i class="fas fa-chart-area"></i>Generate Chart</button>
             </div></div>
         </section>
 

--- a/resources/assets/js/components/transfer-modal.vue
+++ b/resources/assets/js/components/transfer-modal.vue
@@ -199,13 +199,6 @@
                     tags: [],
                     attachments: []
                 },
-
-                toggleButtonProperties: {
-                    colors: {'checked': '#ffcc00', 'unchecked': '#00d1b2'},
-                    height: 40,
-                    labels: {'checked': 'Expense', 'unchecked': 'Income'},
-                    width: 200,
-                },
             }
         },
         computed: {

--- a/resources/assets/js/mixins/bulma-colors-mixin.js
+++ b/resources/assets/js/mixins/bulma-colors-mixin.js
@@ -1,0 +1,24 @@
+export const bulmaColorsMixin = {
+
+    computed: {
+        // values taken from https://bulma.io/documentation/overview/colors/
+        colorWhite: function(){ return "hsl(0, 0%, 100%)"; },
+        colorBlack: function(){ return "hsl(0, 0%, 4%)"; },
+        colorLight: function(){ return "hsl(0, 0%, 96%)"; },
+        colorDark: function(){ return "hsl(0, 0%, 21%)"; },
+        colorPrimary: function(){ return "hsl(171, 100%, 41%)"; },
+        colorLink: function(){ return "hsl(217, 71%, 53%)"; },
+        colorInfo: function(){ return "hsl(204, 86%, 53%)"; },
+        colorSuccess: function(){ return "hsl(141, 53%, 53%)"; },
+        colorWarning: function(){ return "hsl(48, 100%, 67%)"; },
+        colorDanger: function(){ return "hsl(348, 100%, 61%)"; },
+        colorBlackBis: function(){ return "hsl(0, 0%, 7%)"; },
+        colorBlackTer: function(){ return "hsl(0, 0%, 14%)"; },
+        colorGreyDarker: function(){ return "hsl(0, 0%, 21%)"; },
+        colorGreyDark: function(){ return "hsl(0, 0%, 29%)"; },
+        colorGreyLight: function(){ return "hsl(0,0%,71%)"; },
+        colorGreyLighter: function(){ return "hsl(0,0%,86%)"; },
+        colorWhiteTer: function(){ return "hsl(0, 0%, 96%)"; },
+        colorWhiteBis: function(){ return "hsl(0, 0%, 98%)"; },
+    }
+};

--- a/resources/assets/js/mixins/entries-object-mixin.js
+++ b/resources/assets/js/mixins/entries-object-mixin.js
@@ -36,7 +36,6 @@ export const entriesObjectMixin = {
             this.largeBatchEntryData = [];
 
             // init data from page 0
-            this.largeBatchEntryData = this.rawEntriesData;
             this.chainBatchRequest(0, filterParameters);
         },
         dataHasBeenFetched: function(){

--- a/resources/assets/js/plugins/eventHub.js
+++ b/resources/assets/js/plugins/eventHub.js
@@ -61,7 +61,11 @@ export default {
                 /**
                  * @returns {string}
                  */
-                EVENT_STATS_TAGS: function(){ return 'stats-display-tags-chart' }
+                EVENT_STATS_TAGS: function(){ return 'stats-display-tags-chart' },
+                /**
+                 * @return {string}
+                 */
+                EVENT_STATS_DISTRIBUTION: function(){ return 'stats-display-distribution-char' },
             },
             methods: {
                 broadcast(event, data = null){

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -4,10 +4,12 @@ namespace Tests\Browser;
 
 use App\Entry;
 use App\Http\Controllers\Api\EntryController;
+use App\Traits\Tests\Dusk\BulmaColors as DuskTraitBulmaColors;
 use App\Traits\Tests\Dusk\Loading as DuskTraitLoading;
 use App\Traits\Tests\Dusk\Navbar as DuskTraitNavbar;
 use App\Traits\Tests\Dusk\Notification as DuskTraitNotification;
 use App\Traits\Tests\Dusk\TagsInput as DuskTraitTagsInput;
+use App\Traits\Tests\Dusk\ToggleButton as DuskTraitToggleButton;
 use App\Traits\Tests\WaitTimes;
 use Facebook\WebDriver\WebDriverBy;
 use Tests\Browser\Pages\HomePage;
@@ -29,10 +31,12 @@ class EntryModalExistingEntryTest extends DuskTestCase {
 
     use WaitTimes;
     use HomePageSelectors;
+    use DuskTraitBulmaColors;
     use DuskTraitLoading;
     use DuskTraitNavbar;
     use DuskTraitNotification;
     use DuskTraitTagsInput;
+    use DuskTraitToggleButton;
 
     private $_class_lock = "fa-lock";
     private $_class_unlock = "fa-unlock-alt";
@@ -45,10 +49,18 @@ class EntryModalExistingEntryTest extends DuskTestCase {
     private $_class_existing_attachment = "existing-attachment";
     private $_modal_id_prefix = "#entry-";
 
+    public function __construct($name = null, array $data = [], $dataName = ''){
+        parent::__construct($name, $data, $dataName);
+        $this->_color_expense_switch_expense = self::$COLOR_WARNING_HEX;
+        $this->_color_expense_switch_income = self::$COLOR_PRIMARY_HEX;
+    }
+
     public function providerUnconfirmedEntry(){
         return [
-            "Expense"=>[$this->_selector_table_unconfirmed_expense, $this->_label_expense_switch_expense],  // test 1/25
-            "Income"=>[$this->_selector_table_unconfirmed_income, $this->_label_expense_switch_income],     // test 2/25
+            // test 1/25
+            "Expense"=>[$this->_selector_table_unconfirmed_expense, $this->_label_expense_switch_expense, $this->_color_expense_switch_expense],
+            // test 2/25
+            "Income"=>[$this->_selector_table_unconfirmed_income, $this->_label_expense_switch_income, $this->_color_expense_switch_income],
         ];
     }
 
@@ -56,20 +68,21 @@ class EntryModalExistingEntryTest extends DuskTestCase {
      * @dataProvider providerUnconfirmedEntry
      * @param string $data_entry_selector
      * @param string $data_expense_switch_label
+     * @param string $expense_switch_colour
      *
      * @throws Throwable
      *
      * @group entry-modal-1
      * test (see provider)/25
      */
-    public function testClickingOnEntryTableEditButtonOfUnconfirmedEntry($data_entry_selector, $data_expense_switch_label){
-        $this->browse(function(Browser $browser) use ($data_entry_selector, $data_expense_switch_label){
+    public function testClickingOnEntryTableEditButtonOfUnconfirmedEntry($data_entry_selector, $data_expense_switch_label, $expense_switch_colour){
+        $this->browse(function(Browser $browser) use ($data_entry_selector, $data_expense_switch_label, $expense_switch_colour){
             $browser
                 ->visit(new HomePage());
             $this->waitForLoadingToStop($browser);
             $browser
                 ->openExistingEntryModal($data_entry_selector)
-                ->with($this->_selector_modal_entry, function($entry_modal) use ($data_expense_switch_label){
+                ->with($this->_selector_modal_entry, function($entry_modal) use ($data_expense_switch_label, $expense_switch_colour){
                     $entry_id = $entry_modal->value($this->_selector_modal_entry_field_entry_id);
                     $this->assertNotEmpty($entry_id);
                     $entry_data = $this->getApiEntry($entry_id);
@@ -84,15 +97,15 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                             $this->assertContains($this->_class_light_grey_text, $entry_confirm_class);
                         })
 
-                        ->with($this->_selector_modal_body, function($modal_body) use ($entry_data, $data_expense_switch_label){
+                        ->with($this->_selector_modal_body, function($modal_body) use ($entry_data, $data_expense_switch_label, $expense_switch_colour){
                             $modal_body
                                 ->assertInputValue($this->_selector_modal_entry_field_date, $entry_data['entry_date'])
                                 ->assertInputValue($this->_selector_modal_entry_field_value, $entry_data['entry_value'])
                                 ->assertSelected($this->_selector_modal_entry_field_account_type, $entry_data['account_type_id'])
                                 ->assertInputValue($this->_selector_modal_entry_field_memo, $entry_data['memo'])
                                 ->assertSee($this->_label_account_type_meta_account_name)
-                                ->assertSee($this->_label_account_type_meta_last_digits)
-                                ->assertSee($data_expense_switch_label);
+                                ->assertSee($this->_label_account_type_meta_last_digits);
+                            $this->assertToggleButtonState($modal_body, $this->_selector_modal_entry_field_expense, $data_expense_switch_label, $expense_switch_colour);
                         })
 
                         ->with($this->_selector_modal_foot, function($modal_foot){
@@ -112,8 +125,10 @@ class EntryModalExistingEntryTest extends DuskTestCase {
 
     public function providerConfirmedEntry(){
         return [
-            "Expense"=>[$this->_selector_table_confirmed_expense, $this->_label_expense_switch_expense],    // test 3/25
-            "Income"=>[$this->_selector_table_confirmed_income, $this->_label_expense_switch_income],       // test 4/25
+            // test 3/25
+            "Expense"=>[$this->_selector_table_confirmed_expense, $this->_label_expense_switch_expense, $this->_color_expense_switch_expense],
+            // test 4/25
+            "Income"=>[$this->_selector_table_confirmed_income, $this->_label_expense_switch_income, $this->_color_expense_switch_income],
         ];
     }
 
@@ -121,19 +136,20 @@ class EntryModalExistingEntryTest extends DuskTestCase {
      * @dataProvider providerConfirmedEntry
      * @param string $data_entry_selector
      * @param string $data_expense_switch_label
+     * @param string $expense_switch_color
      *
      * @throws Throwable
      *
      * @group entry-modal-1
      * test (see provider)/25
      */
-    public function testClickingOnEntryTableEditButtonOfConfirmedEntry($data_entry_selector, $data_expense_switch_label){
-        $this->browse(function(Browser $browser) use ($data_entry_selector, $data_expense_switch_label){
+    public function testClickingOnEntryTableEditButtonOfConfirmedEntry($data_entry_selector, $data_expense_switch_label, $expense_switch_color){
+        $this->browse(function(Browser $browser) use ($data_entry_selector, $data_expense_switch_label, $expense_switch_color){
             $browser->visit(new HomePage());
             $this->waitForLoadingToStop($browser);
             $browser
                 ->openExistingEntryModal($data_entry_selector)
-                ->with($this->_selector_modal_entry, function($entry_modal) use ($data_expense_switch_label){
+                ->with($this->_selector_modal_entry, function($entry_modal) use ($data_expense_switch_label, $expense_switch_color){
                     $entry_id = $entry_modal->value($this->_selector_modal_entry_field_entry_id);
                     $this->assertNotEmpty($entry_id);
                     $entry_data = $this->getApiEntry($entry_id);
@@ -151,15 +167,16 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                             $this->assertEquals("true", $modal_head->attribute($this->_selector_modal_entry_btn_confirmed, "disabled"));
                         })
 
-                        ->with($this->_selector_modal_body, function($modal_body) use ($entry_data, $data_expense_switch_label){
+                        ->with($this->_selector_modal_body, function($modal_body) use ($entry_data, $data_expense_switch_label, $expense_switch_color){
                             $modal_body
                                 ->assertInputValue($this->_selector_modal_entry_field_date, $entry_data['entry_date'])
                                 ->assertInputValue($this->_selector_modal_entry_field_value, $entry_data['entry_value'])
                                 ->assertSelected($this->_selector_modal_entry_field_account_type, $entry_data['account_type_id'])
                                 ->assertSee($this->_label_account_type_meta_account_name)
                                 ->assertSee($this->_label_account_type_meta_last_digits)
-                                ->assertInputValue($this->_selector_modal_entry_field_memo, $entry_data['memo'])
-                                ->assertSee($data_expense_switch_label)
+                                ->assertInputValue($this->_selector_modal_entry_field_memo, $entry_data['memo']);
+                            $this->assertToggleButtonState($modal_body, $this->_selector_modal_entry_field_expense, $data_expense_switch_label, $expense_switch_color);
+                            $modal_body
                                 ->assertMissing($this->_selector_modal_entry_field_upload)
                                 ->assertDontSee($this->_label_file_upload);
 
@@ -376,7 +393,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
             $browser
                 ->with($this->_selector_modal_entry, function($entry_modal) use (&$attachment_count){
                     $attachments = $entry_modal->driver->findElements(WebDriverBy::className($this->_class_existing_attachment));
-                    $this->assertEquals($attachment_count-1, count($attachments), "Attachment was NOT removed from UI");
+                    $this->assertCount($attachment_count-1, $attachments, "Attachment was NOT removed from UI");
                 });
         });
     }
@@ -596,13 +613,13 @@ class EntryModalExistingEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser) use ($entry_selector, $selector_bool){
             $browser->visit(new HomePage());
             $this->waitForLoadingToStop($browser);
-            $browser->openExistingEntryModal($entry_selector.'.'.($selector_bool ? $this->_class_is_expense:$this->_class_is_income))
+            $browser
+                ->openExistingEntryModal($entry_selector.'.'.($selector_bool ? $this->_class_is_expense:$this->_class_is_income))
                 ->with($this->_selector_modal_body, function(Browser $modal_body) use ($selector_bool){
-                    $entry_expense_switch_text = $modal_body->text($this->_selector_modal_entry_field_expense);
-                    $this->assertEquals($selector_bool ? $this->_label_expense_switch_expense:$this->_label_expense_switch_income , $entry_expense_switch_text);
-                    $modal_body
-                        ->click($this->_selector_modal_entry_field_expense)
-                        ->pause(500); // 0.5 seconds - need to wait for the transition to complete after click;
+                    $toggle_label = $selector_bool ? $this->_label_expense_switch_expense:$this->_label_expense_switch_income;
+                    $toggle_colour = $selector_bool ? $this->_color_expense_switch_expense:$this->_color_expense_switch_income;
+                    $this->assertToggleButtonState($modal_body, $this->_selector_modal_entry_field_expense, $toggle_label, $toggle_colour);
+                    $this->toggleToggleButton($modal_body, $this->_selector_modal_entry_field_expense);
                 })
                 ->with($this->_selector_modal_foot, function(Browser $modal_foot){
                     $modal_foot->click($this->_selector_modal_entry_btn_save);
@@ -611,8 +628,9 @@ class EntryModalExistingEntryTest extends DuskTestCase {
             $browser
                 ->openExistingEntryModal($entry_selector.'.'.($selector_bool?$this->_class_is_income:$this->_class_is_expense))
                 ->with($this->_selector_modal_body, function(Browser $modal_body) use ($selector_bool){
-                    $entry_expense_switch_text = $modal_body->text($this->_selector_modal_entry_field_expense);
-                    $this->assertEquals(($selector_bool?$this->_label_expense_switch_income:$this->_label_expense_switch_expense), $entry_expense_switch_text);
+                    $toggle_label = $selector_bool ? $this->_label_expense_switch_income:$this->_label_expense_switch_expense;
+                    $toggle_colour = $selector_bool ? $this->_color_expense_switch_income:$this->_color_expense_switch_expense;
+                    $this->assertToggleButtonState($modal_body, $this->_selector_modal_entry_field_expense, $toggle_label, $toggle_colour);
                 });
         });
     }
@@ -658,13 +676,14 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                     $entry_modal
                         ->with($this->_selector_modal_body, function(Browser $modal_body) use ($transfer_entry_data){
                             $expense_switch_label = $transfer_entry_data['expense'] ? $this->_label_expense_switch_expense : $this->_label_expense_switch_income;
+                            $expense_switch_colour = $transfer_entry_data['expense'] ? $this->_color_expense_switch_expense : $this->_color_expense_switch_income;
 
                             $modal_body
                                 ->assertInputValue($this->_selector_modal_entry_field_date, $transfer_entry_data['entry_date'])
                                 ->assertInputValue($this->_selector_modal_entry_field_value, $transfer_entry_data['entry_value'])
                                 ->assertSelected($this->_selector_modal_entry_field_account_type, $transfer_entry_data['account_type_id'])
-                                ->assertInputValue($this->_selector_modal_entry_field_memo, $transfer_entry_data['memo'])
-                                ->assertSeeIn($this->_selector_modal_entry_field_expense, $expense_switch_label);
+                                ->assertInputValue($this->_selector_modal_entry_field_memo, $transfer_entry_data['memo']);
+                            $this->assertToggleButtonState($modal_body, $this->_selector_modal_entry_field_expense, $expense_switch_label, $expense_switch_colour);
                         })
                         ->with($this->_selector_modal_head, function(Browser $modal_head) use ($transfer_entry_data){
                             $modal_entry_id = $modal_head->value($this->_selector_modal_entry_field_entry_id);
@@ -676,8 +695,8 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                                 ->assertVisible($this->_selector_modal_entry_btn_transfer)
                                 ->click($this->_selector_modal_entry_btn_transfer);
                         });
-                });
-            $browser
+                })
+
                 ->assertVisible($this->_selector_modal_entry)
                 ->with($this->_selector_modal_entry, function(Browser $entry_modal) use ($entry_data){
                     $entry_modal
@@ -688,8 +707,8 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                                 ->assertInputValue($this->_selector_modal_entry_field_date, $entry_data['entry_date'])
                                 ->assertInputValue($this->_selector_modal_entry_field_value, $entry_data['entry_value'])
                                 ->assertSelected($this->_selector_modal_entry_field_account_type, $entry_data['account_type_id'])
-                                ->assertInputValue($this->_selector_modal_entry_field_memo, $entry_data['memo'])
-                                ->assertSeeIn($this->_selector_modal_entry_field_expense, $expense_switch_label);
+                                ->assertInputValue($this->_selector_modal_entry_field_memo, $entry_data['memo']);
+                            $this->assertToggleButtonState($modal_body, $this->_selector_modal_entry_field_expense, $expense_switch_label);
                         })
                         ->with($this->_selector_modal_head, function(Browser $modal_head) use ($entry_data){
                             $modal_entry_id = $modal_head->value($this->_selector_modal_entry_field_entry_id);

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -676,14 +676,13 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                     $entry_modal
                         ->with($this->_selector_modal_body, function(Browser $modal_body) use ($transfer_entry_data){
                             $expense_switch_label = $transfer_entry_data['expense'] ? $this->_label_expense_switch_expense : $this->_label_expense_switch_income;
-                            $expense_switch_colour = $transfer_entry_data['expense'] ? $this->_color_expense_switch_expense : $this->_color_expense_switch_income;
 
                             $modal_body
                                 ->assertInputValue($this->_selector_modal_entry_field_date, $transfer_entry_data['entry_date'])
                                 ->assertInputValue($this->_selector_modal_entry_field_value, $transfer_entry_data['entry_value'])
                                 ->assertSelected($this->_selector_modal_entry_field_account_type, $transfer_entry_data['account_type_id'])
                                 ->assertInputValue($this->_selector_modal_entry_field_memo, $transfer_entry_data['memo']);
-                            $this->assertToggleButtonState($modal_body, $this->_selector_modal_entry_field_expense, $expense_switch_label, $expense_switch_colour);
+                            $this->assertToggleButtonState($modal_body, $this->_selector_modal_entry_field_expense, $expense_switch_label);
                         })
                         ->with($this->_selector_modal_head, function(Browser $modal_head) use ($transfer_entry_data){
                             $modal_entry_id = $modal_head->value($this->_selector_modal_entry_field_entry_id);

--- a/tests/Browser/FilterModalTest.php
+++ b/tests/Browser/FilterModalTest.php
@@ -6,6 +6,7 @@ use App\Account;
 use App\AccountType;
 use App\Helpers\CurrencyHelper;
 use App\Traits\Tests\Dusk\AccountOrAccountTypeTogglingSelector as DuskTraitAccountOrAccountTypeTogglingSelector;
+use App\Traits\Tests\Dusk\BulmaColors as DuskTraitBulmaColors;
 use App\Traits\Tests\Dusk\Loading as DuskTraitLoading;
 use App\Traits\Tests\Dusk\Navbar as DuskTraitNavbar;
 use Facebook\WebDriver\WebDriverBy;
@@ -30,12 +31,20 @@ class FilterModalTest extends DuskTestCase {
 
     use HomePageSelectors;
     use DuskTraitAccountOrAccountTypeTogglingSelector;
+    use DuskTraitBulmaColors;
     use DuskTraitLoading;
     use DuskTraitNavbar;
 
     use WithFaker;
 
     private $_partial_selector_filter_tag = "#filter-tag-";
+
+    public function __construct($name = null, array $data = [], $dataName = ''){
+        parent::__construct($name, $data, $dataName);
+        $this->_account_or_account_type_toggling_selector_label_id = "filter-modal";
+        $this->_color_filter_switch_default = self::$COLOR_GREY_LIGHT_HEX;
+        $this->_color_filter_switch_active = self::$COLOR_INFO_HEX;
+    }
 
     /**
      * @throws Throwable
@@ -96,7 +105,7 @@ class FilterModalTest extends DuskTestCase {
                     );
 
                     // account/account-type selector
-                    $this->_id_label = 'filter-modal';
+                    $this->_account_or_account_type_toggling_selector_label_id = 'filter-modal';
                     $this->assertDefaultStateOfAccountOrAccountTypeTogglingSelectorComponent($modal, $accounts);
 
                     // tags - button(s)
@@ -111,73 +120,61 @@ class FilterModalTest extends DuskTestCase {
                             ->assertSeeIn($tag_selector.'+label', $tag['name']);
                     }
 
-                    $modal
-                        // income - switch
-                        ->assertSee("Income:")
-                        ->assertVisible($this->_selector_modal_filter_field_switch_income)
-                        ->assertSeeIn($this->_selector_modal_filter_field_switch_income, $this->_label_switch_disabled);
-                    $this->assertElementColour(
+                    // income - switch
+                    $modal->assertSee("Income:");
+                    $this->assertToggleButtonState(
                         $modal,
-                        $this->_selector_modal_filter_field_switch_income.' '.$this->_class_switch_core,
+                        $this->_selector_modal_filter_field_switch_income,
+                        $this->_label_switch_disabled,
                         $this->_color_filter_switch_default
                     );
 
-                        // expense - switch
-                    $modal
-                        ->assertSee("Expense:")
-                        ->assertVisible($this->_selector_modal_filter_field_switch_expense)
-                        ->assertSeeIn($this->_selector_modal_filter_field_switch_expense, $this->_label_switch_disabled);
-                    $this->assertElementColour(
+                    // expense - switch
+                    $modal->assertSee("Expense:");
+                    $this->assertToggleButtonState(
                         $modal,
-                        $this->_selector_modal_filter_field_switch_expense.' '.$this->_class_switch_core,
+                        $this->_selector_modal_filter_field_switch_expense,
+                        $this->_label_switch_disabled,
                         $this->_color_filter_switch_default
                     );
 
-                        // has attachment - switch
-                    $modal
-                        ->assertSee("Has Attachment(s):")
-                        ->assertVisible($this->_selector_modal_filter_field_switch_has_attachment)
-                        ->assertSeeIn($this->_selector_modal_filter_field_switch_has_attachment, $this->_label_switch_disabled);
-                    $this->assertElementColour(
+                    // has attachment - switch
+                    $modal->assertSee("Has Attachment(s):");
+                    $this->assertToggleButtonState(
                         $modal,
-                        $this->_selector_modal_filter_field_switch_has_attachment.' '.$this->_class_switch_core,
+                        $this->_selector_modal_filter_field_switch_has_attachment,
+                        $this->_label_switch_disabled,
                         $this->_color_filter_switch_default
                     );
 
-                        // no attachment - switch
-                    $modal
-                        ->assertSee("No Attachment(s):")
-                        ->assertVisible($this->_selector_modal_filter_field_switch_no_attachment)
-                        ->assertSeeIn($this->_selector_modal_filter_field_switch_no_attachment, $this->_label_switch_disabled);
-                    $this->assertElementColour(
+                    // no attachment - switch
+                    $modal->assertSee("No Attachment(s):");
+                    $this->assertToggleButtonState(
                         $modal,
-                        $this->_selector_modal_filter_field_switch_no_attachment.' '.$this->_class_switch_core,
+                        $this->_selector_modal_filter_field_switch_no_attachment,
+                        $this->_label_switch_disabled,
                         $this->_color_filter_switch_default
                     );
 
-                        // is transfer - switch
-                    $modal
-                        ->assertSee("Transfer:")
-                        ->assertVisible($this->_selector_modal_filter_field_switch_transfer)
-                        ->assertSeeIn($this->_selector_modal_filter_field_switch_transfer, $this->_label_switch_disabled);
-                    $this->assertElementColour(
+                    // is transfer - switch
+                    $modal->assertSee("Transfer:");
+                    $this->assertToggleButtonState(
                         $modal,
-                        $this->_selector_modal_filter_field_switch_transfer.' '.$this->_class_switch_core,
+                        $this->_selector_modal_filter_field_switch_transfer,
+                        $this->_label_switch_disabled,
                         $this->_color_filter_switch_default
                     );
 
-                        // unconfirmed - switch
-                    $modal
-                        ->assertSee("Not Confirmed:")
-                        ->assertVisible($this->_selector_modal_filter_field_switch_unconfirmed)
-                        ->assertSeeIn($this->_selector_modal_filter_field_switch_unconfirmed, $this->_label_switch_disabled);
-                    $this->assertElementColour(
+                    // unconfirmed - switch
+                    $modal->assertSee("Not Confirmed:");
+                    $this->assertToggleButtonState(
                         $modal,
-                        $this->_selector_modal_filter_field_switch_unconfirmed.' '.$this->_class_switch_core,
+                        $this->_selector_modal_filter_field_switch_unconfirmed,
+                        $this->_label_switch_disabled,
                         $this->_color_filter_switch_default
                     );
 
-                        // min range - input
+                    // min range - input
                     $modal
                         ->assertSee("Min Range:")
                         ->assertVisible($this->_selector_modal_filter_field_min_value)
@@ -188,8 +185,8 @@ class FilterModalTest extends DuskTestCase {
                         $this->_selector_modal_filter_field_min_value.' is not type="text"'
                     );
 
+                    // max range - input
                     $modal
-                        // max range - input
                         ->assertSee("Max Range:")
                         ->assertVisible($this->_selector_modal_filter_field_max_value)
                         ->assertInputValue($this->_selector_modal_filter_field_max_value, "");
@@ -236,7 +233,7 @@ class FilterModalTest extends DuskTestCase {
         $filter_modal_field_selectors = [
             $this->_selector_modal_filter_field_start_date,
             $this->_selector_modal_filter_field_end_date,
-            $this->_selector_modal_filter_field_account_and_account_type,
+            self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT,
             $this->_selector_modal_filter_field_tags,
             $this->_selector_modal_filter_field_switch_income,
             $this->_selector_modal_filter_field_switch_expense,
@@ -360,35 +357,16 @@ class FilterModalTest extends DuskTestCase {
             $this->openFilterModal($browser);
             $browser
                 ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function(Browser $modal) use ($has_disabled_account, $has_disabled_account_type, $accounts, $account_types){
-                    $modal
-                        ->assertVisible($this->getSwitchAccountAndAccountTypeId())
-                        ->assertVisible($this->_selector_modal_filter_field_account_and_account_type)
-
-                        ->assertSeeIn($this->getSwitchAccountAndAccountTypeId(), "Account");
-                    $this->assertElementColour($modal, $this->getSwitchAccountAndAccountTypeId().' '.$this->_class_switch_core, $this->_color_filter_switch_default);
+                    $this->assertDefaultStateOfAccountOrAccountTypeTogglingSelectorComponent($modal, $accounts);
 
                     if($has_disabled_account){
-                        $modal
-                            ->assertVisible($this->_selector_modal_filter_field_checkbox_show_disabled_label)
-                            ->assertSeeIn($this->_selector_modal_filter_field_checkbox_show_disabled_label, $this->_label_checkbox_show_disabled);
+                        $this->assertShowDisabledAccountOrAccountTypeCheckboxIsVisible($modal);
+                        $this->toggleShowDisabledAccountOrAccountTypeCheckbox($modal);
+                        $this->assertSelectOptionValuesOfAccountOrAccountType($modal, $accounts);
+                        // click again to reset state for account-types
+                        $this->toggleShowDisabledAccountOrAccountTypeCheckbox($modal);
                     } else {
-                        $modal->assertMissing($this->_selector_modal_filter_field_checkbox_show_disabled);
-                    }
-
-                    $modal
-                        ->assertSelected($this->_selector_modal_filter_field_account_and_account_type, "")
-                        ->assertSeeIn($this->_selector_modal_filter_field_account_and_account_type, $this->_label_select_option_filter_default)
-                        ->assertSelectHasOption($this->_selector_modal_filter_field_account_and_account_type, "")
-                        ->assertSelectHasOptions($this->_selector_modal_filter_field_account_and_account_type, collect($accounts)->where('disabled', false)->pluck('id')->toArray());
-
-                    if($has_disabled_account){
-                        $modal
-                            ->click($this->_selector_modal_filter_field_checkbox_show_disabled_label)
-                            ->assertSelectHasOptions(
-                                $this->_selector_modal_filter_field_account_and_account_type,
-                                collect($accounts)->pluck('id')->toArray()
-                            )
-                            ->click($this->_selector_modal_filter_field_checkbox_show_disabled_label);  // click again to reset state for account-types
+                        $this->assertShowDisabledAccountOrAccountTypeCheckboxIsNotVisible($modal);
                     }
 
                     // test currency displayed in "Min Range" & "Max Range" fields is $
@@ -396,10 +374,9 @@ class FilterModalTest extends DuskTestCase {
                     $this->assertContains($this->_class_icon_dollar, $modal->attribute($this->_selector_modal_filter_field_max_value_icon, 'class'));
 
                     // select an account and confirm the name in the select changes
-                    $account_to_select = collect($accounts)->where('disabled', 0)->random(1)->first();
-                    $modal
-                        ->select($this->_selector_modal_filter_field_account_and_account_type, $account_to_select['id'])
-                        ->assertSeeIn($this->_selector_modal_filter_field_account_and_account_type, $account_to_select['name']);
+                    $account_to_select = collect($accounts)->where('disabled', 0)->random();
+                    $this->selectAccountOrAccountTypeValue($modal, $account_to_select['id']);
+                    $modal->assertSeeIn(self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT, $account_to_select['name']);
 
                     // test select account changes currency displayed in "Min Range" & "Max Range" fields
                     $fail_message = "account data:".json_encode($account_to_select);
@@ -414,48 +391,36 @@ class FilterModalTest extends DuskTestCase {
                         $fail_message
                     );
 
-                    $modal
-                        ->click($this->getSwitchAccountAndAccountTypeId())
-                        ->pause(self::$WAIT_ONE_SECOND_IN_MILLISECONDS)
+                    $this->toggleAccountOrAccountTypeSwitch($modal);
+                    $this->assertToggleButtonState(
+                        $modal,
+                        $this->getSwitchAccountAndAccountTypeId($this->_account_or_account_type_toggling_selector_label_id),
+                        self::$LABEL_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_TOGGLE_ACCOUNTTYPE,
+                        $this->_color_filter_switch_default
+                    );
 
-                        ->assertSeeIn($this->getSwitchAccountAndAccountTypeId(), "Account Type");
-                    $this->assertElementColour($modal, $this->getSwitchAccountAndAccountTypeId().' '.$this->_class_switch_core, $this->_color_filter_switch_default);
+                    $modal
+                        ->assertSelectHasOption(self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT, "")
+                        ->assertSelected(self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT, "")
+                        ->assertSeeIn(self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT, self::$LABEL_ACCOUNT_AND_ACCOUNT_TYPE_SELECT_OPTION_DEFAULT);
+                    $this->assertSelectOptionValuesOfAccountOrAccountType($modal, $account_types);
 
                     if($has_disabled_account_type){
-                        $modal
-                            ->assertVisible($this->_selector_modal_filter_field_checkbox_show_disabled_label)
-                            ->assertSeeIn($this->_selector_modal_filter_field_checkbox_show_disabled_label, $this->_label_checkbox_show_disabled);
+                        $this->assertShowDisabledAccountOrAccountTypeCheckboxIsVisible($modal);
+                        $this->toggleShowDisabledAccountOrAccountTypeCheckbox($modal);
+                        $this->assertSelectOptionValuesOfAccountOrAccountType($modal, $account_types);
                     } else {
-                        $modal->assertMissing($this->_selector_modal_filter_field_checkbox_show_disabled);
-                    }
-
-                    $modal
-                        ->assertSelected($this->_selector_modal_filter_field_account_and_account_type, "")
-                        ->assertSeeIn($this->_selector_modal_filter_field_account_and_account_type, $this->_label_select_option_filter_default)
-                        ->assertSelectHasOption($this->_selector_modal_filter_field_account_and_account_type, "")
-                        ->assertSelectHasOptions(
-                            $this->_selector_modal_filter_field_account_and_account_type,
-                            collect($account_types)->where('disabled', false)->pluck('id')->toArray()
-                        );
-
-                    if($has_disabled_account_type){
-                        $modal
-                            ->click($this->_selector_modal_filter_field_checkbox_show_disabled_label)
-                            ->assertSelectHasOptions(
-                                $this->_selector_modal_filter_field_account_and_account_type,
-                                collect($account_types)->pluck('id')->toArray()
-                            );
+                        $this->assertShowDisabledAccountOrAccountTypeCheckboxIsNotVisible($modal);
                     }
 
                     // test currency displayed in "Min Range" & "Max Range" fields is $
                     $this->assertContains($this->_class_icon_dollar, $modal->attribute($this->_selector_modal_filter_field_min_value_icon, 'class'));
                     $this->assertContains($this->_class_icon_dollar, $modal->attribute($this->_selector_modal_filter_field_max_value_icon, 'class'));
 
+                    // select an account and confirm the name in the select changes
                     $account_type_to_select = $this->faker->randomElement($account_types);
-                    $modal
-                        // select an account and confirm the name in the select changes
-                        ->select($this->_selector_modal_filter_field_account_and_account_type, $account_type_to_select['id'])
-                        ->assertSeeIn($this->_selector_modal_filter_field_account_and_account_type, $account_type_to_select['name']);
+                    $this->selectAccountOrAccountTypeValue($modal, $account_type_to_select['id']);
+                    $modal->assertSeeIn(self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT, $account_type_to_select['name']);
 
                     // test select account-type changes currency displayed in "Min Range" & "Max Range" fields
                     $account_from_account_type = collect($accounts)->where('id', '=', $account_type_to_select['account_id'])->first();
@@ -484,12 +449,12 @@ class FilterModalTest extends DuskTestCase {
 
     public function providerFlipSwitch(){
         return [
-            "flip income"=>['#filter-is-income'],               // test 12/25
-            "flip expense"=>['#filter-is-expense'],             // test 13/25
-            "flip has-attachment"=>['#filter-has-attachment'],  // test 14/25
-            "flip no-attachment"=>['#filter-no-attachment'],    // test 15/25
-            "flip transfer"=>['#filter-is-transfer'],           // test 16/25
-            "flip not confirmed"=>['#filter-unconfirmed']       // test 17/25
+            "flip income"=>[$this->_selector_modal_filter_field_switch_income],                 // test 12/25
+            "flip expense"=>[$this->_selector_modal_filter_field_switch_expense],               // test 13/25
+            "flip has-attachment"=>[$this->_selector_modal_filter_field_switch_has_attachment], // test 14/25
+            "flip no-attachment"=>[$this->_selector_modal_filter_field_switch_no_attachment],   // test 15/25
+            "flip transfer"=>[$this->_selector_modal_filter_field_switch_transfer],             // test 16/25
+            "flip not confirmed"=>[$this->_selector_modal_filter_field_switch_unconfirmed]      // test 17/25
         ];
     }
 
@@ -509,25 +474,19 @@ class FilterModalTest extends DuskTestCase {
             $this->openFilterModal($browser);
             $browser
                 ->with($this->_selector_modal_filter, function(Browser $modal) use ($switch_selector){
-                    $modal
-                        ->assertVisible($switch_selector)
-                        ->assertSeeIn($switch_selector, $this->_label_switch_disabled);
-                    $this->assertElementColour($modal, $switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_default);
-                    $modal
-                        ->click($switch_selector)
-                        ->pause(self::$WAIT_ONE_SECOND_IN_MILLISECONDS)
-                        ->assertSeeIn($switch_selector, $this->_label_switch_enabled);
-                    $this->assertElementColour($modal, $switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_active);
+                    $this->assertToggleButtonState($modal, $switch_selector, $this->_label_switch_disabled, $this->_color_filter_switch_default);
+                    $this->toggleToggleButton($modal, $switch_selector);
+                    $this->assertToggleButtonState($modal, $switch_selector, $this->_label_switch_enabled, $this->_color_filter_switch_active);
                 });
         });
     }
 
     public function providerFlippingCompanionSwitches(){
         return [
-            "flip income with expense"=>['#filter-is-income', '#filter-is-expense'],                        // test 18/25
-            "flip expense with income"=>['#filter-is-expense', '#filter-is-income'],                        // test 19/25
-            "flip has-attachment with no-attachment"=>['#filter-has-attachment', '#filter-no-attachment'],  // test 20/25
-            "flip no-attachment with has-attachment"=>['#filter-no-attachment', '#filter-has-attachment']   // test 21/25
+            "flip income with expense"=>[$this->_selector_modal_filter_field_switch_income, $this->_selector_modal_filter_field_switch_expense],                              // test 18/25
+            "flip expense with income"=>[$this->_selector_modal_filter_field_switch_expense, $this->_selector_modal_filter_field_switch_income],                              // test 19/25
+            "flip has-attachment with no-attachment"=>[$this->_selector_modal_filter_field_switch_has_attachment, $this->_selector_modal_filter_field_switch_no_attachment],  // test 20/25
+            "flip no-attachment with has-attachment"=>[$this->_selector_modal_filter_field_switch_no_attachment, $this->_selector_modal_filter_field_switch_has_attachment]   // test 21/25
         ];
     }
 
@@ -548,37 +507,24 @@ class FilterModalTest extends DuskTestCase {
             $this->openFilterModal($browser);
             $browser
                 ->with($this->_selector_modal_filter, function(Browser $modal) use ($init_switch_selector, $companion_switch_selector){
-                    $modal
-                        ->assertVisible($init_switch_selector)
-                        ->assertSeeIn($init_switch_selector, $this->_label_switch_disabled);
-                    $this->assertElementColour($modal, $init_switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_default);
-                    $modal
-                        ->assertVisible($companion_switch_selector)
-                        ->assertSeeIn($companion_switch_selector, $this->_label_switch_disabled);
-                    $this->assertElementColour($modal, $companion_switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_default);
-                    $modal
-                        ->click($init_switch_selector)
-                        ->pause(self::$WAIT_ONE_SECOND_IN_MILLISECONDS)
-                        ->assertSeeIn($init_switch_selector, $this->_label_switch_enabled);
-                    $this->assertElementColour($modal, $init_switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_active);
-                    $modal->assertSeeIn($companion_switch_selector, $this->_label_switch_disabled);
-                    $this->assertElementColour($modal, $companion_switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_default);
-                    $modal
-                        ->click($companion_switch_selector)
-                        ->pause(self::$WAIT_ONE_SECOND_IN_MILLISECONDS)
-                        ->assertSeeIn($companion_switch_selector, $this->_label_switch_enabled);
-                    $this->assertElementColour($modal, $companion_switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_active);
-                    $modal
-                        ->assertSeeIn($init_switch_selector, $this->_label_switch_disabled);
-                    $this->assertElementColour($modal, $init_switch_selector.' '.$this->_class_switch_core, $this->_color_filter_switch_default);
+                    $this->assertToggleButtonState($modal, $init_switch_selector, $this->_label_switch_disabled, $this->_color_filter_switch_default);
+                    $this->assertToggleButtonState($modal, $companion_switch_selector, $this->_label_switch_disabled, $this->_color_filter_switch_default);
+
+                    $this->toggleToggleButton($modal, $init_switch_selector);
+                    $this->assertToggleButtonState($modal, $init_switch_selector, $this->_label_switch_enabled, $this->_color_filter_switch_active);
+                    $this->assertToggleButtonState($modal, $companion_switch_selector, $this->_label_switch_disabled, $this->_color_filter_switch_default);
+
+                    $this->toggleToggleButton($modal, $companion_switch_selector);
+                    $this->assertToggleButtonState($modal, $companion_switch_selector, $this->_label_switch_enabled, $this->_color_filter_switch_active);
+                    $this->assertToggleButtonState($modal, $init_switch_selector, $this->_label_switch_disabled, $this->_color_filter_switch_default);
                 });
         });
     }
 
     public function providerRangeValueConvertsIntoDecimalOfTwoPlaces(){
         return [
-            'Min Range'=>['#filter-min-value'], // test 22/25
-            'Max Range'=>['#filter-max-value'], // test 23/25
+            'Min Range'=>[$this->_selector_modal_filter_field_min_value], // test 22/25
+            'Max Range'=>[$this->_selector_modal_filter_field_max_value], // test 23/25
         ];
     }
 
@@ -663,17 +609,17 @@ class FilterModalTest extends DuskTestCase {
 
                     $modal
                         ->type($this->_selector_modal_filter_field_start_date, $start_date)
-                        ->type($this->_selector_modal_filter_field_end_date, $start_date)
-                        ->click($this->getSwitchAccountAndAccountTypeId())
-                        ->select($this->_selector_modal_filter_field_account_and_account_type, $account_type['id']);
+                        ->type($this->_selector_modal_filter_field_end_date, $start_date);
+                    $this->toggleAccountOrAccountTypeSwitch($modal);
+                    $this->selectAccountOrAccountTypeValue($modal, $account_type['id']);
 
                     foreach($tags_to_select as $tag_to_select){
                         $modal->click($this->_selector_modal_filter_field_tags.' '.$this->_partial_selector_filter_tag.$tag_to_select['id'].'+label');
                     }
 
+                    $this->toggleToggleButton($modal, $this->faker->randomElement($companion_switch_set_1));
+                    $this->toggleToggleButton($modal, $this->faker->randomElement($companion_switch_set_2));
                     $modal
-                        ->click($this->faker->randomElement($companion_switch_set_1))
-                        ->click($this->faker->randomElement($companion_switch_set_2))
                         ->click($this->_selector_modal_filter_field_switch_transfer)
                         ->click($this->_selector_modal_filter_field_switch_unconfirmed)
                         ->type($this->_selector_modal_filter_field_max_value, "65.43")
@@ -693,20 +639,20 @@ class FilterModalTest extends DuskTestCase {
                     $modal
                         ->assertInputValue($this->_selector_modal_filter_field_start_date, '')
                         ->assertInputValue($this->_selector_modal_filter_field_end_date, '')
-                        ->assertSeeIn($this->getSwitchAccountAndAccountTypeId(), "Account")
-                        ->assertSelected($this->_selector_modal_filter_field_account_and_account_type, '');
+                        ->assertSelected(self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT, '')
+                        ->assertSeeIn(self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT, self::$LABEL_ACCOUNT_AND_ACCOUNT_TYPE_SELECT_OPTION_DEFAULT);
 
                     foreach($tags as $tag){
                         $modal->assertNotChecked($this->_selector_modal_filter_field_tags.' '.$this->_partial_selector_filter_tag.$tag['id']);
                     }
 
+                    $this->assertToggleButtonState($modal, $this->_selector_modal_filter_field_switch_income, $this->_label_switch_disabled, $this->_color_filter_switch_default);
+                    $this->assertToggleButtonState($modal, $this->_selector_modal_filter_field_switch_expense, $this->_label_switch_disabled, $this->_color_filter_switch_default);
+                    $this->assertToggleButtonState($modal, $this->_selector_modal_filter_field_switch_has_attachment, $this->_label_switch_disabled, $this->_color_filter_switch_default);
+                    $this->assertToggleButtonState($modal, $this->_selector_modal_filter_field_switch_no_attachment, $this->_label_switch_disabled, $this->_color_filter_switch_default);
+                    $this->assertToggleButtonState($modal, $this->_selector_modal_filter_field_switch_transfer, $this->_label_switch_disabled, $this->_color_filter_switch_default);
+                    $this->assertToggleButtonState($modal, $this->_selector_modal_filter_field_switch_unconfirmed, $this->_label_switch_disabled, $this->_color_filter_switch_default);
                     $modal
-                        ->assertSeeIn($this->_selector_modal_filter_field_switch_income, $this->_label_switch_disabled)
-                        ->assertSeeIn($this->_selector_modal_filter_field_switch_expense, $this->_label_switch_disabled)
-                        ->assertSeeIn($this->_selector_modal_filter_field_switch_has_attachment, $this->_label_switch_disabled)
-                        ->assertSeeIn($this->_selector_modal_filter_field_switch_no_attachment, $this->_label_switch_disabled)
-                        ->assertSeeIn($this->_selector_modal_filter_field_switch_transfer, $this->_label_switch_disabled)
-                        ->assertSeeIn($this->_selector_modal_filter_field_switch_unconfirmed, $this->_label_switch_disabled)
                         ->assertInputValue($this->_selector_modal_filter_field_min_value, "")
                         ->assertInputValue($this->_selector_modal_filter_field_max_value, "");
 
@@ -720,7 +666,7 @@ class FilterModalTest extends DuskTestCase {
         return [
             "Start Date"=>[$this->_selector_modal_filter_field_start_date],                         // test 1/25
             "End Date"=>[$this->_selector_modal_filter_field_end_date],                             // test 2/25
-            "Account&Account-type"=>[$this->_selector_modal_filter_field_account_and_account_type], // test 3/25
+            "Account&Account-type"=>[self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT],        // test 3/25
             "Tags"=>[$this->_partial_selector_filter_tag],                                          // test 4/25
             "Income"=>[$this->_selector_modal_filter_field_switch_income],                          // test 5/25
             "Expense"=>[$this->_selector_modal_filter_field_switch_expense],                        // test 6/25
@@ -760,18 +706,18 @@ class FilterModalTest extends DuskTestCase {
                             $modal->type($filter_param, $filter_value['typed']);
                             break;
 
-                        case $this->_selector_modal_filter_field_account_and_account_type:
+                        case self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT:
                             $is_account = $this->faker->boolean;
                             if($is_account){
                                 // account
                                 $filter_values = $this->getApiAccounts();
                             } else {
                                 // account-type
-                                $modal->click($this->getSwitchAccountAndAccountTypeId());
+                                $this->toggleAccountOrAccountTypeSwitch($modal);
                                 $filter_values = $this->getApiAccountTypes();
                             }
-                            $filter_value = collect($filter_values)->where('disabled', false)->random(1)->first();
-                            $modal->select($filter_param, $filter_value['id']);
+                            $filter_value = collect($filter_values)->where('disabled', false)->random();
+                            $this->selectAccountOrAccountTypeValue($modal, $filter_value['id']);
 
                             if($is_account){
                                 $account = Account::find_account_with_types($filter_value['id']);
@@ -795,7 +741,7 @@ class FilterModalTest extends DuskTestCase {
                         case $this->_selector_modal_filter_field_switch_no_attachment:
                         case $this->_selector_modal_filter_field_switch_transfer:
                         case $this->_selector_modal_filter_field_switch_unconfirmed:
-                            $modal->click($filter_param);
+                            $this->toggleToggleButton($modal, $filter_param);
                             break;
 
                         case $this->_selector_modal_filter_field_min_value:
@@ -842,7 +788,7 @@ class FilterModalTest extends DuskTestCase {
                                 );
                                 break;
 
-                            case $this->_selector_modal_filter_field_account_and_account_type:
+                            case self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT:
                                 // only rows with account-type(s)
                                 $row_entry_account_type = $table_row->findElement(WebDriverBy::cssSelector($this->_selector_table_row_account_type))->getText();
                                 if(is_array($filter_value)){
@@ -931,8 +877,8 @@ class FilterModalTest extends DuskTestCase {
                 // modify all (or at least most) fields
                 ->with($this->_selector_modal_filter.' '.$this->_selector_modal_body, function(Browser $modal) use (&$filter_value){
                     $accounts = $this->getApiAccounts();
-                    $filter_value = collect($accounts)->where('disabled', 0)->random(1)->first();
-                    $modal->select($this->_selector_modal_filter_field_account_and_account_type, $filter_value['id']);
+                    $filter_value = collect($accounts)->where('disabled', 0)->random();
+                    $this->selectAccountOrAccountTypeValue($modal, $filter_value['id']);
                 })
 
                 ->with($this->_selector_modal_filter.' '.$this->_selector_modal_foot, function($modal){
@@ -960,13 +906,6 @@ class FilterModalTest extends DuskTestCase {
                     $this->assertEquals($filter_value['name'], $account_name, "Could not find value at selector:".$panel->resolver->format($selector));
                 });
         });
-    }
-
-    /**
-     * @return string
-     */
-    private function getSwitchAccountAndAccountTypeId(){
-        return sprintf($this->_selector_pattern_modal_filter_field_switch_account_and_account_type, 'filter-modal');
     }
 
 }

--- a/tests/Browser/StatsDistributionTest.php
+++ b/tests/Browser/StatsDistributionTest.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Traits\Tests\Dusk\AccountOrAccountTypeTogglingSelector as DuskTraitAccountOrAccountTypeTogglingSelector;
+use App\Traits\Tests\Dusk\BatchFilterEntries as DuskTraitBatchFilterEntries;
+use App\Traits\Tests\Dusk\BulmaDatePicker as DuskTraitBulmaDatePicker;
+use App\Traits\Tests\Dusk\Loading as DuskTraitLoading;
+use App\Traits\Tests\Dusk\StatsSidePanel as DuskTraitStatsSidePanel;
+use App\Traits\Tests\InjectDatabaseStateIntoException;
+use Illuminate\Support\Collection;
+use Laravel\Dusk\Browser;
+use Tests\Browser\Pages\StatsPage;
+use Tests\DuskWithMigrationsTestCase as DuskTestCase;
+use Throwable;
+
+/**
+ * Class StatsDistributionTest
+ *
+ * @package Tests\Browser
+ *
+ * @group stats
+ * @group stats-distribution
+ */
+class StatsDistributionTest extends DuskTestCase {
+
+    use DuskTraitAccountOrAccountTypeTogglingSelector;
+    use DuskTraitBulmaDatePicker;
+    use DuskTraitBatchFilterEntries;
+    use DuskTraitLoading;
+    use DuskTraitStatsSidePanel;
+
+    use InjectDatabaseStateIntoException;
+
+    private static $SELECTOR_STATS_DISTRIBUTION = '#stats-distribution';
+    private static $SELECTOR_STATS_FORM_DISTRIBUTION = '#stats-form-distribution';
+    private static $SELECTOR_STATS_FORM_TOGGLE_EXPENSEINCOME = '#distribution-expense-or-income';
+    private static $SELECTOR_STATS_FORM_BUTTON_GENERATE = '.generate-stats';
+    private static $SELECTOR_STATS_RESULTS_AREA = ".stats-results-distribution";
+    private static $SELECTOR_CHART_DISTRIBUTION = "canvas#pie-chart";
+
+    private static $LABEL_FORM_TOGGLE_EXPENSEINCOME_DEFAULT = "Expense";
+    private static $LABEL_FORM_BUTTON_GENERATE = "Generate Chart";
+    private static $LABEL_NO_STATS_DATA = "No data available";
+
+    private static $VUE_KEY_STANDARDISEDATA = "standardiseData";
+
+    public function __construct($name = null, array $data = [], $dataName = ''){
+        parent::__construct($name, $data, $dataName);
+        $this->_account_or_account_type_toggling_selector_label_id = 'distribution-chart';
+    }
+
+    /**
+     * @throws Throwable
+     *
+     * @group stats-distribution-1
+     * test 1/25
+     */
+    public function testSelectDistributionSidebarOption(){
+        $this->browse(function(Browser $browser) {
+            $browser
+                ->visit(new StatsPage())
+                ->assertVisible(self::$SELECTOR_STATS_SIDE_PANEL);
+            $this->assertStatsSidePanelHeading($browser);
+            $this->clickStatsSidePanelOptionDistribution($browser);
+            $this->assertStatsSidePanelOptionIsActive($browser, self::$LABEL_STATS_SIDE_PANEL_OPTION_DISTRIBUTION);
+        });
+    }
+
+    /**
+     * @throws Throwable
+     *
+     * @group stats-distribution-1
+     * test 2/25
+     */
+    public function testFormHasCorrectElements(){
+        $accounts = $this->getApiAccounts();
+
+        $this->browse(function(Browser $browser) use ($accounts){
+            $browser->visit(new StatsPage());
+            $this->clickStatsSidePanelOptionDistribution($browser);
+            $browser
+                ->assertVisible(self::$SELECTOR_STATS_FORM_DISTRIBUTION)
+                ->with(self::$SELECTOR_STATS_FORM_DISTRIBUTION, function(Browser $form) use ($accounts){
+                    // account/account-type selector
+                    $this->assertDefaultStateOfAccountOrAccountTypeTogglingSelectorComponent($form, $accounts);
+
+                    // expense/income - switch
+                    $class_switch_core = ".v-switch-core";
+                    $color_switch_default = "#B5B5B5";
+                    $form
+                        ->assertVisible(self::$SELECTOR_STATS_FORM_TOGGLE_EXPENSEINCOME)
+                        ->assertSeeIn(self::$SELECTOR_STATS_FORM_TOGGLE_EXPENSEINCOME, self::$LABEL_FORM_TOGGLE_EXPENSEINCOME_DEFAULT);
+                    $this->assertElementColour($form, self::$SELECTOR_STATS_FORM_TOGGLE_EXPENSEINCOME.' '.$class_switch_core, $color_switch_default);
+
+                    // bulma date-picker
+                    $this->assertDefaultStateBulmaDatePicker($form);
+
+                    // button
+                    $form
+                        ->assertVisible(self::$SELECTOR_STATS_FORM_BUTTON_GENERATE)
+                        ->assertSeeIn(self::$SELECTOR_STATS_FORM_BUTTON_GENERATE, self::$LABEL_FORM_BUTTON_GENERATE);
+                    $button_classes = $form->attribute(self::$SELECTOR_STATS_FORM_BUTTON_GENERATE, 'class');
+                    $this->assertContains('is-primary', $button_classes);
+                });
+        });
+    }
+
+    /**
+     * @throws Throwable
+     *
+     * @group stats-distribution-1
+     * test 3/25
+     */
+    public function testDefaultDataResultsArea(){
+        $this->browse(function(Browser $browser){
+            $browser->visit(new StatsPage());
+            $this->clickStatsSidePanelOptionDistribution($browser);
+            $browser
+                ->assertVisible(self::$SELECTOR_STATS_RESULTS_AREA)
+                ->assertSeeIn(self::$SELECTOR_STATS_RESULTS_AREA, self::$LABEL_NO_STATS_DATA);
+        });
+    }
+
+    public function providerGenerateDistributionChart(){
+        $previous_year_start = date("Y-01-01", strtotime('-1 year'));
+        $today = date("Y-m-d");
+        //[$datepicker_start, $datepicker_end, $is_account_switch_toggled, $is_expense_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available]
+        return [
+            //  default state of account/account-types; expense; default date range
+            [null, null, false, false, false, false],                   // test 4/25
+            // default state of account/account-types; income; default date range
+            [null, null, false, true, false, false],                    // test 5/25
+            // default state of account/account-types; expense; date range a year past to today
+            [$previous_year_start, $today, false, false, false, false], // test 6/25
+            // default state of account/account-types; income; date range a year past to today
+            [$previous_year_start, $today, false, true, false, false],  // test 7/25
+            // random account; expense; date range a year past to today
+            [$previous_year_start, $today, false, false, true, false],  // test 8/25
+            // random account; income; date range a year past to today
+            [$previous_year_start, $today, false, true, true, false],   // test 9/25
+            // random account-type; expense; date range a year past to today
+            [$previous_year_start, $today, true, false, true, false],   // test 10/25
+            // random account-type; income; date range a year past to today
+            [$previous_year_start, $today, true, true, true, false],    // test 11/25
+            // random disabled account; expense; date range a year past to today
+            [$previous_year_start, $today, false, false, true, true],   // test 12/25
+            // random disabled account; income; date range a year past to today
+            [$previous_year_start, $today, false, true, true, true],    // test 13/25
+            // random disabled account-type; expense; date range a year past to today
+            [$previous_year_start, $today, true, false, true, true],    // test 14/25
+            // random disabled account-type; income; date range a year past to today
+            [$previous_year_start, $today, true, true, true, true],     // test 15/25
+        ];
+    }
+
+    /**
+     * @dataProvider providerGenerateDistributionChart
+     *
+     * @param string $datepicker_start
+     * @param string $datepicker_end
+     * @param bool $is_account_switch_toggled
+     * @param bool $is_expense_switch_toggled
+     * @param bool $is_random_selector_value
+     * @param bool $are_disabled_select_options_available
+     *
+     * @throws Throwable
+     *
+     * @group stats-distribution-1
+     * test (see provider)/25
+     */
+    public function testGenerateDistributionChart($datepicker_start, $datepicker_end, $is_account_switch_toggled, $is_expense_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available){
+        $accounts = collect($this->getApiAccounts());
+        $account_types = collect($this->getApiAccountTypes());
+        $tags = collect($this->getApiTags());
+
+        $this->setDatabaseStateInjectionPermission(self::$ALLOW_INJECT_DATABASE_STATE_ON_EXCEPTION);
+
+        $this->browse(function (Browser $browser) use ($datepicker_start, $datepicker_end, $is_account_switch_toggled, $is_expense_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $accounts, $account_types, $tags){
+            $filter_data = [];
+
+            $browser->visit(new StatsPage());
+            $this->clickStatsSidePanelOptionDistribution($browser);
+
+            $browser
+                ->assertVisible(self::$SELECTOR_STATS_FORM_DISTRIBUTION)
+                ->with(self::$SELECTOR_STATS_FORM_DISTRIBUTION, function(Browser $form) use ($is_expense_switch_toggled, $is_account_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $accounts, $account_types, &$filter_data, $datepicker_start, $datepicker_end){
+                    if($are_disabled_select_options_available){
+                        $this->toggleShowDisabledAccountOrAccountTypeCheckbox($form);
+                    }
+
+                    if($is_account_switch_toggled){
+                        // switch to account-types
+                        $this->toggleAccountOrAccountTypeSwitch($form);
+                        $account_or_account_type_id = $is_random_selector_value ? $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
+                    } else {
+                        // stay with accounts
+                        $account_or_account_type_id = $is_random_selector_value ? $accounts->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
+                    }
+                    $this->selectAccountOrAccountTypeValue($form, $account_or_account_type_id);
+                    $filter_data = $this->generateFilterArrayElementAccountOrAccountypeId($filter_data, $is_account_switch_toggled, $account_or_account_type_id);
+
+                    if($is_expense_switch_toggled){
+                        // expense/income - switch
+                        $form->click(self::$SELECTOR_STATS_FORM_TOGGLE_EXPENSEINCOME);
+                    }
+                    $filter_data = $this->generateFilterArrayElementExpense($filter_data, !$is_expense_switch_toggled);
+
+                    if(!is_null($datepicker_start) && !is_null($datepicker_end)){
+                        $this->setDateRange($form, $datepicker_start, $datepicker_end);
+                    } else {
+                        $datepicker_start = date('Y-m-01');
+                        $datepicker_end = date('Y-m-t');
+                    }
+                    $filter_data = $this->generateFilterArrayElementDatepicker($filter_data, $datepicker_start, $datepicker_end);
+
+                    $form->click(self::$SELECTOR_STATS_FORM_BUTTON_GENERATE);
+                });
+
+            $entries = $this->getBatchedFilteredEntries($filter_data);
+
+            $this->waitForLoadingToStop($browser);
+            $browser
+                ->assertDontSeeIn(self::$SELECTOR_STATS_RESULTS_AREA, self::$LABEL_NO_STATS_DATA)
+                ->with(self::$SELECTOR_STATS_RESULTS_AREA, function(Browser $stats_results_area){
+                    $stats_results_area->assertVisible(self::$SELECTOR_CHART_DISTRIBUTION);
+                })
+                ->assertVue(self::$VUE_KEY_STANDARDISEDATA, $this->standardiseData($entries, $tags), self::$SELECTOR_STATS_DISTRIBUTION);
+        });
+    }
+
+    /**
+     * @param Collection $entries
+     * @param Collection $tags
+     * @return array
+     */
+    private function standardiseData($entries, $tags){
+        $standardised_chart_data = [];
+
+        foreach($entries as $entry){
+            if(empty($entry['tags'])){
+                $entry['tags'][] = 0;
+            }
+            foreach($entry['tags'] as $tag_id){
+                $key = $tag_id === 0 ? 'untagged' : $tags->where('id', $tag_id)->pluck('name')->first();
+
+                if(!isset($standardised_chart_data[$key])){
+                    $standardised_chart_data[$key] = ['x'=>$key,'y'=>0];
+                }
+                $standardised_chart_data[$key]['y'] += $entry['entry_value'];
+                $standardised_chart_data[$key]['y'] = round($standardised_chart_data[$key]['y'], 2);
+            }
+        }
+        $x_col = array_column($standardised_chart_data, 'x');
+        array_multisort($x_col, SORT_ASC, $standardised_chart_data);
+        return array_values($standardised_chart_data);
+    }
+
+}

--- a/tests/Browser/StatsSummaryTest.php
+++ b/tests/Browser/StatsSummaryTest.php
@@ -39,7 +39,7 @@ class StatsSummaryTest extends DuskTestCase {
 
     public function __construct($name = null, array $data = [], $dataName = ''){
         parent::__construct($name, $data, $dataName);
-        $this->_id_label = 'summary-chart';
+        $this->_account_or_account_type_toggling_selector_label_id = 'summary-chart';
     }
 
     /**

--- a/tests/Browser/StatsSummaryTest.php
+++ b/tests/Browser/StatsSummaryTest.php
@@ -142,12 +142,12 @@ class StatsSummaryTest extends DuskTestCase {
         $account_types = collect($this->getApiAccountTypes());
 
         $this->browse(function (Browser $browser) use ($datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $accounts, $account_types){
-            $account_or_account_type_id = null;
+            $filter_data = [];
 
             $browser
                 ->visit(new StatsPage())
                 ->assertVisible(self::$SELECTOR_STATS_FORM_SUMMARY)
-                ->with(self::$SELECTOR_STATS_FORM_SUMMARY, function(Browser $form) use (&$datepicker_start, &$datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, &$account_or_account_type_id, $accounts, $account_types){
+                ->with(self::$SELECTOR_STATS_FORM_SUMMARY, function(Browser $form) use ($datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, &$filter_data, $accounts, $account_types){
                     if($are_disabled_select_options_available){
                         $this->toggleShowDisabledAccountOrAccountTypeCheckbox($form);
                     }
@@ -160,6 +160,7 @@ class StatsSummaryTest extends DuskTestCase {
                         $account_or_account_type_id = ($is_random_selector_value) ? $accounts->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
                     }
                     $this->selectAccountOrAccountTypeValue($form, $account_or_account_type_id);
+                    $filter_data = $this->generateFilterArrayElementAccountOrAccountypeId($filter_data, $is_switch_toggled, $account_or_account_type_id);
 
                     if(!is_null($datepicker_start) && !is_null($datepicker_end)){
                         $this->setDateRange($form, $datepicker_start, $datepicker_end);
@@ -168,6 +169,7 @@ class StatsSummaryTest extends DuskTestCase {
                         $datepicker_start = date('Y-m-01');
                         $datepicker_end = date('Y-m-t');
                     }
+                    $filter_data = $this->generateFilterArrayElementDatepicker($filter_data, $datepicker_start, $datepicker_end);
 
                     $form->click(self::$SELECTOR_BUTTON_GENERATE);
                 });
@@ -176,16 +178,16 @@ class StatsSummaryTest extends DuskTestCase {
             $browser
                 ->assertDontSeeIn(self::$SELECTOR_STATS_RESULTS_AREA, self::$LABEL_NO_STATS_DATA)
 
-                ->with(self::$SELECTOR_STATS_RESULTS_AREA, function(Browser $stats_results) use ($datepicker_start, $datepicker_end, $is_switch_toggled, &$account_or_account_type_id, $account_types, $accounts){
+                ->with(self::$SELECTOR_STATS_RESULTS_AREA, function(Browser $stats_results) use ($filter_data, $account_types, $accounts){
                     $selector_table_total_income_expense = 'table:nth-child(1)';
                     $selector_table_top_10_income_expense = 'table:nth-child(3)';
                     $selector_table_label = 'caption';
                     $selector_table_body_rows = 'tbody tr';
 
-                    $entries = $this->getBatchedFilteredEntries($datepicker_start, $datepicker_end, $account_or_account_type_id, $is_switch_toggled);
+                    $entries = $this->getBatchedFilteredEntries($filter_data);
                     $stats_results
                         ->assertVisible($selector_table_total_income_expense)
-                        ->with($selector_table_total_income_expense, function(Browser $table) use ($selector_table_label, $selector_table_body_rows, $entries, $accounts, $account_types, $account_or_account_type_id, $datepicker_start, $datepicker_end, $is_switch_toggled){
+                        ->with($selector_table_total_income_expense, function(Browser $table) use ($selector_table_label, $selector_table_body_rows, $entries, $accounts, $account_types){
                             $totals = $this->getTotalIncomeExpenses($entries, $accounts, $account_types);
 
                             $table->assertSeeIn($selector_table_label, "Total Income/Expenses");

--- a/tests/Browser/StatsTagsTest.php
+++ b/tests/Browser/StatsTagsTest.php
@@ -45,7 +45,7 @@ class StatsTagsTest extends DuskTestCase {
 
     public function __construct($name = null, array $data = [], $dataName = ''){
         parent::__construct($name, $data, $dataName);
-        $this->_id_label = 'tags-chart';
+        $this->_account_or_account_type_toggling_selector_label_id = 'tags-chart';
     }
 
     /**

--- a/tests/Browser/StatsTagsTest.php
+++ b/tests/Browser/StatsTagsTest.php
@@ -178,15 +178,14 @@ class StatsTagsTest extends DuskTestCase {
         $tags = collect($this->getApiTags());
 
         $this->browse(function(Browser $browser) use ($datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $accounts, $account_types, $tag_count, $tags){
-            $account_or_account_type_id = null;
-            $form_tags = null;
+            $filter_data = [];
 
             $browser->visit(new StatsPage());
             $this->clickStatsSidePanelOptionTags($browser);
 
             $browser
                 ->assertVisible(self::$SELECTOR_STATS_FORM_TAGS)
-                ->with(self::$SELECTOR_STATS_FORM_TAGS, function(Browser $form) use ($is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $accounts, $account_types, &$account_or_account_type_id, $tag_count, $tags, &$form_tags, &$datepicker_start, &$datepicker_end){
+                ->with(self::$SELECTOR_STATS_FORM_TAGS, function(Browser $form) use ($is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $accounts, $account_types, &$filter_data, $tag_count, $tags, $datepicker_start, $datepicker_end){
                     if($are_disabled_select_options_available){
                         $this->toggleShowDisabledAccountOrAccountTypeCheckbox($form);
                     }
@@ -200,6 +199,7 @@ class StatsTagsTest extends DuskTestCase {
                         $account_or_account_type_id = $is_random_selector_value ? $accounts->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
                     }
                     $this->selectAccountOrAccountTypeValue($form, $account_or_account_type_id);
+                    $filter_data = $this->generateFilterArrayElementAccountOrAccountypeId($filter_data, $is_switch_toggled, $account_or_account_type_id);
 
                     $form_tags = $tags->chunk($tag_count)->first();
                     if(!is_null($form_tags)){
@@ -208,6 +208,7 @@ class StatsTagsTest extends DuskTestCase {
                             $this->assertTagInInput($form, $tag['name']);
                         }
                     }
+                    $filter_data = $this->generateFilterArrayElementTags($filter_data, $form_tags);
 
                     if(!is_null($datepicker_start) && !is_null($datepicker_end)){
                         $this->setDateRange($form, $datepicker_start, $datepicker_end);
@@ -215,12 +216,13 @@ class StatsTagsTest extends DuskTestCase {
                         $datepicker_start = date('Y-m-01');
                         $datepicker_end = date('Y-m-t');
                     }
+                    $filter_data = $this->generateFilterArrayElementDatepicker($filter_data, $datepicker_start, $datepicker_end);
 
                     $this->createEntryWithAllTags($is_switch_toggled, $account_or_account_type_id, $account_types, $tags);
                     $form->click(self::$SELECTOR_BUTTON_GENERATE);
                 });
 
-            $entries = $this->getBatchedFilteredEntries($datepicker_start, $datepicker_end, $account_or_account_type_id, $is_switch_toggled, $form_tags);
+            $entries = $this->getBatchedFilteredEntries($filter_data);
 
             $this->waitForLoadingToStop($browser);
             $browser

--- a/tests/Browser/StatsTrendingTest.php
+++ b/tests/Browser/StatsTrendingTest.php
@@ -158,13 +158,13 @@ class StatsTrendingTest extends DuskTestCase {
         $account_types = collect($this->getApiAccountTypes());
 
         $this->browse(function (Browser $browser) use ($accounts, $account_types, $datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available){
-            $account_or_account_type_id = null;
+            $filter_data = [];
 
             $browser->visit(new StatsPage());
             $this->clickStatsSidePanelOptionTrending($browser);
             $browser
                 ->assertVisible(self::$SELECTOR_STATS_FORM_TRENDING)
-                ->with(self::$SELECTOR_STATS_FORM_TRENDING, function(Browser $form) use ($accounts, $account_types, &$datepicker_start, &$datepicker_end, $is_switch_toggled, &$account_or_account_type_id, $is_random_selector_value, $are_disabled_select_options_available){
+                ->with(self::$SELECTOR_STATS_FORM_TRENDING, function(Browser $form) use ($accounts, $account_types, $datepicker_start, $datepicker_end, $is_switch_toggled, &$filter_data, $is_random_selector_value, $are_disabled_select_options_available){
                     if($are_disabled_select_options_available){
                         $this->toggleShowDisabledAccountOrAccountTypeCheckbox($form);
                     }
@@ -178,6 +178,7 @@ class StatsTrendingTest extends DuskTestCase {
                     }
 
                     $this->selectAccountOrAccountTypeValue($form, $account_or_account_type_id);
+                    $filter_data = $this->generateFilterArrayElementAccountOrAccountypeId($filter_data, $is_switch_toggled, $account_or_account_type_id);
 
                     if(!is_null($datepicker_start) && !is_null($datepicker_end)){
                         $this->setDateRange($form, $datepicker_start, $datepicker_end);
@@ -185,16 +186,17 @@ class StatsTrendingTest extends DuskTestCase {
                         $datepicker_start = date('Y-m-01');
                         $datepicker_end = date('Y-m-t');
                     }
+                    $filter_data = $this->generateFilterArrayElementDatepicker($filter_data, $datepicker_start, $datepicker_end);
 
                     $form->click(self::$SELECTOR_BUTTON_GENERATE);
                 });
 
                 $this->waitForLoadingToStop($browser);
-                $entries = $this->getBatchedFilteredEntries($datepicker_start, $datepicker_end, $account_or_account_type_id, $is_switch_toggled);
+                $entries = $this->getBatchedFilteredEntries($filter_data);
 
                 $browser
                     ->assertDontSeeIn(self::$SELECTOR_STATS_RESULTS_AREA, self::$LABEL_NO_STATS_DATA)
-                    ->with(self::$SELECTOR_STATS_RESULTS_AREA, function(Browser $stats_results) use ($datepicker_start, $datepicker_end, $account_or_account_type_id, $is_switch_toggled){
+                    ->with(self::$SELECTOR_STATS_RESULTS_AREA, function(Browser $stats_results){
                         //  line-chart graph canvas should be visible
                         $stats_results->assertVisible(self::$SELECTOR_CHART_TRENDING);
                     })

--- a/tests/Browser/StatsTrendingTest.php
+++ b/tests/Browser/StatsTrendingTest.php
@@ -43,7 +43,7 @@ class StatsTrendingTest extends DuskTestCase {
 
     public function __construct($name = null, array $data = [], $dataName = ''){
         parent::__construct($name, $data, $dataName);
-        $this->_id_label = 'trending-chart';
+        $this->_account_or_account_type_toggling_selector_label_id = 'trending-chart';
     }
 
     /**

--- a/tests/Traits/HomePageSelectors.php
+++ b/tests/Traits/HomePageSelectors.php
@@ -94,10 +94,6 @@ trait HomePageSelectors {
     private $_selector_modal_filter = "@filter-modal";  // see Browser\Pages\HomePage.php
     private $_selector_modal_filter_field_start_date = "#filter-start-date";
     private $_selector_modal_filter_field_end_date = "#filter-end-date";
-    private $_selector_pattern_modal_filter_field_switch_account_and_account_type = "#toggle-account-and-account-types-for-%s"; // this is a pattern, not an actual identifier
-    private $_selector_modal_filter_field_checkbox_show_disabled = ".show-disabled-accounts-or-account-types";
-    private $_selector_modal_filter_field_checkbox_show_disabled_label = ".show-disabled-accounts-or-account-types label";
-    private $_selector_modal_filter_field_account_and_account_type = ".select-account-or-account-types-id";
     private $_selector_modal_filter_field_tags= "#filter-tags";
     private $_selector_modal_filter_field_switch_income = "#filter-is-income";
     private $_selector_modal_filter_field_switch_expense = "#filter-is-expense";
@@ -144,7 +140,6 @@ trait HomePageSelectors {
     private $_label_checkbox_show_disabled = "Show Disabled";
     private $_label_switch_enabled = "Enabled";
     private $_label_switch_disabled = "Disabled";
-    private $_label_select_option_filter_default = "[ ALL ]";
     private $_label_file_upload = "Drag & Drop";
     private $_label_btn_dropzone_remove_file = "REMOVE FILE";
     private $_label_btn_cancel = "Cancel";


### PR DESCRIPTION
- Modified the `BatchFilterEntries.php` testing trait to process/provide valid `/entries` request filter parameters.
- Changed the icons used in some of the "Generate Chart" buttons on the `/stats` page.
- Renamed a variable used for testing to better identify what it is used for.
- Created a distribution stats chart
- Moved testing logic for toggle button switches into it's own Dusk trait.
- Consolidated colors used into mixins for vuejs components and a dusk trait for testing. The values used match bulma values.