### PR TITLE
Feature/fix-tag-filtering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
   # make sure user `www-data` has ownership of everything
   - docker container exec -t app.money-tracker chown -R www-data:www-data .
   # general application setup
-  - cp public/vue/mix-manifest.json public/mix-manifest.json  # putting cached file back in the correct spot
+  - docker container exec -t --user www-data app.money-tracker cp public/vue/mix-manifest.json public/mix-manifest.json  # putting cached file back in the correct spot
   - .docker/cmd/artisan.sh cache:clear
   - .docker/cmd/artisan.sh view:clear
   - .docker/cmd/artisan.sh key:generate

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,8 +88,8 @@ jobs:
         - wget -O .webhook/send-file.sh https://raw.githubusercontent.com/jdenoc/travis-ci-discord-webhook/1.3.0/send-file.sh
         - chmod +x .webhook/*.sh
         # list php.ini settings
-        - docker container exec -t app.money-tracker php -i
-        - docker container exec -t app.money-tracker php -m
+        - docker-compose -f .docker/docker-compose.yml run application php -i
+        - docker-compose -f .docker/docker-compose.yml run application php -m
       before_script: skip
       script: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_script:
   # make sure user `www-data` has ownership of everything
   - docker container exec -t app.money-tracker chown -R www-data:www-data .
   # general application setup
+  - cp public/vue/mix-manifest.json public/mix-manifest.json  # putting cached file back in the correct spot
   - .docker/cmd/artisan.sh cache:clear
   - .docker/cmd/artisan.sh view:clear
   - .docker/cmd/artisan.sh key:generate
@@ -82,6 +83,7 @@ jobs:
         - cat yarn.lock
         # build/compile website with webpack
         - .docker/cmd/yarn.sh run build-prod
+        - cp public/mix-manifest.json public/vue/mix-manifest.json  # doing this to allow for caching
         # install travis-ci/discord integration script(s)
         - mkdir -p .webhook
         - wget -O .webhook/send.sh https://raw.githubusercontent.com/jdenoc/travis-ci-discord-webhook/1.3.0/send.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,9 @@ jobs:
         - wget -O .webhook/send.sh https://raw.githubusercontent.com/jdenoc/travis-ci-discord-webhook/1.3.0/send.sh
         - wget -O .webhook/send-file.sh https://raw.githubusercontent.com/jdenoc/travis-ci-discord-webhook/1.3.0/send-file.sh
         - chmod +x .webhook/*.sh
+        # list php.ini settings
+        - docker container exec -t app.money-tracker php -i
+        - docker container exec -t app.money-tracker php -m
       before_script: skip
       script: true
 
@@ -142,7 +145,7 @@ after_failure:
   - .webhook/send.sh failure $WEBHOOK_URL
   - .webhook/send-file.sh --retry=3 --delay=7 --ext=png --ext=jpg --ext=jpeg --ext=gif $DUSK_SCREENSHOT_DIR $WEBHOOK_URL
   - .webhook/send-file.sh --retry=3 --delay=7 --ext=sql $DUSK_DB_DUMP_DIR $WEBHOOK_URL
-  - docker container logs app.money-tracker > /dev/null
+  - docker container logs app.money-tracker
   - docker container exec -t app.money-tracker .docker/cmd/laravel-logs.sh
 
 after_script:

--- a/app/Http/Controllers/Api/EntryController.php
+++ b/app/Http/Controllers/Api/EntryController.php
@@ -106,7 +106,6 @@ class EntryController extends Controller {
      *
      * @param Request $request
      * @return \Illuminate\Contracts\Routing\ResponseFactory
-     * @throws \JsonException
      */
     public function create_entry(Request $request){
         return $this->modify_entry($request);
@@ -118,7 +117,6 @@ class EntryController extends Controller {
      * @param int $entry_id
      * @param Request $request
      * @return \Illuminate\Contracts\Routing\ResponseFactory
-     * @throws \JsonException
      */
     public function update_entry($entry_id, Request $request){
         return $this->modify_entry($request, $entry_id);
@@ -128,11 +126,10 @@ class EntryController extends Controller {
      * @param Request $request
      * @param int|false $update_id
      * @return \Illuminate\Contracts\Routing\ResponseFactory
-     * @throws \JsonException
      */
     private function modify_entry(Request $request, $update_id=false){
         $request_body = $request->getContent();
-        $entry_data = json_decode($request_body, true, 512, JSON_THROW_ON_ERROR);
+        $entry_data = json_decode($request_body, true);
 
         // no data check
         if(empty($entry_data)){

--- a/database/migrations/2020_11_11_181153_change_entry_tags_primary_key_to_compound_primary_key.php
+++ b/database/migrations/2020_11_11_181153_change_entry_tags_primary_key_to_compound_primary_key.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeEntryTagsPrimaryKeyToCompoundPrimaryKey extends Migration {
+
+    private static $TABLE = 'entry_tags';
+    private static $OLD_INDEX_NAME = "entry_tag_pivot_index";   // comes from 2018_02_12_192742_add_index_to_entry_tags_pivot_table.php
+    private static $PRIMARY_INDEX_COLUMNS = ['entry_id', 'tag_id'];
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(){
+        Schema::table(self::$TABLE, function (Blueprint $table) {
+            /**
+             * QUERY from below code:
+                delete from entry_tags
+                where id in (
+                  select id from (
+                    select id from entry_tags
+                    group by entry_id, tag_id
+                      having count(id) > 1
+                  )
+                );
+             */
+            $duplicate_ids = DB::table(self::$TABLE)
+                ->select('id')
+                ->groupBy(self::$PRIMARY_INDEX_COLUMNS)
+                ->havingRaw('count(id) > 1')
+                ->get()->pluck('id');
+            DB::table(self::$TABLE)
+                ->whereIn('id', $duplicate_ids)
+                ->delete();
+
+            $table->dropIndex(self::$OLD_INDEX_NAME);
+            $table->dropColumn('id');
+            $table->primary(self::$PRIMARY_INDEX_COLUMNS);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(){
+        Schema::table(self::$TABLE, function (Blueprint $table) {
+            $table->dropPrimary();
+            $table->index(self::$PRIMARY_INDEX_COLUMNS, self::$OLD_INDEX_NAME);
+        });
+
+        Schema::table(self::$TABLE, function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::table(self::$TABLE, function (){
+            // There is no nice way to move columns around using laravel/blueprint code
+            DB::statement("ALTER TABLE ".self::$TABLE." MODIFY COLUMN stamp timestamp not null AFTER id");
+            DB::statement("ALTER TABLE ".self::$TABLE." MODIFY COLUMN tag_id int unsigned not null AFTER id");
+            DB::statement("ALTER TABLE ".self::$TABLE." MODIFY COLUMN entry_id int unsigned not null AFTER id");
+        });
+    }
+}

--- a/database/seeds/UiSampleDatabaseSeeder.php
+++ b/database/seeds/UiSampleDatabaseSeeder.php
@@ -235,7 +235,7 @@ class UiSampleDatabaseSeeder extends Seeder {
         } else {
             $entry_tag_ids = $this->faker->randomElements($tag_ids, $this->faker->numberBetween(self::COUNT_MIN, self::COUNT_TAG/2));
         }
-        $entry->tags()->attach($entry_tag_ids);
+        $entry->tags()->syncWithoutDetaching($entry_tag_ids);
     }
 
     /**

--- a/resources/views/favicon-component.blade.php
+++ b/resources/views/favicon-component.blade.php
@@ -1,5 +1,5 @@
 <!-- favicon -->
-<link rel="apple-touch-icon" sizes="180x180" href="{{ favicon(asset('imgs/favicon/apple-touch-icon.png')) }}">
-<link rel="icon" type="image/png" sizes="32x32" href="{{ favicon(asset('imgs/favicon/favicon-32x32.png')) }}">
-<link rel="icon" type="image/png" sizes="16x16" href="{{ favicon(asset('imgs/favicon/favicon-16x16.png')) }}">
-<link rel="manifest" href="{{ asset('imgs/favicon/site.webmanifest') }}">
+<link rel="apple-touch-icon" sizes="180x180" href="{{ favicon('imgs/favicon/apple-touch-icon.png') }}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ favicon('imgs/favicon/favicon-32x32.png') }}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ favicon('imgs/favicon/favicon-16x16.png') }}">
+<link rel="manifest" href="{{ 'imgs/favicon/site.webmanifest' }}">

--- a/resources/views/head-component.blade.php
+++ b/resources/views/head-component.blade.php
@@ -13,5 +13,5 @@
 <!-- Fonts -->
 <link href="https://fonts.googleapis.com/css?family=Raleway:100,600" rel="stylesheet" type="text/css">
 
-<link href="{{asset('vue/css/app.css')}}" rel="stylesheet" type="text/css">
-<link href="{{asset('vue/css/font-awesome.css')}}" rel="stylesheet" type="text/css">
+<link href="{{mix('vue/css/app.css')}}" rel="stylesheet" type="text/css">
+<link href="{{mix('vue/css/font-awesome.css')}}" rel="stylesheet" type="text/css">

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -31,6 +31,6 @@
             </div>
         </div>
     </div>
-    <script type="text/javascript" src="{{asset('vue/js/app-home.js')}}"></script>
+    <script type="text/javascript" src="{{mix('vue/js/app-home.js')}}"></script>
 </body>
 </html>

--- a/resources/views/stats.blade.php
+++ b/resources/views/stats.blade.php
@@ -26,6 +26,6 @@
         <notification></notification>
     </div>
 </div>
-<script type="text/javascript" src="{{asset('vue/js/app-stats.js')}}"></script>
+<script type="text/javascript" src="{{mix('vue/js/app-stats.js')}}"></script>
 </body>
 </html>

--- a/tests/Feature/Api/Get/GetEntriesTest.php
+++ b/tests/Feature/Api/Get/GetEntriesTest.php
@@ -114,7 +114,9 @@ class GetEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
     public function testLargeDataSets($entry_count){
         // GIVEN
         $table = with(new Entry)->getTable();
+        /** @var AccountType $generated_account_type */
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
+        /** @var Entry $generated_entries */
         $generated_entries = factory(Entry::class, self::$MAX_ENTRIES_IN_RESPONSE)->make(['account_type_id'=>$generated_account_type->id]);
         // generating entries in batches and using database insert methods because it's faster
         for($i=0; $i<($entry_count/self::$MAX_ENTRIES_IN_RESPONSE); $i++){

--- a/tests/Feature/Api/Post/PostEntriesTest.php
+++ b/tests/Feature/Api/Post/PostEntriesTest.php
@@ -106,6 +106,7 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
     public function testPostEntries($filter_details){
         // GIVEN
         $generate_entry_count = $this->_faker->numberBetween(self::MIN_TEST_ENTRIES, self::$MAX_ENTRIES_IN_RESPONSE);
+        /** @var AccountType $generated_account_type */
         $generated_account_type = factory(AccountType::class)->create(['account_id'=>$this->_generated_account->id]);
         $filter_details = $this->set_test_specific_filters($filter_details);
 
@@ -381,7 +382,7 @@ class PostEntriesTest extends \Tests\Feature\Api\ListEntriesBase {
                     $entry_components['has_attachments'] = $constraint;
                     break;
                 case self::$FILTER_KEY_TAGS:
-                    $entry_components[$filter_name] = [$this->_faker->randomElement($constraint)];
+                    $entry_components[$filter_name] = is_array($constraint) ? $constraint : [$constraint];
                     break;
                 case self::$FILTER_KEY_IS_TRANSFER:
                     if($constraint == true){


### PR DESCRIPTION
- removed `entry_tags.id` database table column and made a composite primary key using the `entry_tags.entry_id` and `entry_tags.tag_id` columns.
- When filtering entries by tags, we will now be performing a `AND` filter instead of an `OR` filter. i.e.: if you search for entries with tag _A_ and tag _B_ you will only receive results of entries with tag _A_ and tag _B_, instead of ALL entries that had tag _A_ and tag _B_ associated with it. Regardless of overlap.