### PR TITLE
support/correct-large-file-upload-error

### DIFF
--- a/.docker/app.dockerfile
+++ b/.docker/app.dockerfile
@@ -36,7 +36,7 @@ RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini \
   && sed -i "s/expose_php = On/expose_php = Off/" $PHP_INI_DIR/php.ini
 
 # set php error logging
-RUN echo 'error_log = /dev/stderr' >> $PHP_INI_DIR/conf.d/php-error_log.ini
+RUN echo 'error_log = /var/www/money-tracker/storage/logs/php_error.log' >> $PHP_INI_DIR/conf.d/php-error_log.ini
 
 # set php timezone
 RUN echo 'date.timezone = "UTC"' >> $PHP_INI_DIR/conf.d/php-date.timezone.ini

--- a/.docker/cmd/mysql.sh
+++ b/.docker/cmd/mysql.sh
@@ -8,6 +8,6 @@ if [[ ! -f ${ENV_FILE} ]]; then
 fi
 
 docker container exec -it mysql.money-tracker mysql \
-	-u`cat $ENV_FILE | grep DB_USERNAME | sed 's/DB_USERNAME=//'` \
-	-p`cat $ENV_FILE | grep DB_PASSWORD | sed 's/DB_PASSWORD=//'` \
-	`cat $ENV_FILE | grep DB_DATABASE | sed 's/DB_DATABASE=//'`
+	-u"$(grep DB_USERNAME $ENV_FILE | sed 's/DB_USERNAME=//')" \
+	-p"$(grep DB_PASSWORD $ENV_FILE | sed 's/DB_PASSWORD=//')" \
+	"$(grep DB_DATABASE $ENV_FILE | sed 's/DB_DATABASE=//')"

--- a/.docker/cmd/mysql.sh
+++ b/.docker/cmd/mysql.sh
@@ -7,7 +7,7 @@ if [[ ! -f ${ENV_FILE} ]]; then
 	exit
 fi
 
-docker container exec -it mysql.money-tracker mysql \
+docker container exec -i mysql.money-tracker mysql \
 	-u"$(grep DB_USERNAME $ENV_FILE | sed 's/DB_USERNAME=//')" \
 	-p"$(grep DB_PASSWORD $ENV_FILE | sed 's/DB_PASSWORD=//')" \
 	"$(grep DB_DATABASE $ENV_FILE | sed 's/DB_DATABASE=//')"

--- a/.docker/mysql-health-check.sh
+++ b/.docker/mysql-health-check.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-test1=$( mysqladmin ping --user=$MYSQL_USER --password=$MYSQL_PASSWORD \
+test1=$( mysqladmin ping --user="$MYSQL_USER" --password="$MYSQL_PASSWORD" \
 	2>&1 | grep -v "Warning: Using a password" )
 
-test2=$( mysql --user=$MYSQL_USER --password=$MYSQL_PASSWORD --database=$MYSQL_DATABASE --skip-column-names  -e "SELECT NOW();" \
+test2=$( mysql --user="$MYSQL_USER" --password="$MYSQL_PASSWORD" --database="$MYSQL_DATABASE" --skip-column-names  -e "SELECT NOW();" \
 	2>&1 | grep -v "Warning: Using a password" )
 
 test1_ok="mysqld is alive"
 test2_ok=$( date +"%Y-%m-%d %H:%M:%S" )
 
-if [[ $test1 == $test1_ok ]]; then
-	if [[ $test2 == $test2_ok ]]; then
+if [[ $test1 == "$test1_ok" ]]; then
+	if [[ $test2 == "$test2_ok" ]]; then
 		echo OK;
 	else
 		# mysql connection denied

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ before_script:
   - .docker/cmd/artisan.sh travis-ci --display-env
   - docker container exec -t app.money-tracker env
   # setup laravel log files
+  - docker container exec -t --user www-data app.money-tracker touch storage/logs/php_error.log
   - docker container exec -t --user www-data app.money-tracker touch storage/logs/laravel.debug.log
   - docker container exec -t --user www-data app.money-tracker touch storage/logs/laravel.info.log
   - docker container exec -t --user www-data app.money-tracker touch storage/logs/laravel.notice.log

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,7 +3,7 @@
 namespace App\Exceptions;
 
 use Exception;
-use Illuminate\Auth\AuthenticationException;
+use Illuminate\Http\Exceptions\PostTooLargeException;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use \Symfony\Component\HttpFoundation\Response as HttpStatus;
@@ -50,9 +50,20 @@ class Handler extends ExceptionHandler
      * @return \Illuminate\Http\Response
      */
     public function render($request, Exception $exception){
-        if ($exception instanceof TokenMismatchException || $request->is('attachment/upload')){
+        if ($exception instanceof TokenMismatchException && $request->is('attachment/upload')){
             // handle TokenMismatchException's for attachment/upload
-            return response(['error'=>"token mis-match"],HttpStatus::HTTP_UNAUTHORIZED);
+            return response(['error' => "token mis-match"], HttpStatus::HTTP_UNAUTHORIZED);
+
+        } elseif($exception instanceof PostTooLargeException && $request->is('attachment/upload')){
+            return response(
+                ['error'=>'The uploaded file exceeds your post_max_size ini directive.'],
+                HttpStatus::HTTP_REQUEST_ENTITY_TOO_LARGE
+            );
+        } elseif($request->is('attachment/upload')){
+            return response(
+                ['error'=>'Error occurred during upload. Contact admin.'],
+                HttpStatus::HTTP_INTERNAL_SERVER_ERROR
+            );
         } else {
             return parent::render($request, $exception);
         }

--- a/app/Traits/Tests/Dusk/BatchFilterEntries.php
+++ b/app/Traits/Tests/Dusk/BatchFilterEntries.php
@@ -65,7 +65,7 @@ trait BatchFilterEntries {
     private function getBatchedFilteredEntries($filter_data){
         $entries = $this->getApiEntries(0, $filter_data);
         if(empty($entries)){
-            throw new \UnexpectedValueException("Entries not available with filter ".print_r($filter_data, true));
+            throw new \UnexpectedValueException("Entries not available with filter ".json_encode($filter_data));
         }
 
         $total_pages = intval( ceil($entries['count']/EntryController::MAX_ENTRIES_IN_RESPONSE) );

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -41,6 +41,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
     const INI_POSTMAXSIZE = 'post_max_size';
     const INI_UPLOADMAXFILESIZE = 'upload_max_filesize';
     const INI_DISPLAYERRORS = 'display_errors';
+    const INI_DISPLAYSTARTUPERRORS = 'display_startup_errors';
 
     private $_class_lock = "fa-lock";
     private $_class_unlock = "fa-unlock-alt";
@@ -55,6 +56,8 @@ class EntryModalExistingEntryTest extends DuskTestCase {
 
     private $_cached_entries_collection = [];
 
+    private $_default_ini_settings = [];
+
     public function __construct($name = null, array $data = [], $dataName = ''){
         parent::__construct($name, $data, $dataName);
         $this->_color_expense_switch_expense = self::$COLOR_WARNING_HEX;
@@ -65,7 +68,8 @@ class EntryModalExistingEntryTest extends DuskTestCase {
         parent::setUp();
         $this->_cached_entries_collection = [];
         if($this->getName(false) === 'testAttemptToAddAnAttachmentTooLargeToAnExistingEntry'){
-            ini_set(self::INI_DISPLAYERRORS, 0);
+            $this->_default_ini_settings[self::INI_DISPLAYERRORS] = ini_set(self::INI_DISPLAYERRORS, 0);
+            $this->_default_ini_settings[self::INI_DISPLAYSTARTUPERRORS] = ini_set(self::INI_DISPLAYSTARTUPERRORS, 0);
         }
     }
 
@@ -1110,7 +1114,9 @@ class EntryModalExistingEntryTest extends DuskTestCase {
 
     protected function tearDown(){
         if($this->getName(false) === 'testAttemptToAddAnAttachmentTooLargeToAnExistingEntry'){
-            ini_set(self::INI_DISPLAYERRORS, 1);
+            foreach($this->_default_ini_settings as $ini_setting=>$ini_value){
+                ini_set($ini_setting, $ini_value);
+            }
             \Storage::delete($this->getTestDummyFilename());    // remove any files that any tests may have created
         }
         parent::tearDown();

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -53,6 +53,8 @@ class EntryModalExistingEntryTest extends DuskTestCase {
     private $_class_existing_attachment = "existing-attachment";
     private $_modal_id_prefix = "#entry-";
 
+    private $_cached_entries_collection = [];
+
     public function __construct($name = null, array $data = [], $dataName = ''){
         parent::__construct($name, $data, $dataName);
         $this->_color_expense_switch_expense = self::$COLOR_WARNING_HEX;
@@ -61,6 +63,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
 
     public function setUp(){
         parent::setUp();
+        $this->_cached_entries_collection = [];
         if($this->getName(false) === 'testAttemptToAddAnAttachmentTooLargeToAnExistingEntry'){
             ini_set(self::INI_DISPLAYERRORS, 0);
         }
@@ -1046,7 +1049,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
      * @return string
      */
     private function randomEntrySelector($entry_constraints = []){
-        $entries_collection = collect($this->removeCountFromApiResponse($this->getApiEntries()));
+        $entries_collection = $this->getCachedEntriesAsCollection();
         if(!empty($entry_constraints)){
             foreach(array_keys($entry_constraints) as $constraint){
                 $entries_collection = $entries_collection->where($constraint, $entry_constraints[$constraint]);
@@ -1054,6 +1057,18 @@ class EntryModalExistingEntryTest extends DuskTestCase {
         }
         $entry_id = $entries_collection->pluck('id')->random();
         return $this->_modal_id_prefix.$entry_id;
+    }
+
+    /**
+     * Helps to reduce the amount of HTTP requests made while testing
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    private function getCachedEntriesAsCollection(){
+        if(empty($this->_cached_entries_collection)){
+            $this->_cached_entries_collection = collect($this->removeCountFromApiResponse($this->getApiEntries()));
+        }
+        return $this->_cached_entries_collection;
     }
 
     /**

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -981,7 +981,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
      * test (see provider)/25
      */
     public function testAttemptToAddAnAttachmentTooLargeToAnExistingEntry($max_upload_filesize, $error_message){
-        $dummy_filename = \Storage::path(self::$storage_path).'/'.$this->getName(false).'.txt';
+        $dummy_filename = $this->getTestDummyFilename();
         $this->generateDummyFile(
             $dummy_filename,
             $max_upload_filesize
@@ -1081,6 +1081,18 @@ class EntryModalExistingEntryTest extends DuskTestCase {
         fseek($fp, $file_size-1, SEEK_CUR);
         fwrite($fp, 'z');
         fclose($fp);
+    }
+
+    /**
+     * @return string
+     */
+    private function getTestDummyFilename(){
+        return \Storage::path(self::$storage_path).'/'.$this->getName(false).'.txt';
+    }
+
+    protected function tearDown(){
+        \Storage::delete($this->getTestDummyFilename());    // remove any files that any tests may have created
+        parent::tearDown();
     }
 
 }

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -61,7 +61,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
 
     public function setUp(){
         parent::setUp();
-        if($this->getName(false) === ''){
+        if($this->getName(false) === 'testAttemptToAddAnAttachmentTooLargeToAnExistingEntry'){
             ini_set(self::INI_DISPLAYERRORS, 0);
         }
     }

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -38,6 +38,11 @@ class EntryModalExistingEntryTest extends DuskTestCase {
     use DuskTraitTagsInput;
     use DuskTraitToggleButton;
 
+    const INI_POSTMAXSIZE = 'post_max_size';
+    const INI_UPLOADMAXFILESIZE = 'upload_max_filesize';
+    const OVERRIDE_INI_UPLOADMAXFILESIZE='1M';
+    const OVERRIDE_INI_POSTMAXSIZE='3M';
+
     private $_class_lock = "fa-lock";
     private $_class_unlock = "fa-unlock-alt";
     private $_class_disabled = "disabled";
@@ -944,19 +949,22 @@ class EntryModalExistingEntryTest extends DuskTestCase {
     }
 
     public function providerAttemptToAddAnAttachmentTooLargeToAnExistingEntry(){
-        $upload_max_filesize=$this->convertPhpIniFileSizeToBytes(ini_get('upload_max_filesize'));
-        $post_max_size=$this->convertPhpIniFileSizeToBytes(ini_get('post_max_size'));
+        ini_set(self::INI_POSTMAXSIZE, self::OVERRIDE_INI_POSTMAXSIZE);
+        ini_set(self::INI_UPLOADMAXFILESIZE, self::OVERRIDE_INI_UPLOADMAXFILESIZE);
+
+        $upload_max_filesize=$this->convertPhpIniFileSizeToBytes(ini_get(self::INI_UPLOADMAXFILESIZE));
+        $post_max_size=$this->convertPhpIniFileSizeToBytes(ini_get(self::INI_POSTMAXSIZE));
 
         return [
-            'upload_max_filesize+1'=>[  // test 25/25
+            self::INI_UPLOADMAXFILESIZE.'+1'=>[  // test 25/25
                 $upload_max_filesize+1,
                 'The file "%s" exceeds your upload_max_filesize ini directive'   // this text is lifted from vendor/symfony/http-foundation/File/UploadedFile.php#266
             ],
-            'post_max_size'=>[          // test 26/25
+            self::INI_POSTMAXSIZE=>[          // test 26/25
                 $post_max_size,
                 'The uploaded file exceeds your post_max_size ini directive.'   // this text is lifted from app/Exceptions/Handler.php#60
             ],
-            'post_max_size+1'=>[        // test 27/25
+            self::INI_POSTMAXSIZE.'+1'=>[        // test 27/25
                 $post_max_size+1,
                 'The uploaded file exceeds your post_max_size ini directive.'   // this text is lifted from app/Exceptions/Handler.php#60
             ]

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -943,6 +943,67 @@ class EntryModalExistingEntryTest extends DuskTestCase {
         });
     }
 
+    public function providerAttemptToAddAnAttachmentTooLargeToAnExistingEntry(){
+        $upload_max_filesize=$this->convertPhpIniFileSizeToBytes(ini_get('upload_max_filesize'));
+        $post_max_size=$this->convertPhpIniFileSizeToBytes(ini_get('post_max_size'));
+
+        return [
+            'upload_max_filesize+1'=>[  // test 25/25
+                $upload_max_filesize+1,
+                'The file "%s" exceeds your upload_max_filesize ini directive'   // this text is lifted from vendor/symfony/http-foundation/File/UploadedFile.php#266
+            ],
+            'post_max_size'=>[          // test 26/25
+                $post_max_size,
+                'The uploaded file exceeds your post_max_size ini directive.'   // this text is lifted from app/Exceptions/Handler.php#60
+            ],
+            'post_max_size+1'=>[        // test 27/25
+                $post_max_size+1,
+                'The uploaded file exceeds your post_max_size ini directive.'   // this text is lifted from app/Exceptions/Handler.php#60
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider providerAttemptToAddAnAttachmentTooLargeToAnExistingEntry
+     * @param int $max_upload_filesize
+     * @param string $error_message
+     *
+     * @throws Throwable
+     * @group entry-modal-1
+     * test (see provider)/25
+     */
+    public function testAttemptToAddAnAttachmentTooLargeToAnExistingEntry($max_upload_filesize, $error_message){
+        $dummy_filename = \Storage::path(self::$storage_path).'/'.$this->getName(false).'.txt';
+        $this->generateDummyFile(
+            $dummy_filename,
+            $max_upload_filesize
+        );
+        $this->assertFileExists($dummy_filename);
+        $this->assertEquals(filesize($dummy_filename), $max_upload_filesize);
+
+        $this->browse(function(Browser $browser) use ($dummy_filename, $error_message){
+            $entry_selector = $this->randomUnconfirmedEntrySelector(true);
+
+            $browser->visit(new HomePage());
+            $this->waitForLoadingToStop($browser);
+
+            $browser
+                ->openExistingEntryModal($entry_selector)
+                ->with($this->_selector_modal_entry, function($entry_modal) use ($dummy_filename){
+                    $entry_modal
+                        ->assertVisible($this->_selector_modal_entry_field_upload)
+                        ->attach($this->_selector_modal_entry_dropzone_hidden_file_input, $dummy_filename)
+                        ->waitFor($this->_selector_modal_entry_dropzone_upload_thumbnail, self::$WAIT_SECONDS);
+                });
+
+            $this->assertNotificationContents(
+                $browser,
+                self::$NOTIFICATION_TYPE_WARNING,
+                sprintf($error_message, basename($dummy_filename))
+            );
+        });
+    }
+
     /**
      * @param bool $get_id
      * @return string
@@ -982,6 +1043,36 @@ class EntryModalExistingEntryTest extends DuskTestCase {
         }
         $entry_id = $entries_collection->pluck('id')->random();
         return $this->_modal_id_prefix.$entry_id;
+    }
+
+    /**
+     * @param string $ini_value
+     * @return int
+     */
+    private function convertPhpIniFileSizeToBytes($ini_value){
+        $size_type = strtolower($ini_value[strlen($ini_value)-1]);
+        $val = intval($ini_value);
+        switch($size_type) {
+            case 'g':
+                return $val * 1024*1024*1024;
+            case 'm':
+                return $val * 1024*1024;
+            case 'k':
+                return $val * 1024;
+            default:
+                return $val;
+        }
+    }
+
+    /**
+     * @param string $file_name
+     * @param int $file_size    size of file to be created in bytes
+     */
+    private function generateDummyFile($file_name, $file_size){
+        $fp = fopen($file_name, 'w');
+        fseek($fp, $file_size-1, SEEK_CUR);
+        fwrite($fp, 'z');
+        fclose($fp);
     }
 
 }

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -40,8 +40,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
 
     const INI_POSTMAXSIZE = 'post_max_size';
     const INI_UPLOADMAXFILESIZE = 'upload_max_filesize';
-    const OVERRIDE_INI_UPLOADMAXFILESIZE='1M';
-    const OVERRIDE_INI_POSTMAXSIZE='3M';
+    const INI_DISPLAYERRORS = 'display_errors';
 
     private $_class_lock = "fa-lock";
     private $_class_unlock = "fa-unlock-alt";
@@ -58,6 +57,13 @@ class EntryModalExistingEntryTest extends DuskTestCase {
         parent::__construct($name, $data, $dataName);
         $this->_color_expense_switch_expense = self::$COLOR_WARNING_HEX;
         $this->_color_expense_switch_income = self::$COLOR_PRIMARY_HEX;
+    }
+
+    public function setUp(){
+        parent::setUp();
+        if($this->getName(false) === ''){
+            ini_set(self::INI_DISPLAYERRORS, 0);
+        }
     }
 
     public function providerUnconfirmedEntry(){
@@ -949,9 +955,6 @@ class EntryModalExistingEntryTest extends DuskTestCase {
     }
 
     public function providerAttemptToAddAnAttachmentTooLargeToAnExistingEntry(){
-        ini_set(self::INI_POSTMAXSIZE, self::OVERRIDE_INI_POSTMAXSIZE);
-        ini_set(self::INI_UPLOADMAXFILESIZE, self::OVERRIDE_INI_UPLOADMAXFILESIZE);
-
         $upload_max_filesize=$this->convertPhpIniFileSizeToBytes(ini_get(self::INI_UPLOADMAXFILESIZE));
         $post_max_size=$this->convertPhpIniFileSizeToBytes(ini_get(self::INI_POSTMAXSIZE));
 
@@ -1091,7 +1094,10 @@ class EntryModalExistingEntryTest extends DuskTestCase {
     }
 
     protected function tearDown(){
-        \Storage::delete($this->getTestDummyFilename());    // remove any files that any tests may have created
+        if($this->getName(false) === 'testAttemptToAddAnAttachmentTooLargeToAnExistingEntry'){
+            ini_set(self::INI_DISPLAYERRORS, 1);
+            \Storage::delete($this->getTestDummyFilename());    // remove any files that any tests may have created
+        }
         parent::tearDown();
     }
 


### PR DESCRIPTION
Better handling of attachment uploads that are too big for PHP to process.

Resolves #251 