### PR TITLE
Feature/exclude-transfers-from-stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ git fetch --tags
 MOST_RECENT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
 git checkout -q tags/$MOST_RECENT_TAG
 ```
-- <a name="prod-updates-2a">Step 2.a</a>
+- <a name="prod-updates-2a">Step 2.a</a> <small>_(optional)_</small>
 ```
 # *** OPTIONAL ***
 # Edit .env file
@@ -274,21 +274,21 @@ git checkout -q tags/$MOST_RECENT_TAG
 cp .env .env.bkup
 # Perform modifications described in release notes.
 ```
-- <a name="prod-updates-2b">Step 2.b</a>
+- <a name="prod-updates-2b">Step 2.b</a> <small>_(optional)_</small>
 ```
 # *** OPTIONAL ***
 # New/Updates to composer packages
 # Note: check update release notes. 
 composer update --no-dev -o
 ```
-- <a name="prod-updates-2c">Step 2.c</a>
+- <a name="prod-updates-2c">Step 2.c</a> <small>_(optional)_</small>
 ```
 # *** OPTIONAL ***
 # New/Updates to yarn packages
 # Note: check update release notes. 
 yarn install
 ```
-- <a name="prod-updates-2d">Step 2.d</a>
+- <a name="prod-updates-2d">Step 2.d</a> <small>_(optional)_</small>
 ```
 # *** OPTIONAL ***
 # Database updates

--- a/README.md
+++ b/README.md
@@ -355,6 +355,8 @@ php artisan dusk --stop-on-failure
 ## Other Documentation
 - [Laravel](https://laravel.com/docs/6.x/)
 - [VueJS](https://vuejs.org/v2/guide/)
+- [Bulma](https://bulma.io/documentation/)
+- [ChartJs](https://www.chartjs.org/)
 - [Docker](https://docs.docker.com/)
 - [Composer](https://getcomposer.org/doc/)
 - [Yarn](https://yarnpkg.com/en/docs)
@@ -362,4 +364,3 @@ php artisan dusk --stop-on-failure
 - [Laravel Dusk](https://laravel.com/docs/6.x/dusk)
 - [Travis CI](https://docs.travis-ci.com/user/languages/php/)
 - [git](https://git-scm.com/doc)
-- [ChartJs](https://www.chartjs.org/)

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ php artisan app:version $MOST_RECENT_TAG
 
 # setup new cache
 php artisan config:cache
+php artisan view:cache
 ```
 - <a name="prod-updates-5">Step 5</a>
 ```

--- a/app/Helpers/CurrencyHelper.php
+++ b/app/Helpers/CurrencyHelper.php
@@ -19,7 +19,6 @@ class CurrencyHelper {
 
     /**
      * @return Collection
-     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
     public static function fetchCurrencies(){
         $currency_json = \Storage::get(self::$CURRENCY_FILE_PATH);
@@ -37,8 +36,6 @@ class CurrencyHelper {
     /**
      * Currency codes are based on the ISO4217 standard
      * @link https://en.wikipedia.org/wiki/ISO_4217
-     *
-     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
     public static function getCodesAsArray(){
         if(is_null(self::$_currencies)){

--- a/app/Traits/Tests/Dusk/StatsIncludeTransfersCheckboxButton.php
+++ b/app/Traits/Tests/Dusk/StatsIncludeTransfersCheckboxButton.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Traits\Tests\Dusk;
+
+use Laravel\Dusk\Browser;
+
+trait StatsIncludeTransfersCheckboxButton {
+
+    protected static $SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS = '.is-checkradio.is-info.is-small.is-block+label';
+    protected static $SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS_CHECKED = '.is-checkradio.is-info.is-small.is-block:checked+label';
+
+    protected static $LABEL_CHECKBOX_INCLUDES_TRANSFER = "Include Transfers";
+
+    /**
+     * @param Browser $browser
+     */
+    protected function assertIncludeTransfersCheckboxButtonNotVisible(Browser $browser){
+        $browser->assertMissing(self::$SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS);
+    }
+
+    /**
+     * @param Browser $browser
+     */
+    protected function assertIncludeTransfersCheckboxButtonDefaultState(Browser $browser){
+        $browser
+            ->assertVisible(self::$SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS)
+            ->assertSeeIn(self::$SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS, self::$LABEL_CHECKBOX_INCLUDES_TRANSFER);
+        $this->assertIncludesTransfersCheckboxButtonStateInactive($browser);
+    }
+
+    /**
+     * @param Browser $browser
+     */
+    protected function clickIncludeTransfersCheckboxButton(Browser $browser){
+        $browser->click(self::$SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS);
+    }
+
+    /**
+     * @param Browser $browser
+     */
+    protected function assertIncludesTransfersCheckboxButtonStateActive(Browser $browser){
+        $browser
+            ->assertVisible(self::$SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS)
+            ->assertVisible(self::$SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS_CHECKED);
+    }
+
+    /**
+     * @param Browser $browser
+     */
+    protected function assertIncludesTransfersCheckboxButtonStateInactive(Browser $browser){
+        $browser
+            ->assertVisible(self::$SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS)
+            ->assertMissing(self::$SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS_CHECKED);
+    }
+
+}

--- a/resources/js/components/include-transfers-checkbox.vue
+++ b/resources/js/components/include-transfers-checkbox.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="field is-pulled-right"><div class="control">
+    <input class="is-checkradio is-info is-small is-block" type="checkbox"
+       v-bind:id="checkboxRadioId"
+       v-model="propCheck"
+    />
+    <label v-bind:for="checkboxRadioId">Include Transfers</label>
+  </div></div>
+</template>
+
+<script>
+export default {
+  name: "include-transfers-checkbox",
+  props:{
+    includeTransfers: {type: Boolean, required: true},
+    chartName: {type: String, required: true},
+  },
+  data: function(){
+    return {
+      propCheck: this.includeTransfers
+    }
+  },
+  watch:{
+    includeTransfers: function(newValue, oldValue){
+      this.propCheck = newValue;
+    },
+    propCheck: function(newValue, oldValue){
+      this.$emit('update-checkradio', newValue)
+    }
+  },
+  computed:{
+    checkboxRadioId: function(){
+      return this.chartName+"-chart-include-transfers";
+    }
+  },
+
+}
+</script>
+
+<style scoped>
+  .is-checkradio.is-info.is-small.is-block:checked+label::after{
+    top: 0.4rem;
+  }
+</style>

--- a/resources/js/components/stats/chart-defaults/bar-chart.vue
+++ b/resources/js/components/stats/chart-defaults/bar-chart.vue
@@ -1,14 +1,11 @@
 <script>
-    import { Bar } from 'vue-chartjs';
+    import { Bar, mixins } from 'vue-chartjs';
 
     export default {
         name: "bar-chart",
         extends: Bar,
+        mixins: [mixins.reactiveProp],
         props: {
-            chartData: {
-                type: Object,
-                default: null
-            },
             options: {
                 type: Object,
                 default: null

--- a/resources/js/components/stats/chart-defaults/line-chart.vue
+++ b/resources/js/components/stats/chart-defaults/line-chart.vue
@@ -1,14 +1,11 @@
 <script>
-    import { Line } from 'vue-chartjs';
+    import { Line, mixins } from 'vue-chartjs'
 
     export default {
         name: "line-chart",
         extends: Line,
+        mixins: [mixins.reactiveProp],
         props: {
-            chartData: {
-                type: Object,
-                default: null
-            },
             options: {
                 type: Object,
                 default: null

--- a/resources/js/components/stats/chart-defaults/pie-chart.vue
+++ b/resources/js/components/stats/chart-defaults/pie-chart.vue
@@ -1,14 +1,11 @@
 <script>
-    import { Pie } from 'vue-chartjs';
+    import { Pie, mixins } from 'vue-chartjs';
 
     export default {
         name: "pie-chart",
         extends: Pie,
+        mixins: [mixins.reactiveProp],
         props: {
-            chartData: {
-                type: Object,
-                default: null
-            },
             options: {
                 type: Object,
                 default: null

--- a/resources/js/components/stats/distribution-chart.vue
+++ b/resources/js/components/stats/distribution-chart.vue
@@ -69,9 +69,6 @@
         components: {IncludeTransfersCheckbox, AccountAccountTypeTogglingSelector, bulmaCalendar, PieChart, ToggleButton},
         data: function(){
             return {
-                chartConfig: {
-                    titleText: "Generated data"
-                },
                 expenseOrIncomeToggle: true,
                 accountOrAccountTypeToggle: true,
                 accountOrAccountTypeId: '',

--- a/resources/js/components/stats/distribution-chart.vue
+++ b/resources/js/components/stats/distribution-chart.vue
@@ -41,8 +41,8 @@
             ></include-transfers-checkbox>
             <pie-chart
                 v-if="dataLoaded"
-                v-bind:chart-data="this.chartData"
-                v-bind:options="this.chartOptions"
+                v-bind:chart-data="chartData"
+                v-bind:options="chartOptions"
             >Your browser does not support the canvas element.</pie-chart>
         </section>
         <section v-else class="section has-text-centered has-text-weight-semibold is-size-6 stats-results-distribution">

--- a/resources/js/components/stats/distribution-chart.vue
+++ b/resources/js/components/stats/distribution-chart.vue
@@ -33,7 +33,12 @@
             </div></div>
         </section>
         <hr/>
-        <section v-if="areEntriesAvailable" class="section stats-results-distribution">
+        <section v-if="areEntriesAvailable && dataLoaded" class="section stats-results-distribution">
+            <include-transfers-checkbox
+                chart-name="distribution"
+                v-bind:include-transfers="includeTransfers"
+                v-on:update-checkradio="includeTransfers = $event"
+            ></include-transfers-checkbox>
             <pie-chart
                 v-if="dataLoaded"
                 v-bind:chart-data="this.chartData"
@@ -49,17 +54,19 @@
 <script>
     import AccountAccountTypeTogglingSelector from "../account-account-type-toggling-selector";
     import bulmaCalendar from "../bulma-calendar";
+    import IncludeTransfersCheckbox from "../include-transfers-checkbox";
     import PieChart from './chart-defaults/pie-chart';
+    import {ToggleButton} from 'vue-js-toggle-button';
+
+    import {bulmaColorsMixin} from "../../mixins/bulma-colors-mixin";
     import {entriesObjectMixin} from "../../mixins/entries-object-mixin";
     import {statsChartMixin} from "../../mixins/stats-chart-mixin";
     import {tagsObjectMixin} from "../../mixins/tags-object-mixin";
-    import {ToggleButton} from 'vue-js-toggle-button';
-    import {bulmaColorsMixin} from "../../mixins/bulma-colors-mixin";
 
     export default {
         name: "distribution-chart",
         mixins: [bulmaColorsMixin, entriesObjectMixin, statsChartMixin, tagsObjectMixin],
-        components: {AccountAccountTypeTogglingSelector, bulmaCalendar, PieChart, ToggleButton},
+        components: {IncludeTransfersCheckbox, AccountAccountTypeTogglingSelector, bulmaCalendar, PieChart, ToggleButton},
         data: function(){
             return {
                 chartConfig: {
@@ -103,6 +110,7 @@
                 let standardisedChartData = [];
 
                 this.largeBatchEntryData
+                    .filter(this.filterIncludeTransferEntries)
                     .forEach(function(entryDatum){
                         let tempDatum = _.cloneDeep(entryDatum);
                         if(tempDatum.tags.length === 0){
@@ -153,7 +161,7 @@
 
                 this.setChartTitle(chartDataFilterParameters.expense, chartDataFilterParameters.start_date, chartDataFilterParameters.end_date);
                 this.multiPageDataFetch(chartDataFilterParameters);
-            },
+            }
         },
         mounted: function(){
             this.getBulmaCalendar.setBulmaCalendarDateRange(this.currentMonthStartDate, this.currentMonthEndDate);

--- a/resources/js/components/stats/summary-chart.vue
+++ b/resources/js/components/stats/summary-chart.vue
@@ -22,12 +22,12 @@
         <hr />
 
         <section class="section stats-results-summary" v-if="areEntriesAvailable && dataLoaded">
-            <div class="field is-pulled-right"><div class="control">
-                <input class="is-checkradio is-info is-small is-block" id="summary-chart-include-transfers" type="checkbox"
-                    v-model="includeTransfers"
-                />
-                <label for="summary-chart-include-transfers">Include Transfers</label>
-            </div></div>
+            <include-transfers-checkbox
+                chart-name="summary"
+                v-bind:include-transfers="includeTransfers"
+                v-on:update-checkradio="includeTransfers = $event"
+            >
+            </include-transfers-checkbox>
 
             <table class="table">
                 <caption class="subtitle is-5 has-text-left">Total Income/Expenses</caption>
@@ -84,6 +84,7 @@
 <script>
     import bulmaCalendar from '../bulma-calendar';
     import AccountAccountTypeTogglingSelector from "../account-account-type-toggling-selector";
+    import IncludeTransfersCheckbox from "../include-transfers-checkbox";
     import {Currency} from "../../currency";
 
     import {accountsObjectMixin} from "../../mixins/accounts-object-mixin";
@@ -94,7 +95,7 @@
     export default {
         name: "summary-chart",
         mixins: [statsChartMixin, entriesObjectMixin, accountsObjectMixin, accountTypesObjectMixin],
-        components: {AccountAccountTypeTogglingSelector, bulmaCalendar},
+        components: {IncludeTransfersCheckbox, AccountAccountTypeTogglingSelector, bulmaCalendar},
         data: function(){
           return {
               currencyObject: new Currency(),

--- a/resources/js/components/stats/summary-chart.vue
+++ b/resources/js/components/stats/summary-chart.vue
@@ -26,8 +26,7 @@
                 chart-name="summary"
                 v-bind:include-transfers="includeTransfers"
                 v-on:update-checkradio="includeTransfers = $event"
-            >
-            </include-transfers-checkbox>
+            ></include-transfers-checkbox>
 
             <table class="table">
                 <caption class="subtitle is-5 has-text-left">Total Income/Expenses</caption>

--- a/resources/js/components/stats/summary-chart.vue
+++ b/resources/js/components/stats/summary-chart.vue
@@ -153,6 +153,7 @@
 
                 // tally up values for total
                 this.largeBatchEntryData.forEach(function(datum){
+                  // TODO: take into account external transfers (e.g.: transfer_entry_id=0)
                     if(!this.includeTransfers && datum.is_transfer){
                         return; // skip to next entry
                     }
@@ -192,6 +193,7 @@
                     })
                     .filter(function(datum){ return datum.expense === isExpense; })
                     .filter(function(datum){
+                      // TODO: take into account external transfers (e.g.: transfer_entry_id=0)
                         return this.includeTransfers || (!this.includeTransfers && !datum.is_transfer);
                     }.bind(this));
             },

--- a/resources/js/components/stats/summary-chart.vue
+++ b/resources/js/components/stats/summary-chart.vue
@@ -22,6 +22,13 @@
         <hr />
 
         <section class="section stats-results-summary" v-if="areEntriesAvailable && dataLoaded">
+            <div class="field is-pulled-right"><div class="control">
+                <input class="is-checkradio is-info is-small is-block" id="summary-chart-include-transfers" type="checkbox"
+                    v-model="includeTransfers"
+                />
+                <label for="summary-chart-include-transfers">Include Transfers</label>
+            </div></div>
+
             <table class="table">
                 <caption class="subtitle is-5 has-text-left">Total Income/Expenses</caption>
                 <thead>
@@ -145,6 +152,9 @@
 
                 // tally up values for total
                 this.largeBatchEntryData.forEach(function(datum){
+                    if(!this.includeTransfers && datum.is_transfer){
+                        return; // skip to next entry
+                    }
                     let accountCurrency = this.getAccountCurrencyFromAccountTypeId(datum.account_type_id);
                     if(datum.expense){
                         total[accountCurrency].expense += parseFloat(datum.entry_value);
@@ -179,7 +189,10 @@
                         e.entry_value = _.round(entry.entry_value, 2);
                         return e;
                     })
-                    .filter(function(datum){ return datum.expense === isExpense; });
+                    .filter(function(datum){ return datum.expense === isExpense; })
+                    .filter(function(datum){
+                        return this.includeTransfers || (!this.includeTransfers && !datum.is_transfer);
+                    }.bind(this));
             },
 
             getAccountCurrencyFromAccountTypeId: function(accountTypeId){

--- a/resources/js/components/stats/summary-chart.vue
+++ b/resources/js/components/stats/summary-chart.vue
@@ -98,6 +98,7 @@
         components: {IncludeTransfersCheckbox, AccountAccountTypeTogglingSelector, bulmaCalendar},
         data: function(){
           return {
+              chartConfig: { titleText: null},
               currencyObject: new Currency(),
 
               accountOrAccountTypeToggle: true,

--- a/resources/js/components/stats/tags-chart.vue
+++ b/resources/js/components/stats/tags-chart.vue
@@ -64,10 +64,6 @@
         components: {AccountAccountTypeTogglingSelector, BarChart, BulmaCalendar, VoerroTagsInput},
         data: function(){
             return {
-                chartConfig: {
-                    titleText: "Generated data"
-                },
-
                 accountOrAccountTypeToggle: true,
                 accountOrAccountTypeId: '',
                 chartTagIds: []

--- a/resources/js/components/stats/tags-chart.vue
+++ b/resources/js/components/stats/tags-chart.vue
@@ -36,7 +36,7 @@
 
         <hr />
 
-        <section v-if="areEntriesAvailable" class="section stats-results-tags">
+        <section v-if="areEntriesAvailable && dataLoaded" class="section stats-results-tags">
             <bar-chart
                 v-if="dataLoaded"
                 v-bind:chart-data="this.chartData"
@@ -116,6 +116,7 @@
                 let standardisedChartData = {};
 
                 this.largeBatchEntryData
+                    .filter(this.filterIncludeTransferEntries)
                     .forEach(function(entryDatum){
                         let tempDatum = _.cloneDeep(entryDatum);
                         if(tempDatum.tags.length === 0){

--- a/resources/js/components/stats/tags-chart.vue
+++ b/resources/js/components/stats/tags-chart.vue
@@ -37,10 +37,15 @@
         <hr />
 
         <section v-if="areEntriesAvailable && dataLoaded" class="section stats-results-tags">
+            <include-transfers-checkbox
+                chart-name="tags"
+                v-bind:include-transfers="includeTransfers"
+                v-on:update-checkradio="includeTransfers = $event"
+            ></include-transfers-checkbox>
             <bar-chart
                 v-if="dataLoaded"
-                v-bind:chart-data="this.chartData"
-                v-bind:options="this.chartOptions"
+                v-bind:chart-data="chartData"
+                v-bind:options="chartOptions"
             >Your browser does not support the canvas element.</bar-chart>
         </section>
         <section v-else class="section has-text-centered has-text-weight-semibold is-size-6 stats-results-tags">
@@ -53,7 +58,9 @@
     import AccountAccountTypeTogglingSelector from "../account-account-type-toggling-selector";
     import BarChart from "./chart-defaults/bar-chart";
     import BulmaCalendar from '../bulma-calendar';
+    import IncludeTransfersCheckbox from "../include-transfers-checkbox";
     import VoerroTagsInput from '@voerro/vue-tagsinput';
+
     import {entriesObjectMixin} from "../../mixins/entries-object-mixin";
     import {statsChartMixin} from "../../mixins/stats-chart-mixin";
     import {tagsObjectMixin} from "../../mixins/tags-object-mixin";
@@ -61,7 +68,7 @@
     export default {
         name: "tags-chart",
         mixins: [entriesObjectMixin, statsChartMixin, tagsObjectMixin],
-        components: {AccountAccountTypeTogglingSelector, BarChart, BulmaCalendar, VoerroTagsInput},
+        components: {AccountAccountTypeTogglingSelector, BarChart, BulmaCalendar, IncludeTransfersCheckbox, VoerroTagsInput},
         data: function(){
             return {
                 accountOrAccountTypeToggle: true,

--- a/resources/js/components/stats/trending-chart.vue
+++ b/resources/js/components/stats/trending-chart.vue
@@ -22,7 +22,13 @@
 
         <hr />
 
-        <section v-if="areEntriesAvailable" class="section stats-results-trending">
+        <section v-if="areEntriesAvailable && dataLoaded" class="section stats-results-trending">
+            <include-transfers-checkbox
+                chart-name="trending"
+                v-bind:include-transfers="includeTransfers"
+                v-on:update-checkradio="includeTransfers = $event"
+            ></include-transfers-checkbox>
+            <!-- TODO: redraw chart when includeTransfers changes -->
             <line-chart
                 v-if="dataLoaded"
                 v-bind:chart-data="this.chartData"
@@ -38,6 +44,7 @@
 <script>
     import AccountAccountTypeTogglingSelector from "../account-account-type-toggling-selector";
     import BulmaCalendar from "../bulma-calendar";
+    import IncludeTransfersCheckbox from "../include-transfers-checkbox";
     import LineChart from "./chart-defaults/line-chart";
     import {entriesObjectMixin} from "../../mixins/entries-object-mixin";
     import {statsChartMixin} from "../../mixins/stats-chart-mixin";
@@ -45,7 +52,7 @@
     export default {
         name: "trending-chart",
         mixins: [entriesObjectMixin, statsChartMixin],
-        components: {BulmaCalendar, LineChart, AccountAccountTypeTogglingSelector},
+        components: {IncludeTransfersCheckbox, BulmaCalendar, LineChart, AccountAccountTypeTogglingSelector},
         data: function(){
             return {
                 chartConfig: {
@@ -108,6 +115,7 @@
             },
             chartOptions: function(){
                 return {
+                    responsive: true,
                     maintainAspectRatio: false,
                     title: {
                         display: true,
@@ -144,6 +152,11 @@
                 this.largeBatchEntryData
                     .filter(function(chartDatum){ return chartDatum.expense === isExpense })
                     .forEach(function(datum){
+                      // TODO: take into account external transfers (e.g.: transfer_entry_id=0)
+                        if(!this.includeTransfers && datum.is_transfer){
+                            return; // skip to next entry
+                        }
+
                         // condense data points with similar entry_date values
                         let key = datum.entry_date;
                         if(!standardisedChartData.hasOwnProperty(key)){
@@ -151,7 +164,7 @@
                         }
                         standardisedChartData[key].y += parseFloat(datum.entry_value);
                         standardisedChartData[key].y = _.round(standardisedChartData[key].y, 2);
-                    });
+                    }.bind(this));
 
                 return _.sortBy(
                     Object.values(standardisedChartData),

--- a/resources/js/components/stats/trending-chart.vue
+++ b/resources/js/components/stats/trending-chart.vue
@@ -28,11 +28,10 @@
                 v-bind:include-transfers="includeTransfers"
                 v-on:update-checkradio="includeTransfers = $event"
             ></include-transfers-checkbox>
-            <!-- TODO: redraw chart when includeTransfers changes -->
             <line-chart
                 v-if="dataLoaded"
-                v-bind:chart-data="this.chartData"
-                v-bind:options="this.chartOptions"
+                v-bind:chart-data="chartData"
+                v-bind:options="chartOptions"
             >Your browser does not support the canvas element.</line-chart>
         </section>
         <section v-else class="section has-text-centered has-text-weight-semibold is-size-6 stats-results-trending">

--- a/resources/js/components/stats/trending-chart.vue
+++ b/resources/js/components/stats/trending-chart.vue
@@ -150,13 +150,9 @@
             standardiseData: function(isExpense){
                 let standardisedChartData = [];
                 this.largeBatchEntryData
+                    .filter(this.filterIncludeTransferEntries)
                     .filter(function(chartDatum){ return chartDatum.expense === isExpense })
                     .forEach(function(datum){
-                      // TODO: take into account external transfers (e.g.: transfer_entry_id=0)
-                        if(!this.includeTransfers && datum.is_transfer){
-                            return; // skip to next entry
-                        }
-
                         // condense data points with similar entry_date values
                         let key = datum.entry_date;
                         if(!standardisedChartData.hasOwnProperty(key)){

--- a/resources/js/components/stats/trending-chart.vue
+++ b/resources/js/components/stats/trending-chart.vue
@@ -63,8 +63,7 @@
                     datasetDefault: {
                         fill: false
                     },
-                    timeUnit: 'day',
-                    titleText: "Generated data"
+                    timeUnit: 'day'
                 },
 
                 accountOrAccountTypeToggle: true,

--- a/resources/js/mixins/stats-chart-mixin.js
+++ b/resources/js/mixins/stats-chart-mixin.js
@@ -3,7 +3,8 @@ import {SnotifyStyle} from "vue-snotify";
 export const statsChartMixin = {
     data: function(){
         return {
-            dataLoaded: false
+            dataLoaded: false,
+            includeTransfers: false,
         }
     },
 

--- a/resources/js/mixins/stats-chart-mixin.js
+++ b/resources/js/mixins/stats-chart-mixin.js
@@ -36,5 +36,10 @@ export const statsChartMixin = {
             let b=Math.floor(Math.random() * (max - min + 1) + min);
             return 'rgba('+r+', '+g+', '+b+', 1)';
         },
+        filterIncludeTransferEntries: function(entry){
+            // TODO: take into account external transfers (e.g.: transfer_entry_id=0)
+            return this.includeTransfers
+                || (!this.includeTransfers && entry.hasOwnProperty('is_transfer') && !entry.is_transfer);
+        }
     },
 };

--- a/resources/js/mixins/stats-chart-mixin.js
+++ b/resources/js/mixins/stats-chart-mixin.js
@@ -5,6 +5,10 @@ export const statsChartMixin = {
         return {
             dataLoaded: false,
             includeTransfers: false,
+
+            chartConfig: {
+                titleText: "Generated data"
+            },
         }
     },
 

--- a/resources/sass/stats-chart.scss
+++ b/resources/sass/stats-chart.scss
@@ -28,5 +28,9 @@
   }
   .section:last-child{
     padding-top: 0;
+
+    .is-checkradio.is-info.is-small.is-block:checked+label::after{
+      top: 0.4rem;
+    }
   }
 }

--- a/resources/sass/stats-chart.scss
+++ b/resources/sass/stats-chart.scss
@@ -28,9 +28,5 @@
   }
   .section:last-child{
     padding-top: 0;
-
-    .is-checkradio.is-info.is-small.is-block:checked+label::after{
-      top: 0.4rem;
-    }
   }
 }

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -56,7 +56,6 @@ class EntryModalExistingEntryTest extends DuskTestCase {
 
     private $_cached_entries_collection = [];
 
-
     public function __construct($name = null, array $data = [], $dataName = ''){
         parent::__construct($name, $data, $dataName);
         $this->_color_expense_switch_expense = self::$COLOR_WARNING_HEX;
@@ -691,13 +690,12 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                 ->with($this->_selector_modal_entry, function(Browser $entry_modal) use ($transfer_entry_data){
                     $entry_modal
                         ->with($this->_selector_modal_body, function(Browser $modal_body) use ($transfer_entry_data){
-                            $expense_switch_label = $transfer_entry_data['expense'] ? $this->_label_expense_switch_expense : $this->_label_expense_switch_income;
-
                             $modal_body
                                 ->assertInputValue($this->_selector_modal_entry_field_date, $transfer_entry_data['entry_date'])
                                 ->assertInputValue($this->_selector_modal_entry_field_value, $transfer_entry_data['entry_value'])
                                 ->assertSelected($this->_selector_modal_entry_field_account_type, $transfer_entry_data['account_type_id'])
                                 ->assertInputValue($this->_selector_modal_entry_field_memo, $transfer_entry_data['memo']);
+                            $expense_switch_label = $transfer_entry_data['expense'] ? $this->_label_expense_switch_expense : $this->_label_expense_switch_income;
                             $this->assertToggleButtonState($modal_body, $this->_selector_modal_entry_field_expense, $expense_switch_label);
                         })
                         ->with($this->_selector_modal_head, function(Browser $modal_head) use ($transfer_entry_data){
@@ -710,19 +708,19 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                                 ->assertVisible($this->_selector_modal_entry_btn_transfer)
                                 ->click($this->_selector_modal_entry_btn_transfer);
                         });
-                })
-
+                });
+            $this->waitForLoadingToStop($browser);
+            $browser
                 ->assertVisible($this->_selector_modal_entry)
                 ->with($this->_selector_modal_entry, function(Browser $entry_modal) use ($entry_data){
                     $entry_modal
                         ->with($this->_selector_modal_body, function(Browser $modal_body) use ($entry_data){
-                            $expense_switch_label = $entry_data['expense'] ? $this->_label_expense_switch_expense : $this->_label_expense_switch_income;
-
                             $modal_body
                                 ->assertInputValue($this->_selector_modal_entry_field_date, $entry_data['entry_date'])
                                 ->assertInputValue($this->_selector_modal_entry_field_value, $entry_data['entry_value'])
                                 ->assertSelected($this->_selector_modal_entry_field_account_type, $entry_data['account_type_id'])
                                 ->assertInputValue($this->_selector_modal_entry_field_memo, $entry_data['memo']);
+                            $expense_switch_label = $entry_data['expense'] ? $this->_label_expense_switch_expense : $this->_label_expense_switch_income;
                             $this->assertToggleButtonState($modal_body, $this->_selector_modal_entry_field_expense, $expense_switch_label);
                         })
                         ->with($this->_selector_modal_head, function(Browser $modal_head) use ($entry_data){

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -1021,7 +1021,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
     }
 
     /**
-     * @param bool $get_id
+     * @param int|bool $get_id
      * @return string
      */
     private function randomConfirmedEntrySelector($get_id=false){

--- a/tests/Browser/StatsBase.php
+++ b/tests/Browser/StatsBase.php
@@ -10,6 +10,7 @@ use App\Traits\Tests\Dusk\BulmaDatePicker as DuskTraitBulmaDatePicker;
 use App\Traits\Tests\Dusk\Loading as DuskTraitLoading;
 use App\Traits\Tests\Dusk\StatsSidePanel as DuskTraitStatsSidePanel;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Collection;
 use Laravel\Dusk\Browser;
 use Tests\Browser\Pages\StatsPage;
 use Tests\DuskWithMigrationsTestCase as DuskTestCase;
@@ -32,10 +33,14 @@ class StatsBase extends DuskTestCase {
     protected static $SELECTOR_STATS_RESULTS_DISTRIBUTION = '.stats-results-distribution';
     protected static $SELECTOR_STATS_RESULTS_TAGS = '.stats-results-tags';
 
+    protected static $SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS = '.is-checkradio.is-info.is-small.is-block+label';
+    protected static $SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS_CHECKED = '.is-checkradio.is-info.is-small.is-block:checked+label';
+
     protected static $SELECTOR_BUTTON_GENERATE = '.generate-stats';
 
     protected static $LABEL_GENERATE_CHART_BUTTON = "Generate Chart";
     protected static $LABEL_NO_STATS_DATA = 'No data available';
+    protected static $LABEL_CHECKBOX_INCLUDES_TRANSFER = "Include Transfers";
 
     protected $today = '';
     protected $previous_year_start = '';
@@ -110,6 +115,19 @@ class StatsBase extends DuskTestCase {
         $entry = factory(Entry::class)->create($new_entry_data);
         if(!empty($filter_data[EntryController::FILTER_KEY_TAGS])){
             $entry->tags()->attach($filter_data[EntryController::FILTER_KEY_TAGS]);
+        }
+    }
+
+    /**
+     * @param Collection $entries
+     * @param bool $is_transfer
+     * @return Collection
+     */
+    protected function filterTransferEntries($entries, $is_transfer){
+        if(!$is_transfer){
+            return $entries->where('is_transfer', false);
+        } else {
+            return $entries;
         }
     }
 

--- a/tests/Browser/StatsBase.php
+++ b/tests/Browser/StatsBase.php
@@ -93,9 +93,14 @@ class StatsBase extends DuskTestCase {
      * In those situations, we need to make sure that at least one entry does exist.
      *
      * @param array $filter_data
+     * @param string $memo
      */
-    protected function generateEntryFromFilterData($filter_data){
+    protected function generateEntryFromFilterData($filter_data, $memo = ''){
         $new_entry_data = ['disabled'=>false];
+        if(!empty($memo)){
+            $new_entry_data['memo'] = $memo;
+        }
+        
         $new_entry_data['entry_date'] = $this->faker
             ->dateTimeBetween($filter_data[EntryController::FILTER_KEY_START_DATE], $filter_data[EntryController::FILTER_KEY_END_DATE])
             ->format("Y-m-d");

--- a/tests/Browser/StatsDistributionTest.php
+++ b/tests/Browser/StatsDistributionTest.php
@@ -232,7 +232,7 @@ class StatsDistributionTest extends StatsBase {
                     }
                     $filter_data = $this->generateFilterArrayElementDatepicker($filter_data, $datepicker_start, $datepicker_end);
 
-                    $this->generateEntryFromFilterData($filter_data);
+                    $this->generateEntryFromFilterData($filter_data, $this->getName());
                     $this->createEntryWithAllTags($is_account_switch_toggled, $account_or_account_type_id, $account_types, $tags);
                     $form->click(self::$SELECTOR_BUTTON_GENERATE);
                 });
@@ -318,7 +318,7 @@ class StatsDistributionTest extends StatsBase {
             $account_type_id = $account_types->pluck('id')->random();
         }
 
-        $disabled_entry = factory(\App\Entry::class)->create(['account_type_id'=>$account_type_id, 'disabled'=>false, 'entry_date'=>date('Y-m-d', strtotime('-1 day'))]);
+        $disabled_entry = factory(\App\Entry::class)->create(['memo'=>$this->getName().' - ALL tags', 'account_type_id'=>$account_type_id, 'disabled'=>false, 'entry_date'=>date('Y-m-d', strtotime('-1 day'))]);
         foreach($tags->pluck('id')->all() as $tag_id){
             $disabled_entry->tags()->attach($tag_id);
         }

--- a/tests/Browser/StatsDistributionTest.php
+++ b/tests/Browser/StatsDistributionTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Browser;
 
-use App\Entry;
 use App\Traits\Tests\Dusk\AccountOrAccountTypeTogglingSelector as DuskTraitAccountOrAccountTypeTogglingSelector;
 use App\Traits\Tests\Dusk\BatchFilterEntries as DuskTraitBatchFilterEntries;
 use App\Traits\Tests\Dusk\BulmaColors as DuskTraitBulmaColors;
@@ -111,37 +110,64 @@ class StatsDistributionTest extends StatsBase {
             $this->clickStatsSidePanelOptionDistribution($browser);
             $browser
                 ->assertVisible(self::$SELECTOR_STATS_RESULTS_DISTRIBUTION)
-                ->assertSeeIn(self::$SELECTOR_STATS_RESULTS_DISTRIBUTION, self::$LABEL_NO_STATS_DATA);
+                ->assertSeeIn(self::$SELECTOR_STATS_RESULTS_DISTRIBUTION, self::$LABEL_NO_STATS_DATA)
+                ->with(self::$SELECTOR_STATS_RESULTS_DISTRIBUTION, function(Browser $stats_results){
+                    $this->assertIncludeTransfersCheckboxButtonNotVisible($stats_results);
+                });
         });
     }
 
     public function providerGenerateDistributionChart(){
-        //[$datepicker_start, $datepicker_end, $is_account_switch_toggled, $is_expense_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available]
+        //[$datepicker_start, $datepicker_end, $is_account_switch_toggled, $is_expense_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $include_transfers]
         return [
             //  default state of account/account-types; expense; default date range
-            [null, null, false, false, false, false],                   // test 4/25
+            [null, null, false, false, false, false, false],                   // test 4/25
+            //  default state of account/account-types; expense; default date range; include transfers
+            [null, null, false, false, false, false, true],                   // test 4/25
             // default state of account/account-types; income; default date range
-            [null, null, false, true, false, false],                    // test 5/25
+            [null, null, false, true, false, false, false],                    // test 5/25
+            // default state of account/account-types; income; default date range; include transfers
+            [null, null, false, true, false, false, true],                    // test 6/25
             // default state of account/account-types; expense; date range a year past to today
-            [$this->previous_year_start, $this->today, false, false, false, false], // test 6/25
+            [$this->previous_year_start, $this->today, false, false, false, false, false], // test 7/25
+            // default state of account/account-types; expense; date range a year past to today; include transfers
+            [$this->previous_year_start, $this->today, false, false, false, false, true], // test 8/25
             // default state of account/account-types; income; date range a year past to today
-            [$this->previous_year_start, $this->today, false, true, false, false],  // test 7/25
+            [$this->previous_year_start, $this->today, false, true, false, false, false],  // test 9/25
+            // default state of account/account-types; income; date range a year past to today; include transfers
+            [$this->previous_year_start, $this->today, false, true, false, false, true],  // test 10/25
             // random account; expense; date range a year past to today
-            [$this->previous_year_start, $this->today, false, false, true, false],  // test 8/25
+            [$this->previous_year_start, $this->today, false, false, true, false, false],  // test 11/25
+            // random account; expense; date range a year past to today; include transfers
+            [$this->previous_year_start, $this->today, false, false, true, false, true],  // test 12/25
             // random account; income; date range a year past to today
-            [$this->previous_year_start, $this->today, false, true, true, false],   // test 9/25
+            [$this->previous_year_start, $this->today, false, true, true, false, false],   // test 13/25
+            // random account; income; date range a year past to today; include transfers
+            [$this->previous_year_start, $this->today, false, true, true, false, true],   // test 14/25
             // random account-type; expense; date range a year past to today
-            [$this->previous_year_start, $this->today, true, false, true, false],   // test 10/25
+            [$this->previous_year_start, $this->today, true, false, true, false, false],   // test 15/25
+            // random account-type; expense; date range a year past to today; include transfers
+            [$this->previous_year_start, $this->today, true, false, true, false, true],   // test 16/25
             // random account-type; income; date range a year past to today
-            [$this->previous_year_start, $this->today, true, true, true, false],    // test 11/25
-            // random (possibly) disabled account; expense; date range a year past to today
-            [$this->previous_year_start, $this->today, false, false, true, true],   // test 12/25
-            // random (possibly) disabled account; income; date range a year past to today
-            [$this->previous_year_start, $this->today, false, true, true, true],    // test 13/25
-            // random (possibly) disabled account-type; expense; date range a year past to today
-            [$this->previous_year_start, $this->today, true, false, true, true],    // test 14/25
-            // random (possibly) disabled account-type; income; date range a year past to today
-            [$this->previous_year_start, $this->today, true, true, true, true],     // test 15/25
+            [$this->previous_year_start, $this->today, true, true, true, false, false],    // test 17/25
+            // random account-type; income; date range a year past to today; include transfers
+            [$this->previous_year_start, $this->today, true, true, true, false, true],    // test 18/25
+            // random disabled account; expense; date range a year past to today
+            [$this->previous_year_start, $this->today, false, false, true, true, false],   // test 19/25
+            // random disabled account; expense; date range a year past to today; include transfers
+            [$this->previous_year_start, $this->today, false, false, true, true, true],   // test 20/25
+            // random disabled account; income; date range a year past to today
+            [$this->previous_year_start, $this->today, false, true, true, true, false],    // test 21/25
+            // random disabled account; income; date range a year past to today; include transfers
+            [$this->previous_year_start, $this->today, false, true, true, true, true],    // test 22/25
+            // random disabled account-type; expense; date range a year past to today
+            [$this->previous_year_start, $this->today, true, false, true, true, false],    // test 23/25
+            // random disabled account-type; expense; date range a year past to today; include transfers
+            [$this->previous_year_start, $this->today, true, false, true, true, true],    // test 24/25
+            // random disabled account-type; income; date range a year past to today
+            [$this->previous_year_start, $this->today, true, true, true, true, false],     // test 25/25
+            // random disabled account-type; income; date range a year past to today; include transfers
+            [$this->previous_year_start, $this->today, true, true, true, true, true],     // test 26/25
         ];
     }
 
@@ -154,18 +180,19 @@ class StatsDistributionTest extends StatsBase {
      * @param bool $is_expense_switch_toggled
      * @param bool $is_random_selector_value
      * @param bool $are_disabled_select_options_available
+     * @param bool $include_transfers
      *
      * @throws Throwable
      *
      * @group stats-distribution-1
      * test (see provider)/25
      */
-    public function testGenerateDistributionChart($datepicker_start, $datepicker_end, $is_account_switch_toggled, $is_expense_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available){
+    public function testGenerateDistributionChart($datepicker_start, $datepicker_end, $is_account_switch_toggled, $is_expense_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $include_transfers){
         $accounts = collect($this->getApiAccounts());
         $account_types = collect($this->getApiAccountTypes());
         $tags = collect($this->getApiTags());
 
-        $this->browse(function (Browser $browser) use ($datepicker_start, $datepicker_end, $is_account_switch_toggled, $is_expense_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $accounts, $account_types, $tags){
+        $this->browse(function (Browser $browser) use ($datepicker_start, $datepicker_end, $is_account_switch_toggled, $is_expense_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $include_transfers, $accounts, $account_types, $tags){
             $filter_data = [];
 
             $browser->visit(new StatsPage());
@@ -211,11 +238,17 @@ class StatsDistributionTest extends StatsBase {
                 });
 
             $entries = $this->getBatchedFilteredEntries($filter_data);
+            $entries = $this->filterTransferEntries($entries, $include_transfers);
 
             $this->waitForLoadingToStop($browser);
             $browser
                 ->assertDontSeeIn(self::$SELECTOR_STATS_RESULTS_DISTRIBUTION, self::$LABEL_NO_STATS_DATA)
-                ->with(self::$SELECTOR_STATS_RESULTS_DISTRIBUTION, static function(Browser $stats_results_area){
+                ->with(self::$SELECTOR_STATS_RESULTS_DISTRIBUTION, function(Browser $stats_results_area) use ($include_transfers){
+                    $this->assertIncludeTransfersCheckboxButtonDefaultState($stats_results_area);
+                    if($include_transfers){
+                        $this->clickIncludeTransfersCheckboxButton($stats_results_area);
+                        $this->assertIncludesTransfersCheckboxButtonStateActive($stats_results_area);
+                    }
                     $stats_results_area->assertVisible(self::$SELECTOR_CHART_DISTRIBUTION);
                 })
                 ->assertVue(self::$VUE_KEY_STANDARDISEDATA, $this->standardiseData($entries, $tags), self::$SELECTOR_STATS_DISTRIBUTION);
@@ -227,7 +260,7 @@ class StatsDistributionTest extends StatsBase {
      * @throws Throwable
      *
      * @group stats-distribution-1
-     * test 16/25
+     * test 27/25
      */
     public function testGeneratingADistributionChartWontCauseSummaryTablesToBecomeVisible(){
         $this->generatingADifferentChartWontCauseSummaryTablesToBecomeVisible(
@@ -285,7 +318,7 @@ class StatsDistributionTest extends StatsBase {
             $account_type_id = $account_types->pluck('id')->random();
         }
 
-        $disabled_entry = factory(Entry::class)->create(['account_type_id'=>$account_type_id, 'disabled'=>false, 'entry_date'=>date('Y-m-d', strtotime('-1 day'))]);
+        $disabled_entry = factory(\App\Entry::class)->create(['account_type_id'=>$account_type_id, 'disabled'=>false, 'entry_date'=>date('Y-m-d', strtotime('-1 day'))]);
         foreach($tags->pluck('id')->all() as $tag_id){
             $disabled_entry->tags()->attach($tag_id);
         }

--- a/tests/Browser/StatsSummaryTest.php
+++ b/tests/Browser/StatsSummaryTest.php
@@ -92,7 +92,7 @@ class StatsSummaryTest extends StatsBase {
      * test 3/25
      */
     public function testDefaultDataResultsArea(){
-        $this->browse(static function(Browser $browser){
+        $this->browse(function(Browser $browser){
             $browser
                 ->visit(new StatsPage())
                 ->assertVisible(self::$SELECTOR_STATS_RESULTS_SUMMARY)

--- a/tests/Browser/StatsSummaryTest.php
+++ b/tests/Browser/StatsSummaryTest.php
@@ -96,8 +96,8 @@ class StatsSummaryTest extends StatsBase {
             $browser
                 ->visit(new StatsPage())
                 ->assertVisible(self::$SELECTOR_STATS_RESULTS_SUMMARY)
-                ->assertSeeIn(self::$SELECTOR_STATS_RESULTS_SUMMARY, self::$LABEL_NO_STATS_DATA)
-                ->assertMissing(self::$SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS_CHECKED);
+                ->assertSeeIn(self::$SELECTOR_STATS_RESULTS_SUMMARY, self::$LABEL_NO_STATS_DATA);
+            $this->assertIncludeTransfersCheckboxButtonNotVisible($browser);
         });
     }
 
@@ -195,16 +195,13 @@ class StatsSummaryTest extends StatsBase {
                     $selector_table_body_rows = 'tbody tr';
 
                     $entries = $this->getBatchedFilteredEntries($filter_data);
-                    $stats_results
-                        ->assertVisible(self::$SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS)
-                        ->assertSeeIn(self::$SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS, self::$LABEL_CHECKBOX_INCLUDES_TRANSFER)
-                        ->assertMissing(self::$SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS_CHECKED);
-                    if($include_transfers){
-                        $stats_results
-                            ->click(self::$SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS)
-                            ->assertVisible(self::$SELECTOR_STATS_CHECKBOX_INCLUDE_TRANSFERS_CHECKED);
-                    }
                     $entries = $this->filterTransferEntries($entries, $include_transfers);
+
+                    $this->assertIncludeTransfersCheckboxButtonDefaultState($stats_results);
+                    if($include_transfers){
+                        $this->clickIncludeTransfersCheckboxButton($stats_results);
+                        $this->assertIncludesTransfersCheckboxButtonStateActive($stats_results);
+                    }
 
                     $stats_results
                         ->assertVisible($selector_table_total_income_expense)

--- a/tests/Browser/StatsSummaryTest.php
+++ b/tests/Browser/StatsSummaryTest.php
@@ -180,7 +180,7 @@ class StatsSummaryTest extends StatsBase {
                     }
                     $filter_data = $this->generateFilterArrayElementDatepicker($filter_data, $datepicker_start, $datepicker_end);
 
-                    $this->generateEntryFromFilterData($filter_data);
+                    $this->generateEntryFromFilterData($filter_data, $this->getName());
                     $form->click(self::$SELECTOR_BUTTON_GENERATE);
                 });
 

--- a/tests/Browser/StatsTagsTest.php
+++ b/tests/Browser/StatsTagsTest.php
@@ -120,31 +120,55 @@ class StatsTagsTest extends StatsBase {
 
     public function providerTestGenerateTagsChart(){
         return [
-            //[$datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $tag_count]
+            //[$datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $tag_count, $include_transfers]
             // defaults account/account-type & tags & date-picker values
-            [null, null, false, false, false, 0],   // test 3/25
+            [null, null, false, false, false, 0, false],   // test 4/25
+            // defaults account/account-type & tags & date-picker values & include transfers checkbox button clicked
+            [null, null, false, false, false, 0, true],   // test 5/25
             // date-picker previous year start to present & default tags & default account/account-type
-            [$this->previous_year_start, $this->today, false, false, false, 0], // test 4/25
+            [$this->previous_year_start, $this->today, false, false, false, 0, false], // test 6/25
+            // date-picker previous year start to present & default tags & default account/account-type & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, false, false, false, 0, true], // test 7/25
             // date-picker previous year start to present & default tags & random account
-            [$this->previous_year_start, $this->today, false, true, false, 0],  // test 5/25
+            [$this->previous_year_start, $this->today, false, true, false, 0, false],  // test 8/25
+            // date-picker previous year start to present & default tags & random account & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, false, true, false, 0, true],  // test 9/25
             // date-picker previous year start to present & default tags & random account-type
-            [$this->previous_year_start, $this->today, true, true, false, 0],   // test 6/25
+            [$this->previous_year_start, $this->today, true, true, false, 0, false],   // test 10/25
+            // date-picker previous year start to present & default tags & random account-type & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, true, true, false, 0, true],   // test 11/25
             // date-picker previous year start to present & default tags & random disabled account
-            [$this->previous_year_start, $this->today, false, true, true, 0],   // test 7/25
+            [$this->previous_year_start, $this->today, false, true, true, 0, false],   // test 12/25
+            // date-picker previous year start to present & default tags & random disabled account & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, false, true, true, 0, true],   // test 13/25
             // date-picker previous year start to present & default tags & random disabled account-type
-            [$this->previous_year_start, $this->today, true, true, true, 0],    // test 8/25
+            [$this->previous_year_start, $this->today, true, true, true, 0, false],    // test 14/25
+            // date-picker previous year start to present & default tags & random disabled account-type & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, true, true, true, 0, true],    // test 15/25
             // date-picker previous year start to present & random tag & default account/account-type
-            [$this->previous_year_start, $this->today, false, false, false, 1], // test 9/25
+            [$this->previous_year_start, $this->today, false, false, false, 1, false], // test 16/25
+            // date-picker previous year start to present & random tag & default account/account-type & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, false, false, false, 1, true], // test 17/25
             // date-picker previous year start to present & random tag & random account
-            [$this->previous_year_start, $this->today, false, true, false, 1],  // test 10/25
+            [$this->previous_year_start, $this->today, false, true, false, 1, false],  // test 18/25
+            // date-picker previous year start to present & random tag & random account & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, false, true, false, 1, true],  // test 19/25
             // date-picker previous year start to present & random tag & random account-type
-            [$this->previous_year_start, $this->today, true, true, false, 1],   // test 11/25
+            [$this->previous_year_start, $this->today, true, true, false, 1, false],   // test 20/25
+            // date-picker previous year start to present & random tag & random account-type & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, true, true, false, 1, true],   // test 21/25
             // date-picker previous year start to present & random tag & random disabled account
-            [$this->previous_year_start, $this->today, false, true, true, 1],   // test 12/25
+            [$this->previous_year_start, $this->today, false, true, true, 1, false],   // test 22/25
+            // date-picker previous year start to present & random tag & random disabled account & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, false, true, true, 1, true],   // test 23/25
             // date-picker previous year start to present & random tag & random disabled account-type
-            [$this->previous_year_start, $this->today, true, true, true, 1],    // test 13/25
+            [$this->previous_year_start, $this->today, true, true, true, 1, false],    // test 24/25
+            // date-picker previous year start to present & random tag & random disabled account-type & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, true, true, true, 1, true],    // test 25/25
             // date-picker previous year start to present & random tags & default account/account-type
-            [$this->previous_year_start, $this->today, false, false, false, 2]  // test 14/25
+            [$this->previous_year_start, $this->today, false, false, false, 2, false],  // test 26/25
+            // date-picker previous year start to present & random tags & default account/account-type & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, false, false, false, 2, true]  // test 27/25
         ];
     }
 
@@ -157,18 +181,19 @@ class StatsTagsTest extends StatsBase {
      * @param bool $is_random_selector_value
      * @param bool $are_disabled_select_options_available
      * @param int $tag_count
+     * @param bool $include_transfers
      *
      * @throws Throwable
      *
      * @group stats-tags-1
      * test (see provider)/25
      */
-    public function testGenerateTagsChart($datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $tag_count){
+    public function testGenerateTagsChart($datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $tag_count, $include_transfers){
         $accounts = collect($this->getApiAccounts());
         $account_types = collect($this->getApiAccountTypes());
         $tags = collect($this->getApiTags());
 
-        $this->browse(function(Browser $browser) use ($datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $accounts, $account_types, $tag_count, $tags){
+        $this->browse(function(Browser $browser) use ($datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $accounts, $account_types, $tag_count, $tags, $include_transfers){
             $filter_data = [];
 
             $browser->visit(new StatsPage());
@@ -209,17 +234,24 @@ class StatsTagsTest extends StatsBase {
                     }
                     $filter_data = $this->generateFilterArrayElementDatepicker($filter_data, $datepicker_start, $datepicker_end);
 
-                    $this->generateEntryFromFilterData($filter_data);
+                    $this->generateEntryFromFilterData($filter_data, $this->getName(true));
                     $this->createEntryWithAllTags($is_switch_toggled, $account_or_account_type_id, $account_types, $tags);
                     $form->click(self::$SELECTOR_BUTTON_GENERATE);
                 });
 
-            $entries = $this->getBatchedFilteredEntries($filter_data);
-
             $this->waitForLoadingToStop($browser);
+            $entries = $this->getBatchedFilteredEntries($filter_data);
+            $entries = $this->filterTransferEntries($entries, $include_transfers);
+
             $browser
                 ->assertDontSeeIn(self::$SELECTOR_STATS_RESULTS_TAGS, self::$LABEL_NO_STATS_DATA)
-                ->with(self::$SELECTOR_STATS_RESULTS_TAGS, function(Browser $stats_results_area){
+                ->with(self::$SELECTOR_STATS_RESULTS_TAGS, function(Browser $stats_results_area) use ($include_transfers){
+                    $this->assertIncludeTransfersCheckboxButtonDefaultState($stats_results_area);
+                    if($include_transfers){
+                        $this->clickIncludeTransfersCheckboxButton($stats_results_area);
+                        $this->assertIncludesTransfersCheckboxButtonStateActive($stats_results_area);
+                    }
+
                     $stats_results_area->assertVisible(self::$SELECTOR_CHART_TAGS);
                 })
                 ->assertVue(self::$VUE_KEY_STANDARDISEDATA, $this->standardiseData($entries, $tags), self::$SELECTOR_STATS_TAGS);
@@ -275,7 +307,7 @@ class StatsTagsTest extends StatsBase {
     /**
      * Database seeder doesn't assign tags to disabled entries.
      * It's a waste of resources to do that for every test when most tests don't need that kind of data.
-     * So instead for these tests, we'll create a disabled with all the tags
+     * So instead for these tests, we'll create an entry with all the tags
      *
      * @param bool $is_account_type_rather_than_account_toggled
      * @param int $account_or_account_type_id
@@ -293,7 +325,7 @@ class StatsTagsTest extends StatsBase {
             $account_type_id = $account_types->pluck('id')->random();
         }
 
-        $entry_with_tags = factory(Entry::class)->create(['account_type_id'=>$account_type_id, 'disabled'=>false, 'entry_date'=>date('Y-m-d')]);
+        $entry_with_tags = factory(Entry::class)->create(['memo'=>$this->getName(true).' - ALL TAGS', 'account_type_id'=>$account_type_id, 'disabled'=>false, 'entry_date'=>date('Y-m-d')]);
         foreach($tags->pluck('id')->all() as $tag_id){
             $entry_with_tags->tags()->attach($tag_id);
         }

--- a/tests/Browser/StatsTrendingTest.php
+++ b/tests/Browser/StatsTrendingTest.php
@@ -222,7 +222,7 @@ class StatsTrendingTest extends StatsBase {
      * @throws Throwable
      *
      * @group stats-trending-1
-     * test 10/25
+     * test 16/25
      */
     public function testGeneratingATrendingChartWontCauseSummaryTablesToBecomeVisible(){
         $this->generatingADifferentChartWontCauseSummaryTablesToBecomeVisible(

--- a/tests/Browser/StatsTrendingTest.php
+++ b/tests/Browser/StatsTrendingTest.php
@@ -115,7 +115,7 @@ class StatsTrendingTest extends StatsBase {
 
     public function providerTestGenerateTrendingChart(){
         return [
-            //[$datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available]
+            //[$datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $include_transfers]
             // defaults account/account-type & date-picker values
             [null, null, false, false, false, false],  // test 4/25
             // defaults account/account-type & date-picker values & include transfers checkbox button clicked
@@ -193,7 +193,7 @@ class StatsTrendingTest extends StatsBase {
                     }
                     $filter_data = $this->generateFilterArrayElementDatepicker($filter_data, $datepicker_start, $datepicker_end);
 
-                    $this->generateEntryFromFilterData($filter_data);
+                    $this->generateEntryFromFilterData($filter_data, $this->getName());
                     $form->click(self::$SELECTOR_BUTTON_GENERATE);
                 });
 

--- a/tests/Browser/StatsTrendingTest.php
+++ b/tests/Browser/StatsTrendingTest.php
@@ -108,6 +108,7 @@ class StatsTrendingTest extends StatsBase {
                     $stats_trending
                         ->assertVisible(self::$SELECTOR_STATS_RESULTS_TRENDING)
                         ->assertSeeIn(self::$SELECTOR_STATS_RESULTS_TRENDING, self::$LABEL_NO_STATS_DATA);
+                    $this->assertIncludeTransfersCheckboxButtonNotVisible($stats_trending);
                 });
         });
     }
@@ -116,39 +117,52 @@ class StatsTrendingTest extends StatsBase {
         return [
             //[$datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available]
             // defaults account/account-type & date-picker values
-            [null, null, false, false, false],  // test 4/25
+            [null, null, false, false, false, false],  // test 4/25
+            // defaults account/account-type & date-picker values & include transfers checkbox button clicked
+            [null, null, false, false, false, true],  // test 5/25
             // date-picker previous year start to present & default account/account-type
-            [$this->previous_year_start, $this->today, false, false, false],    // test 5/25
+            [$this->previous_year_start, $this->today, false, false, false, false],    // test 6/25
+            // date-picker previous year start to present & default account/account-type & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, false, false, false, true],    // test 7/25
             // date-picker previous year start to present & random account
-            [$this->previous_year_start, $this->today, false, true, false],     // test 6/25
+            [$this->previous_year_start, $this->today, false, true, false, false],     // test 8/25
+            // date-picker previous year start to present & random account & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, false, true, false, true],     // test 9/25
             // date-picker previous year start to present & random account-type
-            [$this->previous_year_start, $this->today, true, true, false],      // test 7/25
+            [$this->previous_year_start, $this->today, true, true, false, false],      // test 10/25
+            // date-picker previous year start to present & random account-type & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, true, true, false, true],      // test 11/25
             // date-picker previous year start to present & random disabled account
-            [$this->previous_year_start, $this->today, false, true, false],     // test 8/25
+            [$this->previous_year_start, $this->today, false, true, false, false],     // test 12/25
+            // date-picker previous year start to present & random disabled account & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, false, true, false, true],     // test 13/25
             // date-picker previous year start to present & random disabled account-type
-            [$this->previous_year_start, $this->today, true, true, false],      // test 9/25
+            [$this->previous_year_start, $this->today, true, true, false, false],      // test 14/25
+            // date-picker previous year start to present & random disabled account-type & include transfers checkbox button clicked
+            [$this->previous_year_start, $this->today, true, true, false, true],      // test 15/25
         ];
     }
 
     /**
      * @dataProvider providerTestGenerateTrendingChart
      *
-     * @param $datepicker_start
-     * @param $datepicker_end
-     * @param $is_switch_toggled
-     * @param $is_random_selector_value
-     * @param $are_disabled_select_options_available
+     * @param string|null $datepicker_start
+     * @param string|null $datepicker_end
+     * @param bool $is_switch_toggled
+     * @param bool $is_random_selector_value
+     * @param bool $are_disabled_select_options_available
+     * @param bool $include_transfers
      *
      * @throws Throwable
      *
      * @group stats-trending-1
      * test (see provider)/25
      */
-    public function testGenerateTrendingChart($datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available){
+    public function testGenerateTrendingChart($datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $include_transfers){
         $accounts = collect($this->getApiAccounts());
         $account_types = collect($this->getApiAccountTypes());
 
-        $this->browse(function (Browser $browser) use ($accounts, $account_types, $datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available){
+        $this->browse(function (Browser $browser) use ($accounts, $account_types, $datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $include_transfers){
             $filter_data = [];
 
             $browser->visit(new StatsPage());
@@ -185,10 +199,17 @@ class StatsTrendingTest extends StatsBase {
 
                 $this->waitForLoadingToStop($browser);
                 $entries = $this->getBatchedFilteredEntries($filter_data);
+                $entries = $this->filterTransferEntries($entries, $include_transfers);
 
                 $browser
                     ->assertDontSeeIn(self::$SELECTOR_STATS_RESULTS_TRENDING, self::$LABEL_NO_STATS_DATA)
-                    ->with(self::$SELECTOR_STATS_RESULTS_TRENDING, function(Browser $stats_results){
+                    ->with(self::$SELECTOR_STATS_RESULTS_TRENDING, function(Browser $stats_results) use ($include_transfers){
+                        $this->assertIncludeTransfersCheckboxButtonDefaultState($stats_results);
+                        if($include_transfers){
+                            $this->clickIncludeTransfersCheckboxButton($stats_results);
+                            $this->assertIncludesTransfersCheckboxButtonStateActive($stats_results);
+                        }
+
                         //  line-chart graph canvas should be visible
                         $stats_results->assertVisible(self::$SELECTOR_CHART_TRENDING);
                     })


### PR DESCRIPTION
- Added a checkbox/button to the stats _summary table_, _trending chart_, _distribution chart_ & _tags chart_ components to display/hide transfer related entries from aggregated results.
- Added notes to the `README.md` about which _production_ update states are optional.
- Added `php artisan view:cache` to the _production update_ steps within the `README.md`.

Resolves #255 