### PR TITLE
feature/add-tooltips-to-summary-stats-table

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "jdenoc/money-tracker",
+    "description": "income/expense tracker with receipt retention",
     "keywords": ["laravel"],
     "type": "project",
     "require": {

--- a/resources/assets/js/app-stats.js
+++ b/resources/assets/js/app-stats.js
@@ -4,6 +4,9 @@ import Store from './store';
 import Snotify from 'vue-snotify';
 Vue.use(Snotify, {toast: {timeout: 8000}});    // 8 seconds
 
+import VTooltip from 'v-tooltip';
+Vue.use(VTooltip);
+
 import eventHub from "./plugins/eventHub";
 Vue.use(eventHub);
 

--- a/resources/assets/js/components/stats/summary-chart.vue
+++ b/resources/assets/js/components/stats/summary-chart.vue
@@ -53,19 +53,17 @@
                 <thead>
                     <tr>
                         <th>&nbsp;</th>
-                        <th colspan="3">Income</th>
-                        <th colspan="3" class="left-border">Expense</th>
+                        <th colspan="2">Income</th>
+                        <th colspan="2" class="left-border">Expense</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr v-for="(incomeAndExpense, index) in top10IncomeAndExpenses" v-bind:key="index">
                         <td v-text="index+1"></td>
-                        <td v-text="incomeAndExpense.incomeMemo"></td>
+                        <td v-text="incomeAndExpense.incomeMemo" v-tooltip="tooltipContent(incomeAndExpense.incomeDate)"></td>
                         <td v-text="incomeAndExpense.incomeValue" class="has-text-right"></td>
-                        <td v-text="incomeAndExpense.incomeDate"></td>
-                        <td v-text="incomeAndExpense.expenseMemo" class="left-border"></td>
+                        <td v-text="incomeAndExpense.expenseMemo" class="left-border" v-tooltip="tooltipContent(incomeAndExpense.expenseDate)"></td>
                         <td v-text="incomeAndExpense.expenseValue" class="has-text-right"></td>
-                        <td v-text="incomeAndExpense.expenseDate"></td>
                     </tr>
                 </tbody>
             </table>
@@ -166,6 +164,14 @@
             },
         },
         methods: {
+            tooltipContent: function(text){
+                return {
+                    content: text,
+                    html: true,
+                    placement: 'right',
+                    classes: 'is-size-7',
+                }
+            },
             filteredEntries: function(isExpense){
                 return this.largeBatchEntryData
                     .map(function(entry){
@@ -217,5 +223,12 @@
     @import '../../../sass/stats-chart';
     .left-border{
         border-left: 1px solid $grey-lighter;
+    }
+    table:nth-child(3) th:first-child{
+        width: 2%;
+    }
+    table:nth-child(3) th:nth-child(2),
+    table:nth-child(3) th:nth-child(3){
+        width: 48%;
     }
 </style>

--- a/resources/assets/js/components/stats/summary-chart.vue
+++ b/resources/assets/js/components/stats/summary-chart.vue
@@ -21,7 +21,7 @@
         </section>
         <hr />
 
-        <section class="section stats-results-summary" v-if="areEntriesAvailable">
+        <section class="section stats-results-summary" v-if="areEntriesAvailable && dataLoaded">
             <table class="table">
                 <caption class="subtitle is-5 has-text-left">Total Income/Expenses</caption>
                 <thead>

--- a/tests/Browser/StatsBase.php
+++ b/tests/Browser/StatsBase.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Traits\Tests\Dusk\BulmaDatePicker as DuskTraitBulmaDatePicker;
+use App\Traits\Tests\Dusk\Loading as DuskTraitLoading;
+use App\Traits\Tests\Dusk\StatsSidePanel as DuskTraitStatsSidePanel;
+use Laravel\Dusk\Browser;
+use Tests\Browser\Pages\StatsPage;
+use Tests\DuskWithMigrationsTestCase as DuskTestCase;
+use Throwable;
+
+class StatsBase extends DuskTestCase {
+
+    use DuskTraitBulmaDatePicker;
+    use DuskTraitLoading;
+    use DuskTraitStatsSidePanel;
+
+    protected static $SELECTOR_STATS_FORM_SUMMARY = "#stats-form-summary";
+    protected static $SELECTOR_STATS_FORM_TRENDING = '#stats-form-trending';
+    protected static $SELECTOR_STATS_FORM_DISTRIBUTION = '#stats-form-distribution';
+    protected static $SELECTOR_STATS_FORM_TAGS = '#stats-form-tags';
+
+    protected static $SELECTOR_STATS_RESULTS_SUMMARY = '.stats-results-summary';
+    protected static $SELECTOR_STATS_RESULTS_TRENDING = '.stats-results-trending';
+    protected static $SELECTOR_STATS_RESULTS_DISTRIBUTION = '.stats-results-distribution';
+    protected static $SELECTOR_STATS_RESULTS_TAGS = '.stats-results-tags';
+
+    protected static $SELECTOR_BUTTON_GENERATE = '.generate-stats';
+
+    protected static $LABEL_GENERATE_CHART_BUTTON = "Generate Chart";
+    protected static $LABEL_NO_STATS_DATA = 'No data available';
+
+    protected $today = '';
+    protected $previous_year_start = '';
+    protected $month_start = '';
+    protected $month_end = '';
+
+    public function __construct($name = null, array $data = [], $dataName = ''){
+        parent::__construct($name, $data, $dataName);
+        $this->today = date("Y-m-d");
+        $this->previous_year_start = date("Y-01-01", strtotime('-1 year'));
+        $this->month_start = date('Y-m-01');
+        $this->month_end = date("Y-m-t");
+    }
+
+    /**
+     * @param string $side_panel_selector
+     * @param string $stats_form_selector
+     * @param string $stats_results_selector
+     *
+     * @throws Throwable
+     */
+    protected function generatingADifferentChartWontCauseSummaryTablesToBecomeVisible($side_panel_selector, $stats_form_selector, $stats_results_selector){
+        $this->browse(function (Browser $browser) use ($side_panel_selector, $stats_form_selector, $stats_results_selector){
+            $browser
+                ->visit(new StatsPage())
+                ->assertVisible(self::$SELECTOR_STATS_FORM_SUMMARY);
+
+            $this->clickStatsSidePanelOption($browser, $side_panel_selector);
+            $browser
+                ->assertVisible($stats_form_selector)
+                ->with($stats_form_selector, function(Browser $form){
+                    $this->setDateRange($form, $this->previous_year_start, $this->today);
+                    $form->click(self::$SELECTOR_BUTTON_GENERATE);
+                });
+            $this->waitForLoadingToStop($browser);
+            $browser->assertDontSeeIn($stats_results_selector, self::$LABEL_NO_STATS_DATA);
+
+            $this->clickStatsSidePanelOptionSummary($browser);
+            $this->assertStatsSidePanelOptionIsActive($browser, self::$LABEL_STATS_SIDE_PANEL_OPTION_SUMMARY);
+            $browser
+                ->assertVisible(self::$SELECTOR_STATS_FORM_SUMMARY)
+                ->assertSeeIn(self::$SELECTOR_STATS_RESULTS_SUMMARY, self::$LABEL_NO_STATS_DATA);
+        });
+    }
+
+}

--- a/tests/Browser/StatsSummaryTest.php
+++ b/tests/Browser/StatsSummaryTest.php
@@ -257,6 +257,47 @@ class StatsSummaryTest extends DuskTestCase {
         });
     }
 
+    public function providerGeneratingADifferentChartWontCauseSummaryTablesToBecomeVisible(){
+        return [
+            // [$side_panel_selector, $stats_form_selector, $stats_results_selector]
+            'trending'=>[self::$SELECTOR_STATS_SIDE_PANEL_OPTION_TRENDING, '#stats-form-trending', '.stats-results-trending'],
+            'tags'=>[self::$SELECTOR_STATS_SIDE_PANEL_OPTION_TAGS, '#stats-form-tags', '.stats-results-tags'],
+            'distribution'=>[self::$SELECTOR_STATS_SIDE_PANEL_OPTION_DISTRIBUTION, '#stats-form-distribution', '.stats-results-distribution'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerGeneratingADifferentChartWontCauseSummaryTablesToBecomeVisible
+     * @param $side_panel_selector
+     * @param $stats_form_selector
+     * @param $stats_results_selector
+     *
+     * @throws Throwable
+     */
+    public function testGeneratingADifferentChartWontCauseSummaryTablesToBecomeVisible($side_panel_selector, $stats_form_selector, $stats_results_selector){
+        $this->browse(function (Browser $browser) use ($side_panel_selector, $stats_form_selector, $stats_results_selector){
+            $browser
+                ->visit(new StatsPage())
+                ->assertVisible(self::$SELECTOR_STATS_FORM_SUMMARY);
+
+            $this->clickStatsSidePanelOption($browser, $side_panel_selector);
+            $browser
+                ->assertVisible($stats_form_selector)
+                ->with($stats_form_selector, function(Browser $form){
+                    $form->click(self::$SELECTOR_BUTTON_GENERATE);
+                });
+            $this->waitForLoadingToStop($browser);
+            $browser->assertDontSeeIn($stats_results_selector, self::$LABEL_NO_STATS_DATA);
+
+            $this->clickStatsSidePanelOptionSummary($browser);
+            $this->assertStatsSidePanelOptionIsActive($browser, self::$LABEL_STATS_SIDE_PANEL_OPTION_SUMMARY);
+            $browser
+                ->assertVisible(self::$SELECTOR_STATS_FORM_SUMMARY)
+                ->assertSeeIn(self::$SELECTOR_STATS_RESULTS_AREA, self::$LABEL_NO_STATS_DATA);
+        });
+
+    }
+
     /**
      * @param Collection $entries
      * @param Collection $accounts


### PR DESCRIPTION
- Added a description node to `composer.json`
- Moved income/expense dates on summary-chart table into a tooltip.
- Fixed a bug that caused the summary stats tables to display (without data) if another stats chart is displayed.