### PR TITLE
support/allow-stats-for-single-day-data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,8 +129,10 @@ jobs:
     - stage: "e2e-tests: stats"
       script: .docker/cmd/artisan.sh dusk --group stats-summary --stop-on-failure
     - script: .docker/cmd/artisan.sh dusk --group stats-trending --stop-on-failure
-    - script: .docker/cmd/artisan.sh dusk --group stats-distribution --stop-on-failure
-    - script: .docker/cmd/artisan.sh dusk --group stats-tags --stop-on-failure
+    - script: .docker/cmd/artisan.sh dusk --group stats-distribution-1 --stop-on-failure
+    - script: .docker/cmd/artisan.sh dusk --group stats-distribution-2 --stop-on-failure
+    - script: .docker/cmd/artisan.sh dusk --group stats-tags-1 --stop-on-failure
+    - script: .docker/cmd/artisan.sh dusk --group stats-tags-2 --stop-on-failure
 
 # $WEBHOOK_URL should be set in travis-ci settings
 after_success:

--- a/database/factories/EntryFactory.php
+++ b/database/factories/EntryFactory.php
@@ -12,6 +12,7 @@ $factory->define(App\Entry::class, static function(Faker $faker){
         'memo'=>$faker->words(3, true),
         'expense'=>$faker->boolean,
         'confirm'=>$faker->boolean,
+        'disabled'=>false,
         'transfer_entry_id'=>null
     ];
 });

--- a/resources/js/components/bulma-calendar.vue
+++ b/resources/js/components/bulma-calendar.vue
@@ -52,7 +52,7 @@
             const calendar = bulmaCalendar.attach(this.calendarRefs, {
                 color: 'info',
                 isRange: "true",
-                allowSameDayRange: false,
+                allowSameDayRange: true,
                 dateFormat: "YYYY-MM-DD",
                 showTodayButton: false,
             })[0];

--- a/tests/Browser/StatsDistributionTest.php
+++ b/tests/Browser/StatsDistributionTest.php
@@ -121,53 +121,57 @@ class StatsDistributionTest extends StatsBase {
         //[$datepicker_start, $datepicker_end, $is_account_switch_toggled, $is_expense_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $include_transfers]
         return [
             //  default state of account/account-types; expense; default date range
-            [null, null, false, false, false, false, false],                   // test 4/25
+            [null, null, false, false, false, false, false],                   // test 1/25
             //  default state of account/account-types; expense; default date range; include transfers
-            [null, null, false, false, false, false, true],                   // test 4/25
+            [null, null, false, false, false, false, true],                   // test 2/25
             // default state of account/account-types; income; default date range
-            [null, null, false, true, false, false, false],                    // test 5/25
+            [null, null, false, true, false, false, false],                    // test 3/25
             // default state of account/account-types; income; default date range; include transfers
-            [null, null, false, true, false, false, true],                    // test 6/25
+            [null, null, false, true, false, false, true],                    // test 4/25
             // default state of account/account-types; expense; date range a year past to today
-            [$this->previous_year_start, $this->today, false, false, false, false, false], // test 7/25
+            [$this->previous_year_start, $this->today, false, false, false, false, false], // test 5/25
             // default state of account/account-types; expense; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, false, false, false, false, true], // test 8/25
+            [$this->previous_year_start, $this->today, false, false, false, false, true], // test 6/25
             // default state of account/account-types; income; date range a year past to today
-            [$this->previous_year_start, $this->today, false, true, false, false, false],  // test 9/25
+            [$this->previous_year_start, $this->today, false, true, false, false, false],  // test 7/25
             // default state of account/account-types; income; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, false, true, false, false, true],  // test 10/25
+            [$this->previous_year_start, $this->today, false, true, false, false, true],  // test 8/25
             // random account; expense; date range a year past to today
-            [$this->previous_year_start, $this->today, false, false, true, false, false],  // test 11/25
+            [$this->previous_year_start, $this->today, false, false, true, false, false],  // test 9/25
             // random account; expense; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, false, false, true, false, true],  // test 12/25
+            [$this->previous_year_start, $this->today, false, false, true, false, true],  // test 10/25
             // random account; income; date range a year past to today
-            [$this->previous_year_start, $this->today, false, true, true, false, false],   // test 13/25
+            [$this->previous_year_start, $this->today, false, true, true, false, false],   // test 11/25
             // random account; income; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, false, true, true, false, true],   // test 14/25
+            [$this->previous_year_start, $this->today, false, true, true, false, true],   // test 12/25
             // random account-type; expense; date range a year past to today
-            [$this->previous_year_start, $this->today, true, false, true, false, false],   // test 15/25
+            [$this->previous_year_start, $this->today, true, false, true, false, false],   // test 13/25
             // random account-type; expense; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, true, false, true, false, true],   // test 16/25
+            [$this->previous_year_start, $this->today, true, false, true, false, true],   // test 14/25
             // random account-type; income; date range a year past to today
-            [$this->previous_year_start, $this->today, true, true, true, false, false],    // test 17/25
+            [$this->previous_year_start, $this->today, true, true, true, false, false],    // test 15/25
             // random account-type; income; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, true, true, true, false, true],    // test 18/25
+            [$this->previous_year_start, $this->today, true, true, true, false, true],    // test 16/25
             // random disabled account; expense; date range a year past to today
-            [$this->previous_year_start, $this->today, false, false, true, true, false],   // test 19/25
+            [$this->previous_year_start, $this->today, false, false, true, true, false],   // test 17/25
             // random disabled account; expense; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, false, false, true, true, true],   // test 20/25
+            [$this->previous_year_start, $this->today, false, false, true, true, true],   // test 18/25
             // random disabled account; income; date range a year past to today
-            [$this->previous_year_start, $this->today, false, true, true, true, false],    // test 21/25
+            [$this->previous_year_start, $this->today, false, true, true, true, false],    // test 19/25
             // random disabled account; income; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, false, true, true, true, true],    // test 22/25
+            [$this->previous_year_start, $this->today, false, true, true, true, true],    // test 20/25
             // random disabled account-type; expense; date range a year past to today
-            [$this->previous_year_start, $this->today, true, false, true, true, false],    // test 23/25
+            [$this->previous_year_start, $this->today, true, false, true, true, false],    // test 21/25
             // random disabled account-type; expense; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, true, false, true, true, true],    // test 24/25
+            [$this->previous_year_start, $this->today, true, false, true, true, true],    // test 22/25
             // random disabled account-type; income; date range a year past to today
-            [$this->previous_year_start, $this->today, true, true, true, true, false],     // test 25/25
+            [$this->previous_year_start, $this->today, true, true, true, true, false],     // test 23/25
             // random disabled account-type; income; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, true, true, true, true, true],     // test 26/25
+            [$this->previous_year_start, $this->today, true, true, true, true, true],     // test 24/25
+            //  default state of account/account-types; expense; date range today only
+            [$this->today, $this->today, false, false, false, false, false],              // test 25/25
+            //  default state of account/account-types; expense; date range today only; include transfers
+            [$this->today, $this->today, false, false, false, false, true],               // test 26/25
         ];
     }
 
@@ -184,7 +188,7 @@ class StatsDistributionTest extends StatsBase {
      *
      * @throws Throwable
      *
-     * @group stats-distribution-1
+     * @group stats-distribution-2
      * test (see provider)/25
      */
     public function testGenerateDistributionChart($datepicker_start, $datepicker_end, $is_account_switch_toggled, $is_expense_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $include_transfers){

--- a/tests/Browser/StatsSummaryTest.php
+++ b/tests/Browser/StatsSummaryTest.php
@@ -128,6 +128,10 @@ class StatsSummaryTest extends StatsBase {
             [$this->previous_year_start, $this->today, true, true, false, false],     // test 14/25
             // date-picker previous year start to present & random disabled account-type & include transfers
             [$this->previous_year_start, $this->today, true, true, false, true],      // test 15/25
+            // defaults account/account-type & date-picker values; date range today only
+            [$this->today, $this->today, false, false, false, false],                 // test 16/25
+            // defaults account/account-type & date-picker values; date range today only; include transfers
+            [$this->today, $this->today, false, false, false, true],                  // test 17/25
         ];
     }
 

--- a/tests/Browser/StatsTagsTest.php
+++ b/tests/Browser/StatsTagsTest.php
@@ -122,53 +122,57 @@ class StatsTagsTest extends StatsBase {
         return [
             //[$datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $tag_count, $include_transfers]
             // defaults account/account-type & tags & date-picker values
-            [null, null, false, false, false, 0, false],   // test 4/25
+            [null, null, false, false, false, 0, false],   // test 1/25
             // defaults account/account-type & tags & date-picker values & include transfers checkbox button clicked
-            [null, null, false, false, false, 0, true],   // test 5/25
+            [null, null, false, false, false, 0, true],   // test 2/25
             // date-picker previous year start to present & default tags & default account/account-type
-            [$this->previous_year_start, $this->today, false, false, false, 0, false], // test 6/25
+            [$this->previous_year_start, $this->today, false, false, false, 0, false], // test 3/25
             // date-picker previous year start to present & default tags & default account/account-type & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, false, false, false, 0, true], // test 7/25
+            [$this->previous_year_start, $this->today, false, false, false, 0, true], // test 4/25
             // date-picker previous year start to present & default tags & random account
-            [$this->previous_year_start, $this->today, false, true, false, 0, false],  // test 8/25
+            [$this->previous_year_start, $this->today, false, true, false, 0, false],  // test 5/25
             // date-picker previous year start to present & default tags & random account & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, false, true, false, 0, true],  // test 9/25
+            [$this->previous_year_start, $this->today, false, true, false, 0, true],  // test 6/25
             // date-picker previous year start to present & default tags & random account-type
-            [$this->previous_year_start, $this->today, true, true, false, 0, false],   // test 10/25
+            [$this->previous_year_start, $this->today, true, true, false, 0, false],   // test 7/25
             // date-picker previous year start to present & default tags & random account-type & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, true, true, false, 0, true],   // test 11/25
+            [$this->previous_year_start, $this->today, true, true, false, 0, true],   // test 8/25
             // date-picker previous year start to present & default tags & random disabled account
-            [$this->previous_year_start, $this->today, false, true, true, 0, false],   // test 12/25
+            [$this->previous_year_start, $this->today, false, true, true, 0, false],   // test 9/25
             // date-picker previous year start to present & default tags & random disabled account & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, false, true, true, 0, true],   // test 13/25
+            [$this->previous_year_start, $this->today, false, true, true, 0, true],   // test 10/25
             // date-picker previous year start to present & default tags & random disabled account-type
-            [$this->previous_year_start, $this->today, true, true, true, 0, false],    // test 14/25
+            [$this->previous_year_start, $this->today, true, true, true, 0, false],    // test 11/25
             // date-picker previous year start to present & default tags & random disabled account-type & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, true, true, true, 0, true],    // test 15/25
+            [$this->previous_year_start, $this->today, true, true, true, 0, true],    // test 12/25
             // date-picker previous year start to present & random tag & default account/account-type
-            [$this->previous_year_start, $this->today, false, false, false, 1, false], // test 16/25
+            [$this->previous_year_start, $this->today, false, false, false, 1, false], // test 13/25
             // date-picker previous year start to present & random tag & default account/account-type & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, false, false, false, 1, true], // test 17/25
+            [$this->previous_year_start, $this->today, false, false, false, 1, true], // test 14/25
             // date-picker previous year start to present & random tag & random account
-            [$this->previous_year_start, $this->today, false, true, false, 1, false],  // test 18/25
+            [$this->previous_year_start, $this->today, false, true, false, 1, false],  // test 15/25
             // date-picker previous year start to present & random tag & random account & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, false, true, false, 1, true],  // test 19/25
+            [$this->previous_year_start, $this->today, false, true, false, 1, true],  // test 16/25
             // date-picker previous year start to present & random tag & random account-type
-            [$this->previous_year_start, $this->today, true, true, false, 1, false],   // test 20/25
+            [$this->previous_year_start, $this->today, true, true, false, 1, false],   // test 17/25
             // date-picker previous year start to present & random tag & random account-type & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, true, true, false, 1, true],   // test 21/25
+            [$this->previous_year_start, $this->today, true, true, false, 1, true],   // test 18/25
             // date-picker previous year start to present & random tag & random disabled account
-            [$this->previous_year_start, $this->today, false, true, true, 1, false],   // test 22/25
+            [$this->previous_year_start, $this->today, false, true, true, 1, false],   // test 19/25
             // date-picker previous year start to present & random tag & random disabled account & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, false, true, true, 1, true],   // test 23/25
+            [$this->previous_year_start, $this->today, false, true, true, 1, true],   // test 20/25
             // date-picker previous year start to present & random tag & random disabled account-type
-            [$this->previous_year_start, $this->today, true, true, true, 1, false],    // test 24/25
+            [$this->previous_year_start, $this->today, true, true, true, 1, false],    // test 21/25
             // date-picker previous year start to present & random tag & random disabled account-type & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, true, true, true, 1, true],    // test 25/25
+            [$this->previous_year_start, $this->today, true, true, true, 1, true],    // test 22/25
             // date-picker previous year start to present & random tags & default account/account-type
-            [$this->previous_year_start, $this->today, false, false, false, 2, false],  // test 26/25
+            [$this->previous_year_start, $this->today, false, false, false, 2, false],  // test 23/25
             // date-picker previous year start to present & random tags & default account/account-type & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, false, false, false, 2, true]  // test 27/25
+            [$this->previous_year_start, $this->today, false, false, false, 2, true],  // test 24/25
+            // defaults account/account-type & tags; date-picker today ONLY
+            [$this->today, $this->today, false, false, false, 0, false],   // test 25/25
+            // defaults account/account-type & tags; date-picker today ONLY; include transfers
+            [$this->today, $this->today, false, false, false, 0, true],   // test 26/25
         ];
     }
 
@@ -185,7 +189,7 @@ class StatsTagsTest extends StatsBase {
      *
      * @throws Throwable
      *
-     * @group stats-tags-1
+     * @group stats-tags-2
      * test (see provider)/25
      */
     public function testGenerateTagsChart($datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $tag_count, $include_transfers){
@@ -305,10 +309,6 @@ class StatsTagsTest extends StatsBase {
     }
 
     /**
-     * Database seeder doesn't assign tags to disabled entries.
-     * It's a waste of resources to do that for every test when most tests don't need that kind of data.
-     * So instead for these tests, we'll create an entry with all the tags
-     *
      * @param bool $is_account_type_rather_than_account_toggled
      * @param int $account_or_account_type_id
      * @param Collection $account_types

--- a/tests/Browser/StatsTrendingTest.php
+++ b/tests/Browser/StatsTrendingTest.php
@@ -140,6 +140,10 @@ class StatsTrendingTest extends StatsBase {
             [$this->previous_year_start, $this->today, true, true, false, false],      // test 14/25
             // date-picker previous year start to present & random disabled account-type & include transfers checkbox button clicked
             [$this->previous_year_start, $this->today, true, true, false, true],      // test 15/25
+            // defaults account/account-type; date-picker today ONLY
+            [$this->today, $this->today, false, false, false, false],  // test 16/25
+            // defaults account/account-type; date-picker today ONLY; include transfers
+            [$this->today, $this->today, false, false, false, true],  // test 17/25
         ];
     }
 


### PR DESCRIPTION
- EntryFactory now has the `disabled` property as `false` by default.
- Stats datepicker now allows selecting from a single date.