### PR TITLE
hotfix/4.0.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ public/vue
 
 .env
 phpunit.dusk.xml
+.phpunit.result.cache
 _ide_helper*.php
 .phpstorm.meta.php

--- a/tests/Browser/StatsBase.php
+++ b/tests/Browser/StatsBase.php
@@ -92,7 +92,7 @@ class StatsBase extends DuskTestCase {
         $new_entry_data['entry_date'] = $this->faker
             ->dateTimeBetween($filter_data[EntryController::FILTER_KEY_START_DATE], $filter_data[EntryController::FILTER_KEY_END_DATE])
             ->format("Y-m-d");
-        if(!empty($filter_data[EntryController::FILTER_KEY_EXPENSE])){
+        if(isset($filter_data[EntryController::FILTER_KEY_EXPENSE])){
             $new_entry_data['expense'] = $filter_data[EntryController::FILTER_KEY_EXPENSE];
         }
 

--- a/tests/Browser/StatsDistributionTest.php
+++ b/tests/Browser/StatsDistributionTest.php
@@ -134,13 +134,13 @@ class StatsDistributionTest extends StatsBase {
             [$this->previous_year_start, $this->today, true, false, true, false],   // test 10/25
             // random account-type; income; date range a year past to today
             [$this->previous_year_start, $this->today, true, true, true, false],    // test 11/25
-            // random disabled account; expense; date range a year past to today
+            // random (possibly) disabled account; expense; date range a year past to today
             [$this->previous_year_start, $this->today, false, false, true, true],   // test 12/25
-            // random disabled account; income; date range a year past to today
+            // random (possibly) disabled account; income; date range a year past to today
             [$this->previous_year_start, $this->today, false, true, true, true],    // test 13/25
-            // random disabled account-type; expense; date range a year past to today
+            // random (possibly) disabled account-type; expense; date range a year past to today
             [$this->previous_year_start, $this->today, true, false, true, true],    // test 14/25
-            // random disabled account-type; income; date range a year past to today
+            // random (possibly) disabled account-type; income; date range a year past to today
             [$this->previous_year_start, $this->today, true, true, true, true],     // test 15/25
         ];
     }


### PR DESCRIPTION
- Correct minor check that wasn't working when value was `false`
- Excluding `.phpunit.result.cache` files from git.