### PR TITLE
Feature/move-entry-controller-constants

### DIFF
--- a/app/Entry.php
+++ b/app/Entry.php
@@ -2,10 +2,12 @@
 
 namespace App;
 
-use App\Http\Controllers\Api\EntryController;
+use App\Traits\EntryFilterKeys;
 use Carbon\Carbon;
 
 class Entry extends BaseModel {
+
+    use EntryFilterKeys;
 
     const CREATED_AT = 'create_stamp';
     const UPDATED_AT = 'modified_stamp';
@@ -133,22 +135,22 @@ class Entry extends BaseModel {
     private static function filter_entry_collection($entries_query, $filters){
         foreach($filters as $filter_name => $filter_constraint){
             switch($filter_name){
-                case EntryController::FILTER_KEY_START_DATE:
+                case self::$FILTER_KEY_START_DATE:
                     $entries_query->where('entries.entry_date', '>=', $filter_constraint);
                     break;
-                case EntryController::FILTER_KEY_MIN_VALUE:
+                case self::$FILTER_KEY_MIN_VALUE:
                     $entries_query->where('entries.entry_value', '>=', $filter_constraint);
                     break;
-                case EntryController::FILTER_KEY_END_DATE:
+                case self::$FILTER_KEY_END_DATE:
                     $entries_query->where('entries.entry_date', '<=', $filter_constraint);
                     break;
-                case EntryController::FILTER_KEY_MAX_VALUE:
+                case self::$FILTER_KEY_MAX_VALUE:
                     $entries_query->where('entries.entry_value', '<=', $filter_constraint);
                     break;
-                case EntryController::FILTER_KEY_ACCOUNT_TYPE:
+                case self::$FILTER_KEY_ACCOUNT_TYPE:
                     $entries_query->where('entries.account_type_id', $filter_constraint);
                     break;
-                case EntryController::FILTER_KEY_EXPENSE:
+                case self::$FILTER_KEY_EXPENSE:
                     if($filter_constraint === true){
                         $entries_query->where('entries.expense', 1);
                     }
@@ -156,18 +158,18 @@ class Entry extends BaseModel {
                         $entries_query->where('entries.expense', 0);
                     }
                     break;
-                case EntryController::FILTER_KEY_UNCONFIRMED:
+                case self::$FILTER_KEY_UNCONFIRMED:
                     if($filter_constraint === true){
                         $entries_query->where('entries.confirm', 0);
                     }
                     break;
-                case EntryController::FILTER_KEY_ACCOUNT:
+                case self::$FILTER_KEY_ACCOUNT:
                     $entries_query->join('account_types', static function($join) use ($filter_constraint){
                         $join->on('entries.account_type_id', '=', 'account_types.id')
                             ->where('account_types.account_id', $filter_constraint);
                     });
                     break;
-                case EntryController::FILTER_KEY_ATTACHMENTS:
+                case self::$FILTER_KEY_ATTACHMENTS:
                     if($filter_constraint === true){
                         // to get COUNT(attachment.id) > 0 use:
                         // INNER JOIN attachments ON attachments.entry_id=entries.id
@@ -181,7 +183,7 @@ class Entry extends BaseModel {
                             ->whereNull('attachments.entry_id');
                     }
                     break;
-                case EntryController::FILTER_KEY_TAGS:
+                case self::$FILTER_KEY_TAGS:
                     // RIGHT JOIN entry_tags
                     //   ON entry_tags.entry_id=entries.id
                     //   AND entry_tags.tag_id IN ($tags)
@@ -191,7 +193,7 @@ class Entry extends BaseModel {
                             ->whereIn('entry_tags.tag_id', $tag_ids);
                     });
                     break;
-                case EntryController::FILTER_KEY_IS_TRANSFER:
+                case self::$FILTER_KEY_IS_TRANSFER:
                     if($filter_constraint === true){
                         // WHERE entries.transfer_entry_id IS NOT NULL
                         $entries_query->whereNotNull("transfer_entry_id");

--- a/app/Http/Controllers/Api/EntryController.php
+++ b/app/Http/Controllers/Api/EntryController.php
@@ -339,7 +339,7 @@ class EntryController extends Controller {
      */
     private function initTransferEntry($transfer_data, $transfer_side, $required_transfer_fields, $transfer_specific_fields, $transfer_entry_tags){
         // check validity of account_type_id value
-        $account_type = AccountType::find($transfer_data);
+        $account_type = AccountType::find($transfer_data[$transfer_side]);
         if(empty($account_type)){
             throw new \OutOfRangeException();
         }

--- a/app/Http/Controllers/Api/EntryController.php
+++ b/app/Http/Controllers/Api/EntryController.php
@@ -6,6 +6,7 @@ use App\Entry;
 use App\AccountType;
 use App\Attachment;
 use App\Tag;
+use App\Traits\MaxEntryResponseValue;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Storage;
@@ -15,7 +16,8 @@ use Symfony\Component\HttpFoundation\Response as HttpStatus;
 
 class EntryController extends Controller {
 
-    const MAX_ENTRIES_IN_RESPONSE = 50;
+    use MaxEntryResponseValue;
+
     const ERROR_ENTRY_ID = 0;
     const RESPONSE_SAVE_KEY_ID = 'id';
     const RESPONSE_SAVE_KEY_ERROR = 'error';
@@ -460,8 +462,8 @@ class EntryController extends Controller {
     private function provide_paged_entries_response($filters, $page_number=0, $sort_by=Entry::DEFAULT_SORT_PARAMETER, $sort_direction=Entry::DEFAULT_SORT_DIRECTION){
         $entries_collection = Entry::get_collection_of_non_disabled_entries(
             $filters,
-            EntryController::MAX_ENTRIES_IN_RESPONSE,
-            EntryController::MAX_ENTRIES_IN_RESPONSE*$page_number,
+            self::$MAX_ENTRIES_IN_RESPONSE,
+            self::$MAX_ENTRIES_IN_RESPONSE*$page_number,
             $sort_by,
             $sort_direction
         );

--- a/app/Http/Controllers/Api/EntryController.php
+++ b/app/Http/Controllers/Api/EntryController.php
@@ -251,7 +251,7 @@ class EntryController extends Controller {
 
         if(isset($transfer_data[self::$TRANSFER_KEY_TO_ACCOUNT_TYPE]) && $transfer_data[self::$TRANSFER_KEY_TO_ACCOUNT_TYPE] != self::$TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID){
             try{
-                $to_entry = $this->initTransferEntry($transfer_data, self::$TRANSFER_KEY_TO_ACCOUNT_TYPE, $transfer_specific_fields, $transfer_specific_fields, $entry_tags);
+                $to_entry = $this->initTransferEntry($transfer_data, self::$TRANSFER_KEY_TO_ACCOUNT_TYPE, $required_transfer_fields, $transfer_specific_fields, $entry_tags);
             } catch(\OutOfRangeException $e){
                 return response(
                     [self::$RESPONSE_SAVE_KEY_ERROR=>self::$ERROR_MSG_SAVE_ENTRY_INVALID_ACCOUNT_TYPE, self::$RESPONSE_SAVE_KEY_ID=>[]],
@@ -341,7 +341,7 @@ class EntryController extends Controller {
         // check validity of account_type_id value
         $account_type = AccountType::find($transfer_data[$transfer_side]);
         if(empty($account_type)){
-            throw new \OutOfRangeException();
+            throw new \OutOfRangeException(self::$ERROR_MSG_SAVE_ENTRY_INVALID_ACCOUNT_TYPE);
         }
 
         $transfer_entry = new Entry();

--- a/app/Http/Controllers/Api/EntryController.php
+++ b/app/Http/Controllers/Api/EntryController.php
@@ -251,7 +251,7 @@ class EntryController extends Controller {
 
         if(isset($transfer_data[self::$TRANSFER_KEY_TO_ACCOUNT_TYPE]) && $transfer_data[self::$TRANSFER_KEY_TO_ACCOUNT_TYPE] != self::$TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID){
             try{
-                $to_entry = $this->initTransferEntry($transfer_specific_fields, self::$TRANSFER_KEY_TO_ACCOUNT_TYPE, $transfer_specific_fields, $transfer_specific_fields, $entry_tags);
+                $to_entry = $this->initTransferEntry($transfer_data, self::$TRANSFER_KEY_TO_ACCOUNT_TYPE, $transfer_specific_fields, $transfer_specific_fields, $entry_tags);
             } catch(\OutOfRangeException $e){
                 return response(
                     [self::$RESPONSE_SAVE_KEY_ERROR=>self::$ERROR_MSG_SAVE_ENTRY_INVALID_ACCOUNT_TYPE, self::$RESPONSE_SAVE_KEY_ID=>[]],

--- a/app/Traits/EntryFilterKeys.php
+++ b/app/Traits/EntryFilterKeys.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Traits;
+
+trait EntryFilterKeys {
+
+    private static $FILTER_KEY_ACCOUNT = 'account';
+    private static $FILTER_KEY_ACCOUNT_TYPE = 'account_type';
+    private static $FILTER_KEY_ATTACHMENTS = 'attachments';
+    private static $FILTER_KEY_END_DATE = 'end_date';
+    private static $FILTER_KEY_EXPENSE = 'expense';
+    private static $FILTER_KEY_IS_TRANSFER = 'is_transfer';
+    private static $FILTER_KEY_MAX_VALUE = 'max_value';
+    private static $FILTER_KEY_MIN_VALUE = 'min_value';
+    private static $FILTER_KEY_START_DATE = 'start_date';
+    private static $FILTER_KEY_TAGS = 'tags';
+    private static $FILTER_KEY_UNCONFIRMED = 'unconfirmed';
+    private static $FILTER_KEY_SORT = 'sort';
+    private static $FILTER_KEY_SORT_PARAMETER = 'parameter';
+    private static $FILTER_KEY_SORT_DIRECTION = 'direction';
+
+    /**
+     * @param bool $include_tag_ids
+     * @return array
+     */
+    public static function getFilterValidationRules($include_tag_ids = true){
+        $filter_details = [
+            self::$FILTER_KEY_START_DATE=>'date_format:Y-m-d',
+            self::$FILTER_KEY_END_DATE=>'date_format:Y-m-d',
+            self::$FILTER_KEY_ACCOUNT=>'integer',
+            self::$FILTER_KEY_ACCOUNT_TYPE=>'integer',
+            self::$FILTER_KEY_TAGS=>'array',
+            self::$FILTER_KEY_EXPENSE=>'boolean',
+            self::$FILTER_KEY_ATTACHMENTS=>'boolean',
+            self::$FILTER_KEY_MIN_VALUE=>'numeric',
+            self::$FILTER_KEY_MAX_VALUE=>'numeric',
+            self::$FILTER_KEY_UNCONFIRMED=>'boolean',
+            self::$FILTER_KEY_IS_TRANSFER=>'boolean'
+        ];
+
+        if($include_tag_ids){
+            $tags = \App\Tag::all();
+            $tag_ids = $tags->pluck('id')->toArray();
+            $filter_details['tags.*'] = 'in:'.implode(',', $tag_ids);
+        }
+
+        return $filter_details;
+    }
+}

--- a/app/Traits/EntryResponseKeys.php
+++ b/app/Traits/EntryResponseKeys.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Traits;
+
+trait EntryResponseKeys {
+
+    private static $ERROR_ENTRY_ID = 0;
+    private static $RESPONSE_SAVE_KEY_ID = 'id';
+    private static $RESPONSE_SAVE_KEY_ERROR = 'error';
+    private static $RESPONSE_FILTER_KEY_ERROR = 'error';
+    private static $ERROR_MSG_SAVE_ENTRY_NO_ERROR = '';
+    private static $ERROR_MSG_SAVE_ENTRY_NO_DATA = "No data provided";
+    private static $ERROR_MSG_SAVE_ENTRY_MISSING_PROPERTY = "Missing data: %s";
+    private static $ERROR_MSG_SAVE_ENTRY_INVALID_ACCOUNT_TYPE = "Account type provided does not exist";
+    private static $ERROR_MSG_SAVE_ENTRY_DOES_NOT_EXIST = "Entry does not exist";
+    private static $ERROR_MSG_SAVE_TRANSFER_BOTH_EXTERNAL = "A transfer can not consist with both entries belonging to external accounts";
+    private static $ERROR_MSG_FILTER_INVALID = 'invalid filter provided';
+
+}

--- a/app/Traits/EntryTransferKeys.php
+++ b/app/Traits/EntryTransferKeys.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Traits;
+
+trait EntryTransferKeys {
+
+    private static $TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID = 0;
+    private static $TRANSFER_KEY_FROM_ACCOUNT_TYPE = 'from_account_type_id';
+    private static $TRANSFER_KEY_TO_ACCOUNT_TYPE = 'to_account_type_id';
+
+}

--- a/app/Traits/MaxEntryResponseValue.php
+++ b/app/Traits/MaxEntryResponseValue.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Traits;
+
+trait MaxEntryResponseValue {
+
+    public static $MAX_ENTRIES_IN_RESPONSE = 50;
+
+}

--- a/app/Traits/Tests/Dusk/BatchFilterEntries.php
+++ b/app/Traits/Tests/Dusk/BatchFilterEntries.php
@@ -2,12 +2,13 @@
 
 namespace App\Traits\Tests\Dusk;
 
-use App\Http\Controllers\Api\EntryController;
+use App\Traits\EntryFilterKeys;
 use App\Traits\MaxEntryResponseValue;
 use Illuminate\Support\Collection;
 
 trait BatchFilterEntries {
 
+    use EntryFilterKeys;
     use MaxEntryResponseValue;
 
     /**
@@ -17,8 +18,8 @@ trait BatchFilterEntries {
      * @return array
      */
     private function generateFilterArrayElementDatepicker($filter_data, $start_date, $end_date){
-        $filter_data[EntryController::FILTER_KEY_START_DATE] = $start_date;
-        $filter_data[EntryController::FILTER_KEY_END_DATE] = $end_date;
+        $filter_data[self::$FILTER_KEY_START_DATE] = $start_date;
+        $filter_data[self::$FILTER_KEY_END_DATE] = $end_date;
         return $filter_data;
     }
 
@@ -31,9 +32,9 @@ trait BatchFilterEntries {
     private function generateFilterArrayElementAccountOrAccountypeId($filter_data, $is_account_switch_toggled, $account_or_account_type_id){
         if(!empty($account_or_account_type_id)){
             if($is_account_switch_toggled){
-                $filter_data[EntryController::FILTER_KEY_ACCOUNT_TYPE] = $account_or_account_type_id;
+                $filter_data[self::$FILTER_KEY_ACCOUNT_TYPE] = $account_or_account_type_id;
             } else {
-                $filter_data[EntryController::FILTER_KEY_ACCOUNT] = $account_or_account_type_id;
+                $filter_data[self::$FILTER_KEY_ACCOUNT] = $account_or_account_type_id;
             }
         }
         return $filter_data;
@@ -45,7 +46,7 @@ trait BatchFilterEntries {
      * @return array
      */
     private function generateFilterArrayElementExpense($filter_data, $is_expense){
-        $filter_data[EntryController::FILTER_KEY_EXPENSE] = $is_expense;
+        $filter_data[self::$FILTER_KEY_EXPENSE] = $is_expense;
         return $filter_data;
     }
 
@@ -56,7 +57,7 @@ trait BatchFilterEntries {
      */
     private function generateFilterArrayElementTags($filter_data, $tags){
         if(!is_null($tags)){
-            $filter_data[EntryController::FILTER_KEY_TAGS] = $tags->pluck('id')->toArray();
+            $filter_data[self::$FILTER_KEY_TAGS] = $tags->pluck('id')->toArray();
         }
         return $filter_data;
     }

--- a/app/Traits/Tests/Dusk/BatchFilterEntries.php
+++ b/app/Traits/Tests/Dusk/BatchFilterEntries.php
@@ -3,9 +3,12 @@
 namespace App\Traits\Tests\Dusk;
 
 use App\Http\Controllers\Api\EntryController;
+use App\Traits\MaxEntryResponseValue;
 use Illuminate\Support\Collection;
 
 trait BatchFilterEntries {
+
+    use MaxEntryResponseValue;
 
     /**
      * @param array $filter_data
@@ -68,7 +71,7 @@ trait BatchFilterEntries {
             throw new \UnexpectedValueException("Entries not available with filter ".json_encode($filter_data));
         }
 
-        $total_pages = (int) ceil($entries['count']/EntryController::MAX_ENTRIES_IN_RESPONSE);
+        $total_pages = (int) ceil($entries['count']/self::$MAX_ENTRIES_IN_RESPONSE);
         $entries_collection = collect($this->removeCountFromApiResponse($entries));
 
         for($i=1; $i<$total_pages; $i++){

--- a/database/seeds/UiSampleDatabaseSeeder.php
+++ b/database/seeds/UiSampleDatabaseSeeder.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Helpers\CurrencyHelper;
-use App\Http\Controllers\Api\EntryController;
 use Carbon\Carbon;
 use Illuminate\Database\Seeder;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -10,6 +9,7 @@ class UiSampleDatabaseSeeder extends Seeder {
 
     use App\Traits\Tests\StorageTestFiles;
     use WithFaker;
+    use \App\Traits\MaxEntryResponseValue;
 
     const CLI_OUTPUT_PREFIX = "<info>".__CLASS__.":</info> ";
 
@@ -87,10 +87,10 @@ class UiSampleDatabaseSeeder extends Seeder {
         $entries_not_confirmed = $entries_not_disabled->where('confirm', 0);
 
         // just in case we missed an entry necessary for testing, we're going to assign tags to random confirmed & unconfirmed entries
-        $this->attachTagToEntry($tag_ids, $entries_not_confirmed->where('expense', 1)->sortByDesc('entry_date')->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE/2)->first()->random());
-        $this->attachTagToEntry($tag_ids, $entries_not_confirmed->where('expense', 0)->sortByDesc('entry_date')->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE/2)->first()->random());
-        $this->attachTagToEntry($tag_ids, $entries_confirmed->where('expense', 1)->sortByDesc('entry_date')->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE/2)->first()->random());
-        $this->attachTagToEntry($tag_ids, $entries_confirmed->where('expense', 0)->sortByDesc('entry_date')->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE/2)->first()->random());
+        $this->attachTagToEntry($tag_ids, $entries_not_confirmed->where('expense', 1)->sortByDesc('entry_date')->chunk(self::$MAX_ENTRIES_IN_RESPONSE/2)->first()->random());
+        $this->attachTagToEntry($tag_ids, $entries_not_confirmed->where('expense', 0)->sortByDesc('entry_date')->chunk(self::$MAX_ENTRIES_IN_RESPONSE/2)->first()->random());
+        $this->attachTagToEntry($tag_ids, $entries_confirmed->where('expense', 1)->sortByDesc('entry_date')->chunk(self::$MAX_ENTRIES_IN_RESPONSE/2)->first()->random());
+        $this->attachTagToEntry($tag_ids, $entries_confirmed->where('expense', 0)->sortByDesc('entry_date')->chunk(self::$MAX_ENTRIES_IN_RESPONSE/2)->first()->random());
         $this->command->line(self::CLI_OUTPUT_PREFIX."Randomly assigned tags to entries");
 
         // randomly select some entries and mark them as transfers
@@ -107,11 +107,11 @@ class UiSampleDatabaseSeeder extends Seeder {
         }
         $external_transfer_entry = $entries_not_disabled
             ->sortByDesc('entry_date')
-            ->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)
+            ->chunk(self::$MAX_ENTRIES_IN_RESPONSE)
             ->first()
             ->where('transfer_entry_id', null)
             ->random();
-        $external_transfer_entry->transfer_entry_id = EntryController::TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID;
+        $external_transfer_entry->transfer_entry_id = self::$MAX_ENTRIES_IN_RESPONSE;
         $external_transfer_entry->save();
         $this->command->line(self::CLI_OUTPUT_PREFIX."Randomly marked entries as transfers");
 
@@ -129,7 +129,7 @@ class UiSampleDatabaseSeeder extends Seeder {
         // income confirmed
         $this->assignAttachmentToEntry(
             $entries_confirmed
-                ->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)->shift()
+                ->chunk(self::$MAX_ENTRIES_IN_RESPONSE)->shift()
                 ->where('expense', 0)->pluck('id')
                 ->random(),
             $transfer_to_entries->pluck('id')->toArray(),
@@ -138,7 +138,7 @@ class UiSampleDatabaseSeeder extends Seeder {
         // income unconfirmed
         $this->assignAttachmentToEntry(
             $entries_not_confirmed
-                ->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)->shift()
+                ->chunk(self::$MAX_ENTRIES_IN_RESPONSE)->shift()
                 ->where('expense', 0)->pluck('id')
                 ->random(),
             $transfer_to_entries->pluck('id')->toArray(),
@@ -147,7 +147,7 @@ class UiSampleDatabaseSeeder extends Seeder {
         // expense confirmed
         $this->assignAttachmentToEntry(
             $entries_confirmed
-                ->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)->shift()
+                ->chunk(self::$MAX_ENTRIES_IN_RESPONSE)->shift()
                 ->where('expense', 1)->pluck('id')
                 ->random(),
             $transfer_from_entries->pluck('id')->toArray(),
@@ -156,7 +156,7 @@ class UiSampleDatabaseSeeder extends Seeder {
         // expense unconfirmed
         $this->assignAttachmentToEntry(
             $entries_not_confirmed
-                ->chunk(EntryController::MAX_ENTRIES_IN_RESPONSE)->shift()
+                ->chunk(self::$MAX_ENTRIES_IN_RESPONSE)->shift()
                 ->where('expense', 1)->pluck('id')
                 ->random(),
             $transfer_from_entries->pluck('id')->toArray(),

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -424,13 +424,20 @@ class EntryModalExistingEntryTest extends DuskTestCase {
         $this->browse(function(Browser $browser){
             $entry_selector = $this->randomUnconfirmedEntrySelector(true);
             $old_value = "";
-            $new_value = date("Y-m-d", strtotime("-90 days"));
+            $new_value = '';
 
             $browser->visit(new HomePage());
             $this->waitForLoadingToStop($browser);
             $browser->openExistingEntryModal($entry_selector)
-                ->with($this->_selector_modal_body, function(Browser $modal_body) use (&$old_value, $new_value){
+                ->with($this->_selector_modal_body, function(Browser $modal_body) use (&$old_value, &$new_value){
                     $old_value = $modal_body->value($this->_selector_modal_entry_field_date);
+                    // just in case the old and new values match
+                    $day_diff = -90;
+                    do{
+                        $new_value = date("Y-m-d", strtotime(sprintf("%d days", $day_diff)));
+                        $day_diff--;
+                    } while ($new_value === $old_value);
+
                     // clear input[type="date"]
                     for($i=0; $i<strlen($old_value); $i++){
                         $modal_body->keys($this->_selector_modal_entry_field_date, "{backspace}");

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Browser;
 
 use App\Entry;
-use App\Http\Controllers\Api\EntryController;
+use App\Traits\EntryTransferKeys;
 use App\Traits\Tests\Dusk\BulmaColors as DuskTraitBulmaColors;
 use App\Traits\Tests\Dusk\Loading as DuskTraitLoading;
 use App\Traits\Tests\Dusk\Navbar as DuskTraitNavbar;
@@ -29,6 +29,7 @@ use Throwable;
  */
 class EntryModalExistingEntryTest extends DuskTestCase {
 
+    use EntryTransferKeys;
     use WaitTimes;
     use HomePageSelectors;
     use DuskTraitBulmaColors;
@@ -748,7 +749,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                 $entry_selector = $this->randomEntrySelector(['is_transfer'=>true]);
                 $entry_id = $this->getEntryIdFromSelector($entry_selector);
                 $entry_data = $this->getApiEntry($entry_id);
-            } while($entry_data['transfer_entry_id'] !== EntryController::TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID);
+            } while($entry_data['transfer_entry_id'] !== self::$TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID);
             $this->assertEquals($entry_id, $entry_data['id']);
             $entry_selector .= '.'.$this->_class_is_transfer;
 

--- a/tests/Browser/StatsBase.php
+++ b/tests/Browser/StatsBase.php
@@ -5,7 +5,7 @@ namespace Tests\Browser;
 use App\Account;
 use App\AccountType;
 use App\Entry;
-use App\Http\Controllers\Api\EntryController;
+use App\Traits\EntryFilterKeys;
 use App\Traits\Tests\Dusk\BulmaDatePicker as DuskTraitBulmaDatePicker;
 use App\Traits\Tests\Dusk\Loading as DuskTraitLoading;
 use App\Traits\Tests\Dusk\StatsSidePanel as DuskTraitStatsSidePanel;
@@ -23,6 +23,7 @@ class StatsBase extends DuskTestCase {
     use DuskTraitLoading;
     use DuskTraitStatsIncludeTransfersCheckboxButton;
     use DuskTraitStatsSidePanel;
+    use EntryFilterKeys;
     use WithFaker;
 
     protected static $SELECTOR_STATS_FORM_SUMMARY = "#stats-form-summary";
@@ -102,16 +103,16 @@ class StatsBase extends DuskTestCase {
         }
         
         $new_entry_data['entry_date'] = $this->faker
-            ->dateTimeBetween($filter_data[EntryController::FILTER_KEY_START_DATE], $filter_data[EntryController::FILTER_KEY_END_DATE])
+            ->dateTimeBetween($filter_data[self::$FILTER_KEY_START_DATE], $filter_data[self::$FILTER_KEY_END_DATE])
             ->format("Y-m-d");
-        if(isset($filter_data[EntryController::FILTER_KEY_EXPENSE])){
-            $new_entry_data['expense'] = $filter_data[EntryController::FILTER_KEY_EXPENSE];
+        if(isset($filter_data[self::$FILTER_KEY_EXPENSE])){
+            $new_entry_data['expense'] = $filter_data[self::$FILTER_KEY_EXPENSE];
         }
 
-        if(!empty($filter_data[EntryController::FILTER_KEY_ACCOUNT_TYPE])){
-            $new_entry_data['account_type_id'] = $filter_data[EntryController::FILTER_KEY_ACCOUNT_TYPE];
-        } elseif(!empty($filter_data[EntryController::FILTER_KEY_ACCOUNT])){
-            $account = Account::find_account_with_types($filter_data[EntryController::FILTER_KEY_ACCOUNT]);
+        if(!empty($filter_data[self::$FILTER_KEY_ACCOUNT_TYPE])){
+            $new_entry_data['account_type_id'] = $filter_data[self::$FILTER_KEY_ACCOUNT_TYPE];
+        } elseif(!empty($filter_data[self::$FILTER_KEY_ACCOUNT])){
+            $account = Account::find_account_with_types($filter_data[self::$FILTER_KEY_ACCOUNT]);
             $new_entry_data['account_type_id'] = $account->account_types->first()->id;
         } else {
             // Can't leave the assignment up to RNG in the factory.
@@ -120,8 +121,8 @@ class StatsBase extends DuskTestCase {
         }
 
         $entry = factory(Entry::class)->create($new_entry_data);
-        if(!empty($filter_data[EntryController::FILTER_KEY_TAGS])){
-            $entry->tags()->attach($filter_data[EntryController::FILTER_KEY_TAGS]);
+        if(!empty($filter_data[self::$FILTER_KEY_TAGS])){
+            $entry->tags()->attach($filter_data[self::$FILTER_KEY_TAGS]);
         }
     }
 

--- a/tests/Browser/TransferModalTest.php
+++ b/tests/Browser/TransferModalTest.php
@@ -4,7 +4,7 @@ namespace Tests\Browser;
 
 use App\Account;
 use App\AccountType;
-use App\Http\Controllers\Api\EntryController;
+use App\Traits\EntryTransferKeys;
 use App\Traits\Tests\Dusk\Loading as DuskTraitLoading;
 use App\Traits\Tests\Dusk\Navbar as DuskTraitNavbar;
 use App\Traits\Tests\Dusk\Notification as DuskTraitNotification;
@@ -28,6 +28,7 @@ use Throwable;
 class TransferModalTest extends DuskTestCase {
 
     use HomePageSelectors;
+    use EntryTransferKeys;
     use DuskTraitLoading;
     use DuskTraitNavbar;
     use DuskTraitNotification;
@@ -549,8 +550,8 @@ class TransferModalTest extends DuskTestCase {
             $transfer_entry_data = [
                 'memo'=>"Test transfer - save".($has_tags?" w/ tags":'').($has_attachments?" w/ attachments":'').' - '.$this->faker->uuid,
                 'value'=>$this->faker->randomFloat(2, 0, 100),
-                'from_account_type_id'=>($is_from_account_external ? EntryController::TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID : $account_types[0]['id']),
-                'to_account_type_id'=>($is_to_account_external ? EntryController::TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID : $account_types[1]['id']),
+                'from_account_type_id'=>($is_from_account_external ? self::$TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID : $account_types[0]['id']),
+                'to_account_type_id'=>($is_to_account_external ? self::$TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID : $account_types[1]['id']),
                 'tag'=>$tag,
                 'attachment_path'=>\Storage::path($this->getRandomTestFileStoragePath()),
             ];

--- a/tests/Browser/UpdateAccountTotalTest.php
+++ b/tests/Browser/UpdateAccountTotalTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Browser;
 
 use App\Entry;
-use App\Http\Controllers\Api\EntryController;
+use App\Traits\EntryTransferKeys;
 use App\Traits\Tests\Dusk\Loading;
 use App\Traits\Tests\Dusk\Navbar;
 use App\Traits\Tests\WaitTimes;
@@ -25,6 +25,7 @@ use Throwable;
  */
 class UpdateAccountTotalTest extends DuskTestCase {
 
+    use EntryTransferKeys;
     use HomePageSelectors;
     use WaitTimes;
     use Loading;
@@ -258,12 +259,12 @@ class UpdateAccountTotalTest extends DuskTestCase {
 
         } elseif($is_to_account_external){
             $account['to']['id'] = 0;
-            $account['to']['account_type_id'] = EntryController::TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID;
+            $account['to']['account_type_id'] = self::$TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID;
             $account['from'] = $this->_account;
             $account['from']['account_type_id'] = $this->_account_type_id;
         } elseif($is_from_account_external){
             $account['from']['id'] = 0;
-            $account['from']['account_type_id'] = EntryController::TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID;
+            $account['from']['account_type_id'] = self::$TRANSFER_EXTERNAL_ACCOUNT_TYPE_ID;
             $account['to'] = $this->_account;
             $account['to']['account_type_id'] = $this->_account_type_id;
         }

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -3,7 +3,7 @@
 namespace Tests;
 
 use App\Entry;
-use App\Http\Controllers\Api\EntryController;
+use App\Traits\EntryFilterKeys;
 use App\Traits\Tests\LogTestName;
 use App\Traits\Tests\StorageTestFiles;
 use Laravel\Dusk\Browser;
@@ -14,6 +14,7 @@ use Facebook\WebDriver\Remote\DesiredCapabilities;
 abstract class DuskTestCase extends BaseTestCase {
 
     use CreatesApplication;
+    use EntryFilterKeys;
     use StorageTestFiles;
     use LogTestName;
 
@@ -151,11 +152,11 @@ abstract class DuskTestCase extends BaseTestCase {
      * @return array
      */
     public function getApiEntries($page_number=0, $filter_data=[]){
-        // See resources/assets/js/entries.js:16-38
-        // See app/Http/Controllers/Api/EntryController.php:30-43
-        $sort = [EntryController::FILTER_KEY_SORT=>[
-            EntryController::FILTER_KEY_SORT_PARAMETER=>"entry_date",
-            EntryController::FILTER_KEY_SORT_DIRECTION=>Entry::DEFAULT_SORT_DIRECTION
+        // See resources/js/entries.js:16-38
+        // See app/Traits/EntryFilterKeys.php:7-20
+        $sort = [self::$FILTER_KEY_SORT=>[
+            self::$FILTER_KEY_SORT_PARAMETER=>"entry_date",
+            self::$FILTER_KEY_SORT_DIRECTION=>Entry::DEFAULT_SORT_DIRECTION
         ]];
         $filter_data = array_merge($filter_data, $sort);
         $entries_response = $this->json('POST', '/api/entries/'.$page_number, $filter_data);

--- a/tests/Feature/Api/Get/GetEntriesTest.php
+++ b/tests/Feature/Api/Get/GetEntriesTest.php
@@ -4,11 +4,13 @@ namespace Tests\Feature\Api\Get;
 
 use App\AccountType;
 use App\Entry;
-use App\Http\Controllers\Api\EntryController;
+use App\Traits\MaxEntryResponseValue;
 use Illuminate\Support\Facades\DB;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 
 class GetEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
+
+    use MaxEntryResponseValue;
 
     public function testGetEntriesThatDoNotExist(){
         // GIVEN - no data in database
@@ -27,7 +29,7 @@ class GetEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
         // GIVEN
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
 
-        $generate_entry_count = $this->_faker->numberBetween(self::MIN_TEST_ENTRIES, EntryController::MAX_ENTRIES_IN_RESPONSE);
+        $generate_entry_count = $this->_faker->numberBetween(self::MIN_TEST_ENTRIES, self::$MAX_ENTRIES_IN_RESPONSE);
         $generated_entries = $this->batch_generate_entries($generate_entry_count, $generated_account_type->id, [], true);
         $generated_disabled_entries = $generated_entries->where('disabled', 1);
         if($generated_disabled_entries->count() > 0){   // if there are no disabled entries, then there is no need to do any fancy filtering
@@ -62,7 +64,7 @@ class GetEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
         $page_limit = 3;
         // GIVEN
         $generated_account_type = factory(AccountType::class)->create(['account_id' => $this->_generated_account->id]);
-        $generate_entry_count = $this->_faker->numberBetween(($page_limit-1)*EntryController::MAX_ENTRIES_IN_RESPONSE+1, $page_limit*EntryController::MAX_ENTRIES_IN_RESPONSE);
+        $generate_entry_count = $this->_faker->numberBetween(($page_limit-1)*self::$MAX_ENTRIES_IN_RESPONSE+1, $page_limit*self::$MAX_ENTRIES_IN_RESPONSE);
         $generated_entries = $this->batch_generate_entries($generate_entry_count, $generated_account_type->id);
 
         $entries_in_response = [];
@@ -80,9 +82,9 @@ class GetEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
             unset($response_body_as_array['count']);
 
             if($i+1 == $page_limit){
-                $this->assertCount($generate_entry_count - (($page_limit - 1) * EntryController::MAX_ENTRIES_IN_RESPONSE), $response_body_as_array);
+                $this->assertCount($generate_entry_count - (($page_limit - 1) * self::$MAX_ENTRIES_IN_RESPONSE), $response_body_as_array);
             } else {
-                $this->assertCount(EntryController::MAX_ENTRIES_IN_RESPONSE, $response_body_as_array);
+                $this->assertCount(self::$MAX_ENTRIES_IN_RESPONSE, $response_body_as_array);
             }
 
             $entries_in_response = array_merge($entries_in_response, $response_body_as_array);
@@ -113,9 +115,9 @@ class GetEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
         // GIVEN
         $table = with(new Entry)->getTable();
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
-        $generated_entries = factory(Entry::class, EntryController::MAX_ENTRIES_IN_RESPONSE)->make(['account_type_id'=>$generated_account_type->id]);
+        $generated_entries = factory(Entry::class, self::$MAX_ENTRIES_IN_RESPONSE)->make(['account_type_id'=>$generated_account_type->id]);
         // generating entries in batches and using database insert methods because it's faster
-        for($i=0; $i<($entry_count/EntryController::MAX_ENTRIES_IN_RESPONSE); $i++){
+        for($i=0; $i<($entry_count/self::$MAX_ENTRIES_IN_RESPONSE); $i++){
             DB::table($table)->insert($generated_entries->toArray());
         }
 
@@ -127,7 +129,7 @@ class GetEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
         $response_as_array = $response->json();
         $this->assertEquals($entry_count, $response_as_array['count']);
         unset($response_as_array['count']);
-        $this->assertCount(EntryController::MAX_ENTRIES_IN_RESPONSE, $response_as_array);
+        $this->assertCount(self::$MAX_ENTRIES_IN_RESPONSE, $response_as_array);
     }
 
 }

--- a/tests/Feature/Api/Post/PostEntriesTest.php
+++ b/tests/Feature/Api/Post/PostEntriesTest.php
@@ -5,12 +5,13 @@ namespace Tests\Feature\Api\Post;
 use App\AccountType;
 use App\Entry;
 use App\Tag;
-use App\Http\Controllers\Api\EntryController;
+use App\Traits\EntryFilterKeys;
 use App\Traits\MaxEntryResponseValue;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 
 class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
 
+    use EntryFilterKeys;
     use MaxEntryResponseValue;
 
     public function providerPostEntriesFilter(){
@@ -31,36 +32,36 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
         $min_value = $this->_faker->randomFloat(2, 0, $max_value);
 
         $filter_details = [
-            EntryController::FILTER_KEY_START_DATE=>$start_date,
-            EntryController::FILTER_KEY_END_DATE=>$end_date,
-            EntryController::FILTER_KEY_ACCOUNT=>0,       // will be set later
-            EntryController::FILTER_KEY_ACCOUNT_TYPE=>0,  // will be set later
-            EntryController::FILTER_KEY_TAGS=>[],         // will be set later
-            EntryController::FILTER_KEY_EXPENSE=>$this->_faker->boolean,
-            EntryController::FILTER_KEY_ATTACHMENTS=>$this->_faker->boolean,
-            EntryController::FILTER_KEY_MIN_VALUE=>$min_value,
-            EntryController::FILTER_KEY_MAX_VALUE=>$max_value,
-            EntryController::FILTER_KEY_UNCONFIRMED=>$this->_faker->boolean,
-            EntryController::FILTER_KEY_IS_TRANSFER=>$this->_faker->boolean,
+            self::$FILTER_KEY_START_DATE=>$start_date,
+            self::$FILTER_KEY_END_DATE=>$end_date,
+            self::$FILTER_KEY_ACCOUNT=>0,       // will be set later
+            self::$FILTER_KEY_ACCOUNT_TYPE=>0,  // will be set later
+            self::$FILTER_KEY_TAGS=>[],         // will be set later
+            self::$FILTER_KEY_EXPENSE=>$this->_faker->boolean,
+            self::$FILTER_KEY_ATTACHMENTS=>$this->_faker->boolean,
+            self::$FILTER_KEY_MIN_VALUE=>$min_value,
+            self::$FILTER_KEY_MAX_VALUE=>$max_value,
+            self::$FILTER_KEY_UNCONFIRMED=>$this->_faker->boolean,
+            self::$FILTER_KEY_IS_TRANSFER=>$this->_faker->boolean,
         ];
 
-        // confirm all filters in EntryController are listed here
-        $current_filters = EntryController::get_filter_details(false);
+        // confirm all filters in EntryFilterKeys trait are listed here
+        $current_filters = self::getFilterValidationRules(false);
         foreach(array_keys($current_filters) as $existing_filter){
             $this->assertArrayHasKey($existing_filter, $filter_details);
         }
 
         // individual filter requests
         foreach($filter_details as $filter_name=>$filter_value){
-            // confirm all filters listed in test are in EntryController
+            // confirm all filters listed in test are in EntryFilterKeys trait
             $this->assertArrayHasKey($filter_name, $current_filters);
 
             // adding a switch to catch all eventualities for boolean conditions
             switch($filter_name){
-                case EntryController::FILTER_KEY_EXPENSE:
-                case EntryController::FILTER_KEY_ATTACHMENTS:
-                case EntryController::FILTER_KEY_UNCONFIRMED:
-                case EntryController::FILTER_KEY_IS_TRANSFER:
+                case self::$FILTER_KEY_EXPENSE:
+                case self::$FILTER_KEY_ATTACHMENTS:
+                case self::$FILTER_KEY_UNCONFIRMED:
+                case self::$FILTER_KEY_IS_TRANSFER:
                     $filter["filtering [".$filter_name.":true]"] = [
                         [$filter_name=>true]
                     ];
@@ -181,7 +182,7 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
             $this->_generated_tags = factory(Tag::class, $this->_faker->randomDigitNotNull)->create();
         }
         $tag_ids = $this->_generated_tags->pluck('id')->toArray();
-        $filter_details[EntryController::FILTER_KEY_TAGS] = $this->_faker->randomElements($tag_ids, $this->_faker->numberBetween($min_number_of_tags, count($tag_ids)));
+        $filter_details[self::$FILTER_KEY_TAGS] = $this->_faker->randomElements($tag_ids, $this->_faker->numberBetween($min_number_of_tags, count($tag_ids)));
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
         $generated_entries = $this->batch_generate_entries(1, $generated_account_type->id, $this->convert_filters_to_entry_components($filter_details));
 
@@ -203,8 +204,8 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
             $end_date = $this->_faker->date("Y-m-d", $start_date);  // second parameter guarantees $start_date is >= $end_date
         }while($start_date < $end_date);
         $filter_details = [
-            EntryController::FILTER_KEY_START_DATE=>$start_date,
-            EntryController::FILTER_KEY_END_DATE=>$end_date,
+            self::$FILTER_KEY_START_DATE=>$start_date,
+            self::$FILTER_KEY_END_DATE=>$end_date,
         ];
 
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
@@ -219,8 +220,8 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
             $start_date = $this->_faker->date("Y-m-d", $end_date); // second parameter guarantees $start_date is <= $end_date
         }while($start_date > $end_date);
         $filter_details = [
-            EntryController::FILTER_KEY_START_DATE=>$start_date,
-            EntryController::FILTER_KEY_END_DATE=>$end_date,
+            self::$FILTER_KEY_START_DATE=>$start_date,
+            self::$FILTER_KEY_END_DATE=>$end_date,
         ];
 
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
@@ -245,8 +246,8 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
             $max_value = $this->_faker->randomFloat(2, 0, $min_value);
         }while($min_value < $max_value);
         $filter_details = [
-            EntryController::FILTER_KEY_MIN_VALUE=>$min_value,
-            EntryController::FILTER_KEY_MAX_VALUE=>$max_value,
+            self::$FILTER_KEY_MIN_VALUE=>$min_value,
+            self::$FILTER_KEY_MAX_VALUE=>$max_value,
         ];
 
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
@@ -261,8 +262,8 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
             $min_value = $this->_faker->randomFloat(2, 0, $max_value);
         }while($min_value > $max_value);
         $filter_details = [
-            EntryController::FILTER_KEY_MIN_VALUE=>$min_value,
-            EntryController::FILTER_KEY_MAX_VALUE=>$max_value,
+            self::$FILTER_KEY_MIN_VALUE=>$min_value,
+            self::$FILTER_KEY_MAX_VALUE=>$max_value,
         ];
 
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
@@ -288,8 +289,8 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
         // how we intend to sort
         $sort_options = Entry::get_fields_required_for_creation();
         unset($sort_options['memo']);   // can't and don't intend to sort by entry memo
-        $filter_details[EntryController::FILTER_KEY_SORT][EntryController::FILTER_KEY_SORT_PARAMETER] = $this->_faker->randomElement($sort_options);
-        $filter_details[EntryController::FILTER_KEY_SORT][EntryController::FILTER_KEY_SORT_DIRECTION] = $this->_faker->randomElement([Entry::SORT_DIRECTION_ASC, Entry::SORT_DIRECTION_DESC]);
+        $filter_details[self::$FILTER_KEY_SORT][self::$FILTER_KEY_SORT_PARAMETER] = $this->_faker->randomElement($sort_options);
+        $filter_details[self::$FILTER_KEY_SORT][self::$FILTER_KEY_SORT_DIRECTION] = $this->_faker->randomElement([Entry::SORT_DIRECTION_ASC, Entry::SORT_DIRECTION_DESC]);
 
         // WHEN
         $response = $this->json("POST", $this->_uri, $filter_details);
@@ -304,8 +305,8 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
             $response_as_array,
             $generated_entries,
             [],
-            $filter_details[EntryController::FILTER_KEY_SORT][EntryController::FILTER_KEY_SORT_PARAMETER],
-            $filter_details[EntryController::FILTER_KEY_SORT][EntryController::FILTER_KEY_SORT_DIRECTION]
+            $filter_details[self::$FILTER_KEY_SORT][self::$FILTER_KEY_SORT_PARAMETER],
+            $filter_details[self::$FILTER_KEY_SORT][self::$FILTER_KEY_SORT_DIRECTION]
         );
     }
 
@@ -331,16 +332,16 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
      * @return array
      */
     private function set_test_specific_filters($filter_details){
-        if(key_exists(EntryController::FILTER_KEY_TAGS, $filter_details)){
+        if(key_exists(self::$FILTER_KEY_TAGS, $filter_details)){
             $tag_ids = $this->_generated_tags->pluck('id')->toArray();
-            $filter_details[EntryController::FILTER_KEY_TAGS] = $this->_faker->randomElements($tag_ids, $this->_faker->numberBetween(1, count($tag_ids)));
+            $filter_details[self::$FILTER_KEY_TAGS] = $this->_faker->randomElements($tag_ids, $this->_faker->numberBetween(1, count($tag_ids)));
         }
-        if(key_exists(EntryController::FILTER_KEY_ACCOUNT_TYPE, $filter_details)){
+        if(key_exists(self::$FILTER_KEY_ACCOUNT_TYPE, $filter_details)){
             $account_types = $this->_generated_account->account_types()->pluck('id')->toArray();
-            $filter_details[EntryController::FILTER_KEY_ACCOUNT_TYPE] = $this->_faker->randomElement($account_types);
+            $filter_details[self::$FILTER_KEY_ACCOUNT_TYPE] = $this->_faker->randomElement($account_types);
         }
-        if(key_exists(EntryController::FILTER_KEY_ACCOUNT, $filter_details)){
-            $filter_details[EntryController::FILTER_KEY_ACCOUNT] = $this->_generated_account->id;
+        if(key_exists(self::$FILTER_KEY_ACCOUNT, $filter_details)){
+            $filter_details[self::$FILTER_KEY_ACCOUNT] = $this->_generated_account->id;
         }
         return $filter_details;
     }
@@ -353,36 +354,36 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
         $entry_components = [];
         foreach($filters as $filter_name => $constraint){
             switch($filter_name){
-                case EntryController::FILTER_KEY_START_DATE:
-                case EntryController::FILTER_KEY_END_DATE:
+                case self::$FILTER_KEY_START_DATE:
+                case self::$FILTER_KEY_END_DATE:
                     $entry_components['entry_date'] = $constraint;
                     break;
-                case EntryController::FILTER_KEY_MIN_VALUE:
-                case EntryController::FILTER_KEY_MAX_VALUE:
+                case self::$FILTER_KEY_MIN_VALUE:
+                case self::$FILTER_KEY_MAX_VALUE:
                     $entry_components['entry_value'] = $constraint;
                     break;
-                case EntryController::FILTER_KEY_ACCOUNT_TYPE:
+                case self::$FILTER_KEY_ACCOUNT_TYPE:
                     $entry_components['account_type_id'] = $constraint;
                     break;
-                case EntryController::FILTER_KEY_EXPENSE:
-                    if($constraint == true){
+                case self::$FILTER_KEY_EXPENSE:
+                    if($constraint === true){
                         $entry_components[$filter_name] = 1;
-                    } elseif($constraint == false) {
+                    } elseif($constraint === false) {
                         $entry_components[$filter_name] = 0;
                     }
                     break;
-                case EntryController::FILTER_KEY_UNCONFIRMED:
-                    if($constraint == true){
+                case self::$FILTER_KEY_UNCONFIRMED:
+                    if($constraint === true){
                         $entry_components['confirm'] = 0;
                     }
                     break;
-                case EntryController::FILTER_KEY_ATTACHMENTS:
+                case self::$FILTER_KEY_ATTACHMENTS:
                     $entry_components['has_attachments'] = $constraint;
                     break;
-                case EntryController::FILTER_KEY_TAGS:
+                case self::$FILTER_KEY_TAGS:
                     $entry_components[$filter_name] = [$this->_faker->randomElement($constraint)];
                     break;
-                case EntryController::FILTER_KEY_IS_TRANSFER:
+                case self::$FILTER_KEY_IS_TRANSFER:
                     if($constraint == true){
                         $entry_components['transfer_entry_id'] = $this->_faker->randomDigitNotNull;
                     } elseif($constraint == false) {

--- a/tests/Feature/Api/Post/PostEntriesTest.php
+++ b/tests/Feature/Api/Post/PostEntriesTest.php
@@ -6,9 +6,12 @@ use App\AccountType;
 use App\Entry;
 use App\Tag;
 use App\Http\Controllers\Api\EntryController;
+use App\Traits\MaxEntryResponseValue;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 
 class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
+
+    use MaxEntryResponseValue;
 
     public function providerPostEntriesFilter(){
         // need to call setUp() before running through a data provider method
@@ -97,10 +100,11 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
     /**
      * @dataProvider providerPostEntriesFilter
      * @param array $filter_details
+     * @throws \Exception
      */
     public function testPostEntries($filter_details){
         // GIVEN
-        $generate_entry_count = $this->_faker->numberBetween(self::MIN_TEST_ENTRIES, EntryController::MAX_ENTRIES_IN_RESPONSE);
+        $generate_entry_count = $this->_faker->numberBetween(self::MIN_TEST_ENTRIES, self::$MAX_ENTRIES_IN_RESPONSE);
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
         $filter_details = $this->set_test_specific_filters($filter_details);
 
@@ -134,11 +138,12 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
     /**
      * @dataProvider providerPostEntriesFilter
      * @param array $filter_details
+     * @throws \Exception
      */
     public function testPostEntriesByPage($filter_details){
         $page_limit = 3;
         // GIVEN
-        $generate_entry_count = $this->_faker->numberBetween(($page_limit-1)*EntryController::MAX_ENTRIES_IN_RESPONSE+1, $page_limit*EntryController::MAX_ENTRIES_IN_RESPONSE);
+        $generate_entry_count = $this->_faker->numberBetween(($page_limit-1)*self::$MAX_ENTRIES_IN_RESPONSE+1, $page_limit*self::$MAX_ENTRIES_IN_RESPONSE);
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
         $filter_details = $this->set_test_specific_filters($filter_details);
         $generated_entries = $this->batch_generate_entries($generate_entry_count, $generated_account_type->id, $this->convert_filters_to_entry_components($filter_details));
@@ -158,9 +163,9 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
             unset($response_body_as_array['count']);
 
             if($i+1 == $page_limit){
-                $this->assertCount($generate_entry_count-(($page_limit-1)*EntryController::MAX_ENTRIES_IN_RESPONSE), $response_body_as_array);
+                $this->assertCount($generate_entry_count-(($page_limit-1)*self::$MAX_ENTRIES_IN_RESPONSE), $response_body_as_array);
             } else {
-                $this->assertCount(EntryController::MAX_ENTRIES_IN_RESPONSE, $response_body_as_array);
+                $this->assertCount(self::$MAX_ENTRIES_IN_RESPONSE, $response_body_as_array);
             }
 
             $entries_in_response = array_merge($entries_in_response, $response_body_as_array);
@@ -203,7 +208,7 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
         ];
 
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
-        $this->batch_generate_entries($this->_faker->numberBetween(self::MIN_TEST_ENTRIES, EntryController::MAX_ENTRIES_IN_RESPONSE), $generated_account_type->id, $this->convert_filters_to_entry_components($filter_details));
+        $this->batch_generate_entries($this->_faker->numberBetween(self::MIN_TEST_ENTRIES, self::$MAX_ENTRIES_IN_RESPONSE), $generated_account_type->id, $this->convert_filters_to_entry_components($filter_details));
         $this->assertPostEntriesNotFound($filter_details);
     }
 
@@ -219,7 +224,7 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
         ];
 
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
-        $generated_entries_count = $this->_faker->numberBetween(self::MIN_TEST_ENTRIES, EntryController::MAX_ENTRIES_IN_RESPONSE);
+        $generated_entries_count = $this->_faker->numberBetween(self::MIN_TEST_ENTRIES, self::$MAX_ENTRIES_IN_RESPONSE);
         $generated_entries = $this->batch_generate_entries($generated_entries_count, $generated_account_type->id, $this->convert_filters_to_entry_components($filter_details));
 
         // WHEN
@@ -245,7 +250,7 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
         ];
 
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
-        $this->batch_generate_entries($this->_faker->numberBetween(self::MIN_TEST_ENTRIES, EntryController::MAX_ENTRIES_IN_RESPONSE), $generated_account_type->id, $this->convert_filters_to_entry_components($filter_details));
+        $this->batch_generate_entries($this->_faker->numberBetween(self::MIN_TEST_ENTRIES, self::$MAX_ENTRIES_IN_RESPONSE), $generated_account_type->id, $this->convert_filters_to_entry_components($filter_details));
         $this->assertPostEntriesNotFound($filter_details);
     }
 
@@ -261,7 +266,7 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
         ];
 
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
-        $generated_entries_count = $this->_faker->numberBetween(self::MIN_TEST_ENTRIES, EntryController::MAX_ENTRIES_IN_RESPONSE);
+        $generated_entries_count = $this->_faker->numberBetween(self::MIN_TEST_ENTRIES, self::$MAX_ENTRIES_IN_RESPONSE);
         $generated_entries = $this->batch_generate_entries($generated_entries_count, $generated_account_type->id, $this->convert_filters_to_entry_components($filter_details));
 
         // WHEN
@@ -277,7 +282,7 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
 
     public function testPostEntriesFilterSort(){
         // GIVEN
-        $generate_entry_count = $this->_faker->numberBetween(self::MIN_TEST_ENTRIES, EntryController::MAX_ENTRIES_IN_RESPONSE);
+        $generate_entry_count = $this->_faker->numberBetween(self::MIN_TEST_ENTRIES, self::$MAX_ENTRIES_IN_RESPONSE);
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
         $generated_entries = $this->batch_generate_entries($generate_entry_count, $generated_account_type->id, [], false);
         // how we intend to sort

--- a/tests/Feature/Api/Post/PostEntryTest.php
+++ b/tests/Feature/Api/Post/PostEntryTest.php
@@ -6,14 +6,15 @@ use App\Account;
 use App\AccountType;
 use App\Attachment;
 use App\Entry;
-use App\Http\Controllers\Api\EntryController;
 use App\Tag;
+use App\Traits\EntryResponseKeys;
 use Illuminate\Foundation\Testing\WithFaker;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 use Tests\TestCase;
 
 class PostEntryTest extends TestCase {
 
+    use EntryResponseKeys;
     use WithFaker;
 
     private $_base_uri = '/api/entry';
@@ -29,7 +30,7 @@ class PostEntryTest extends TestCase {
         $this->assertResponseStatus($response, HttpStatus::HTTP_BAD_REQUEST);
         $response_as_array = $response->json();
         $this->assertPostResponseHasCorrectKeys($response_as_array);
-        $this->assertFailedPostResponse($response_as_array, EntryController::ERROR_MSG_SAVE_ENTRY_NO_DATA);
+        $this->assertFailedPostResponse($response_as_array, self::$ERROR_MSG_SAVE_ENTRY_NO_DATA);
     }
 
     public function providerCreateEntryWithMissingData(){
@@ -50,7 +51,7 @@ class PostEntryTest extends TestCase {
             unset($entry_data[$required_entry_fields[$i]]);
             $missing_data_entries['missing ['.$required_entry_fields[$i].']'] = [
                 $entry_data,
-                sprintf(EntryController::ERROR_MSG_SAVE_ENTRY_MISSING_PROPERTY, json_encode([$required_entry_fields[$i]]))
+                sprintf(self::$ERROR_MSG_SAVE_ENTRY_MISSING_PROPERTY, json_encode([$required_entry_fields[$i]]))
             ];
         }
 
@@ -65,7 +66,7 @@ class PostEntryTest extends TestCase {
         }
         $missing_data_entries['missing ['.implode(',', $removed_keys).']'] = [
             $entry_data,
-            sprintf(EntryController::ERROR_MSG_SAVE_ENTRY_MISSING_PROPERTY, json_encode($removed_keys))
+            sprintf(self::$ERROR_MSG_SAVE_ENTRY_MISSING_PROPERTY, json_encode($removed_keys))
         ];
 
         return $missing_data_entries;
@@ -100,7 +101,7 @@ class PostEntryTest extends TestCase {
         $this->assertResponseStatus($response, HttpStatus::HTTP_BAD_REQUEST);
         $response_as_array = $response->json();
         $this->assertPostResponseHasCorrectKeys($response_as_array);
-        $this->assertFailedPostResponse($response_as_array, EntryController::ERROR_MSG_SAVE_ENTRY_INVALID_ACCOUNT_TYPE);
+        $this->assertFailedPostResponse($response_as_array, self::$ERROR_MSG_SAVE_ENTRY_INVALID_ACCOUNT_TYPE);
     }
 
     public function testCreateEntryAndAccountTotalUpdate(){
@@ -127,9 +128,9 @@ class PostEntryTest extends TestCase {
         $this->assertResponseStatus($post_response, HttpStatus::HTTP_CREATED);
         $post_response_as_array = $post_response->json();
         $this->assertPostResponseHasCorrectKeys($post_response_as_array);
-        $this->assertEmpty($post_response_as_array[EntryController::RESPONSE_SAVE_KEY_ERROR]);
-        $created_entry_id = $post_response_as_array[EntryController::RESPONSE_SAVE_KEY_ID];
-        $this->assertGreaterThan(EntryController::ERROR_ENTRY_ID, $created_entry_id);
+        $this->assertEmpty($post_response_as_array[self::$RESPONSE_SAVE_KEY_ERROR]);
+        $created_entry_id = $post_response_as_array[self::$RESPONSE_SAVE_KEY_ID];
+        $this->assertGreaterThan(self::$ERROR_ENTRY_ID, $created_entry_id);
 
         // WHEN
         $get_entry_response = $this->get($this->_base_uri.'/'.$created_entry_id);
@@ -178,9 +179,9 @@ class PostEntryTest extends TestCase {
         $this->assertResponseStatus($post_response, HttpStatus::HTTP_CREATED);
         $post_response_as_array = $post_response->json();
         $this->assertPostResponseHasCorrectKeys($post_response_as_array);
-        $this->assertEmpty($post_response_as_array[EntryController::RESPONSE_SAVE_KEY_ERROR]);
-        $created_entry_id = $post_response_as_array[EntryController::RESPONSE_SAVE_KEY_ID];
-        $this->assertGreaterThan(EntryController::ERROR_ENTRY_ID, $created_entry_id);
+        $this->assertEmpty($post_response_as_array[self::$RESPONSE_SAVE_KEY_ERROR]);
+        $created_entry_id = $post_response_as_array[self::$RESPONSE_SAVE_KEY_ID];
+        $this->assertGreaterThan(self::$ERROR_ENTRY_ID, $created_entry_id);
 
         // WHEN
         $get_response = $this->get($this->_base_uri.'/'.$created_entry_id);
@@ -229,9 +230,9 @@ class PostEntryTest extends TestCase {
         $this->assertResponseStatus($post_response, HttpStatus::HTTP_CREATED);
         $post_response_as_array = $post_response->json();
         $this->assertPostResponseHasCorrectKeys($post_response_as_array);
-        $this->assertEmpty($post_response_as_array[EntryController::RESPONSE_SAVE_KEY_ERROR]);
-        $created_entry_id = $post_response_as_array[EntryController::RESPONSE_SAVE_KEY_ID];
-        $this->assertGreaterThan(EntryController::ERROR_ENTRY_ID, $created_entry_id);
+        $this->assertEmpty($post_response_as_array[self::$RESPONSE_SAVE_KEY_ERROR]);
+        $created_entry_id = $post_response_as_array[self::$RESPONSE_SAVE_KEY_ID];
+        $this->assertGreaterThan(self::$ERROR_ENTRY_ID, $created_entry_id);
 
         // WHEN
         $get_response = $this->get($this->_base_uri.'/'.$created_entry_id);
@@ -274,9 +275,9 @@ class PostEntryTest extends TestCase {
         $this->assertResponseStatus($post_response, HttpStatus::HTTP_CREATED);
         $post_response_as_array = $post_response->json();
         $this->assertPostResponseHasCorrectKeys($post_response_as_array);
-        $this->assertEmpty($post_response_as_array[EntryController::RESPONSE_SAVE_KEY_ERROR]);
-        $created_entry_id = $post_response_as_array[EntryController::RESPONSE_SAVE_KEY_ID];
-        $this->assertGreaterThan(EntryController::ERROR_ENTRY_ID, $created_entry_id);
+        $this->assertEmpty($post_response_as_array[self::$RESPONSE_SAVE_KEY_ERROR]);
+        $created_entry_id = $post_response_as_array[self::$RESPONSE_SAVE_KEY_ID];
+        $this->assertGreaterThan(self::$ERROR_ENTRY_ID, $created_entry_id);
 
         // WHEN
         $get_response = $this->get($this->_base_uri.'/'.$created_entry_id);
@@ -313,8 +314,8 @@ class PostEntryTest extends TestCase {
     private function assertPostResponseHasCorrectKeys($response_as_array){
         $failure_message = "POST Response is ".json_encode($response_as_array);
         $this->assertTrue(is_array($response_as_array), $failure_message);
-        $this->assertArrayHasKey(EntryController::RESPONSE_SAVE_KEY_ID, $response_as_array, $failure_message);
-        $this->assertArrayHasKey(EntryController::RESPONSE_SAVE_KEY_ERROR, $response_as_array, $failure_message);
+        $this->assertArrayHasKey(self::$RESPONSE_SAVE_KEY_ID, $response_as_array, $failure_message);
+        $this->assertArrayHasKey(self::$RESPONSE_SAVE_KEY_ERROR, $response_as_array, $failure_message);
     }
 
     /**
@@ -323,9 +324,9 @@ class PostEntryTest extends TestCase {
      */
     private function assertFailedPostResponse($response_as_array, $response_error_msg){
         $failure_message = "POST Response is ".json_encode($response_as_array);
-        $this->assertEquals(EntryController::ERROR_ENTRY_ID, $response_as_array[EntryController::RESPONSE_SAVE_KEY_ID], $failure_message);
-        $this->assertNotEmpty($response_as_array[EntryController::RESPONSE_SAVE_KEY_ERROR], $failure_message);
-        $this->assertStringContainsString($response_error_msg, $response_as_array[EntryController::RESPONSE_SAVE_KEY_ERROR], $failure_message);
+        $this->assertEquals(self::$ERROR_ENTRY_ID, $response_as_array[self::$RESPONSE_SAVE_KEY_ID], $failure_message);
+        $this->assertNotEmpty($response_as_array[self::$RESPONSE_SAVE_KEY_ERROR], $failure_message);
+        $this->assertStringContainsString($response_error_msg, $response_as_array[self::$RESPONSE_SAVE_KEY_ERROR], $failure_message);
     }
 
 }

--- a/tests/Feature/Api/Post/PostEntryTransferTest.php
+++ b/tests/Feature/Api/Post/PostEntryTransferTest.php
@@ -24,8 +24,8 @@ class PostEntryTransferTest extends TestCase {
     const CALL_METHOD = "POST";
     const FLAG_HAS_TAGS = 'has_tags';
     const FLAG_HAS_ATTACHMENTS = 'has_attachments';
-    const FLAG_OVERRIDE_TO = "to";
-    const FLAG_OVERRIDE_FROM = "from";
+    const FLAG_OVERRIDE_TO = "override_to_account_type_id";
+    const FLAG_OVERRIDE_FROM = "override_from_account_type_id";
 
     private $_base_uri = '/api/entry/transfer';
 


### PR DESCRIPTION
- Moved constants from `app/Http/Controllers/Api/EntryController.php` into traits thereby allowing more classes to use them without importing the whole `EntryController` class.
- Moved some code that is duplicated into its own method.