### PR TITLE
feature/db-dump-on-test-failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 services:
   - docker
 
-env: DOCKER_HOST_IP=127.0.0.1 DUSK_SCREENSHOT_DIRECTORY=tests/Browser/screenshots/ COMPOSE_PROJECT_NAME=moneytracker
+env: DOCKER_HOST_IP=127.0.0.1 COMPOSE_PROJECT_NAME=moneytracker DUSK_SCREENSHOT_DIR=tests/Browser/screenshots/ DUSK_DB_DUMP_DIR=tests/Browser/db-dump/
 
 cache:
   directories:
@@ -87,8 +87,8 @@ jobs:
         - .docker/cmd/yarn.sh run build-prod
         # install travis-ci/discord integration script(s)
         - mkdir -p .webhook
-        - wget -O .webhook/send.sh https://raw.githubusercontent.com/jdenoc/travis-ci-discord-webhook/1.2.0/send.sh
-        - wget -O .webhook/image-send.sh https://raw.githubusercontent.com/jdenoc/travis-ci-discord-webhook/1.2.0/image-send.sh
+        - wget -O .webhook/send.sh https://raw.githubusercontent.com/jdenoc/travis-ci-discord-webhook/1.3.0/send.sh
+        - wget -O .webhook/send-file.sh https://raw.githubusercontent.com/jdenoc/travis-ci-discord-webhook/1.3.0/send-file.sh
         - chmod +x .webhook/*.sh
       before_script: skip
       script: true
@@ -139,7 +139,8 @@ after_success:
 
 after_failure:
   - .webhook/send.sh failure $WEBHOOK_URL
-  - .webhook/image-send.sh --retry=3 --delay=7 $DUSK_SCREENSHOT_DIRECTORY $WEBHOOK_URL
+  - .webhook/send-file.sh --retry=3 --delay=7 --ext=png --ext=jpg --ext=jpeg --ext=gif $DUSK_SCREENSHOT_DIR $WEBHOOK_URL
+  - .webhook/send-file.sh --retry=3 --delay=7 --ext=sql $DUSK_DB_DUMP_DIR $WEBHOOK_URL
   - docker container logs --tail all --timestamps app.money-tracker > /dev/null
   - docker container exec -it app.money-tracker .docker/cmd/laravel-logs.sh
 

--- a/app/Traits/Tests/DatabaseFileDump.php
+++ b/app/Traits/Tests/DatabaseFileDump.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Traits\Tests;
+
+use Spatie\DbDumper\Databases\MySql;
+use Symfony\Component\Finder\Finder;
+
+trait DatabaseFileDump {
+
+    private static $DUMP_DIR = __DIR__.'/../../../tests/Browser/db-dump/';
+    private static $DATABASE_CONNECTION_CONFIG_PREFIX = 'database.connections.mysql.';
+
+    public function prepareApplicationForDatabaseDumpFile($test_name){
+        $this->purgeDatabaseFileDumps();
+
+        $this->beforeApplicationDestroyed(function() use ($test_name){
+            $this->generateDatabaseDumpFile($test_name);
+        });
+    }
+
+    /**
+     * @param string $test_name
+     * @throws \Spatie\DbDumper\Exceptions\CannotStartDump
+     * @throws \Spatie\DbDumper\Exceptions\DumpFailed
+     */
+    public function generateDatabaseDumpFile($test_name){
+        if(empty($test_name)){
+            $test_name = microtime(true);
+        }
+
+        MySql::create()
+            ->setDbName(config(self::$DATABASE_CONNECTION_CONFIG_PREFIX.'database'))
+            ->setHost(config(self::$DATABASE_CONNECTION_CONFIG_PREFIX.'host'))
+            ->setUserName(config(self::$DATABASE_CONNECTION_CONFIG_PREFIX.'username'))
+            ->setPassword(config(self::$DATABASE_CONNECTION_CONFIG_PREFIX.'password'))
+            ->dumpToFile(self::$DUMP_DIR.$test_name.'.sql');
+    }
+
+    /**
+     * Purge the database dump files
+     *
+     * Code more or less pulled directly from
+     *      vendor/laravel/dusk/src/Console/DuskCommand.php
+     *      purgeScreenshots()
+     *      purgeConsoleLogs()
+     *
+     * @return void
+     */
+    public function purgeDatabaseFileDumps(){
+        $files = Finder::create()->files()
+            ->in(self::$DUMP_DIR)
+            ->name('*.sql');
+
+        foreach ($files as $file) {
+            @unlink($file->getRealPath());
+        }
+    }
+
+
+}

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "laravel/dusk": "^2.0",
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "~6.0",
+        "spatie/db-dumper": "2.13.1",
         "symfony/thanks": "^1.0"
     },
     "autoload": {

--- a/tests/Browser/db-dump/.gitignore
+++ b/tests/Browser/db-dump/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -68,12 +68,16 @@ abstract class DuskTestCase extends BaseTestCase {
     protected function setUpTraits(){
         $uses = array_flip(class_uses_recursive(static::class));
 
-        if(isset($uses[\App\Traits\Tests\InjectDatabaseStateIntoException::class])){
-            $this->prepareFailureExceptionForDatabaseInjection();
+        if (isset($uses[\App\Traits\Tests\LogTestName::class])){
+            $this->runTestNameLogging($this->getName(true));
         }
 
-        if (isset($uses[\App\Traits\Tests\LogTestName::class])){
-            $this->runTestNameLogging($this->getName());
+        if(isset($uses[\App\Traits\Tests\DatabaseFileDump::class])){
+            $this->prepareApplicationForDatabaseDumpFile($this->getName(true));
+        }
+
+        if(isset($uses[\App\Traits\Tests\InjectDatabaseStateIntoException::class])){
+            $this->prepareFailureExceptionForDatabaseInjection();
         }
 
         return parent::setUpTraits();

--- a/tests/DuskWithMigrationsTestCase.php
+++ b/tests/DuskWithMigrationsTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use App\Traits\Tests\DatabaseFileDump;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 /**
@@ -19,6 +20,13 @@ abstract class DuskWithMigrationsTestCase extends DuskTestCase {
      * when a database migration is not required for said tests.
      */
     use DatabaseMigrations;
+
+    /**
+     * Often when a test involving a database fails, the failure is very database content dependent.
+     * The best way to re-create said failure is to perform a database dump.
+     * Doing this will allow us to re-produce the failing issue and in doing so, allow us to fix the issue.
+     */
+    use DatabaseFileDump;
 
     public function setUp(){
         parent::setUp();


### PR DESCRIPTION
Created a trait for tests that will perform a database file dump at the end of every test. The file will be deleted when the next test begins.