### PR TITLE
Feature/replace-bulma-badge-package

### DIFF
--- a/.github/actions/setup-yarn/action.yml
+++ b/.github/actions/setup-yarn/action.yml
@@ -4,6 +4,9 @@ description: Load Yarn/npm dependancies
 runs:
   using: composite
   steps:
-    - name: Yarn package install
-      run: .docker/cmd/yarn.sh install --non-interactive --frozen-lockfile
+    - id: yarn-check
+      run: .docker/cmd/yarn.sh check
+      shell: bash
+    - id: yarn-install
+      run: .docker/cmd/yarn.sh install --non-interactive
       shell: bash

--- a/.github/actions/setup-yarn/action.yml
+++ b/.github/actions/setup-yarn/action.yml
@@ -4,9 +4,5 @@ description: Load Yarn/npm dependancies
 runs:
   using: composite
   steps:
-    - id: yarn-check
-      run: .docker/cmd/yarn.sh check
-      shell: bash
-    - id: yarn-install
-      run: .docker/cmd/yarn.sh install --non-interactive
+    - run: .docker/cmd/yarn.sh install --non-interactive --check-files --frozen-lockfile
       shell: bash

--- a/app/Traits/Tests/Dusk/TagsInput.php
+++ b/app/Traits/Tests/Dusk/TagsInput.php
@@ -12,8 +12,8 @@ trait TagsInput {
     private static $SELECTOR_TAGS_INPUT_CONTAINER = ".tags-input";
     private static $SELECTOR_TAGS_INPUT_LOADING = '.is-loading .tags-input';
     private static $SELECTOR_TAGS_INPUT_INPUT = ".tags-input input";
-    private static $SELECTOR_TAGS_INPUT_TAG = "span.badge.badge-pill.badge-light";
-    private static $SELECTOR_TAG_AUTOCOMPLETE_OPTIONS = '.typeahead span.badge';
+    private static $SELECTOR_TAGS_INPUT_TAG = "span.tags-input-badge-pill";
+    private static $SELECTOR_TAG_AUTOCOMPLETE_OPTIONS = '.typeahead-badges span.tags-input-badge';
 
     public function assertDefaultStateOfTagsInput(Browser $browser){
         $browser
@@ -29,7 +29,7 @@ trait TagsInput {
      * @param Browser $browser
      * @param string $tag
      */
-    private function fillTagsInputUsingAutocomplete(Browser $browser, $tag){
+    private function fillTagsInputUsingAutocomplete(Browser $browser, string $tag){
         $browser
             ->waitUntilMissing(self::$SELECTOR_TAGS_INPUT_LOADING, self::$WAIT_SECONDS)
             // using safeColorName as our tag, we can be guaranteed after 3 characters we will have a unique word available
@@ -43,12 +43,19 @@ trait TagsInput {
 
     /**
      * @param Browser $browser
+     */
+    public function assertTagsInputHasTagsInInput(Browser $browser){
+        // the very existance of a tag in the input field indicates that they are present
+        $browser->assertVisible(self::$SELECTOR_TAGS_INPUT_CONTAINER.' '.self::$SELECTOR_TAGS_INPUT_TAG);
+    }
+
+    /**
+     * @param Browser $browser
      * @param string $tag
      */
-    public function assertTagInInput(Browser $browser, $tag){
-        $browser
-            ->assertVisible(self::$SELECTOR_TAGS_INPUT_TAG)
-            ->assertSeeIn(self::$SELECTOR_TAGS_INPUT_CONTAINER, $tag);
+    public function assertTagInInput(Browser $browser, string $tag){
+        $this->assertTagsInputHasTagsInInput($browser);
+        $browser->assertSeeIn(self::$SELECTOR_TAGS_INPUT_CONTAINER, $tag);
     }
 
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@creativebulma/bulma-badge": "^1.0.1",
     "@fortawesome/fontawesome-free": "5.15.2",
-    "@voerro/vue-tagsinput": "1.9.1",
+    "@voerro/vue-tagsinput": "^2",
     "axios": "^0.21.0",
     "bulma": "0.9.2",
     "bulma-calendar": "^6.0.7",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "build-prod": "cross-env NODE_ENV=production  node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js && echo 'process completed @ ' `date`"
   },
   "devDependencies": {
+    "@creativebulma/bulma-badge": "^1.0.1",
     "@fortawesome/fontawesome-free": "5.15.2",
     "@voerro/vue-tagsinput": "1.9.1",
     "axios": "^0.21.0",
     "bulma": "0.9.2",
-    "bulma-badge": "1.0.1",
     "bulma-calendar": "^6.0.7",
     "bulma-checkradio": "2.1.0",
     "chart.js": "^2.9.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "build-prod": "cross-env NODE_ENV=production  node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js && echo 'process completed @ ' `date`"
   },
   "devDependencies": {
-    "@creativebulma/bulma-badge": "^1.0.1",
     "@fortawesome/fontawesome-free": "5.15.2",
     "@voerro/vue-tagsinput": "^2",
     "axios": "^0.21.0",

--- a/resources/js/components/stats/tags-chart.vue
+++ b/resources/js/components/stats/tags-chart.vue
@@ -12,14 +12,12 @@
             <div class="field is-horizontal">
                 <div class="field-label is-normal"><label class="label">Tags:</label></div>
                 <div class="field-body"><div class="field"><div class="control" v-bind:class="{'is-loading': !areTagsSet}">
-                    <voerro-tags-input
-                        element-id="stats-tags-chart-tag-input"
-                        v-model="chartTagIds"
-                        v-bind:existing-tags="listTagsAsObject"
-                        v-bind:only-existing-tags="true"
-                        v-bind:typeahead="true"
-                        v-bind:typeahead-max-results="5"
-                    ></voerro-tags-input>
+                    <tagsinput
+                        tagsInputName="stats-tags-chart-tag-input"
+                        v-bind:existingTags="listTags"
+                        v-bind:selected-tags="chartTagIds"
+                        v-on:update-tags-input="chartTagIds = $event"
+                    ></tagsinput>
                 </div></div></div>
             </div>
 
@@ -59,7 +57,7 @@
     import BarChart from "./chart-defaults/bar-chart";
     import BulmaCalendar from '../bulma-calendar';
     import IncludeTransfersCheckbox from "../include-transfers-checkbox";
-    import VoerroTagsInput from '@voerro/vue-tagsinput';
+    import tagsinput from "../tagsinput";
 
     import {entriesObjectMixin} from "../../mixins/entries-object-mixin";
     import {statsChartMixin} from "../../mixins/stats-chart-mixin";
@@ -68,7 +66,7 @@
     export default {
         name: "tags-chart",
         mixins: [entriesObjectMixin, statsChartMixin, tagsObjectMixin],
-        components: {AccountAccountTypeTogglingSelector, BarChart, BulmaCalendar, IncludeTransfersCheckbox, VoerroTagsInput},
+        components: {AccountAccountTypeTogglingSelector, BarChart, BulmaCalendar, IncludeTransfersCheckbox, tagsinput},
         data: function(){
             return {
                 accountOrAccountTypeToggle: true,
@@ -165,7 +163,7 @@
                 }
 
                 if(!_.isEmpty(this.chartTagIds)){
-                    chartDataFilterParameters.tags = this.chartTagIds;
+                    chartDataFilterParameters.tags = this.chartTagIds.map(function(tag){ return tag.id; });
                 }
 
                 this.setChartTitle(chartDataFilterParameters.start_date, chartDataFilterParameters.end_date);
@@ -180,8 +178,6 @@
 
 <style lang="scss" scoped>
     @import '../../../sass/stats-chart';
-    @import '~@voerro/vue-tagsinput/dist/style.css';
-    @import '../../../sass/tags-input';
 
     .field.is-horizontal:nth-child(2){
         margin-bottom: 0;

--- a/resources/js/components/tagsinput.vue
+++ b/resources/js/components/tagsinput.vue
@@ -1,0 +1,58 @@
+<template>
+  <VoerroTagsInput
+      v-bind:element-id="tagsInputName"
+      id-field="id"
+      text-field="name"
+      v-model="propSelectedTags"
+      v-bind:existing-tags="existingTags"
+      v-bind:only-existing-tags="true"
+      v-bind:typeahead="true"
+      v-bind:typeahead-hide-discard="true"
+      v-bind:typeahead-max-results="5"
+  ></VoerroTagsInput>
+</template>
+
+<script>
+import VoerroTagsInput from '@voerro/vue-tagsinput';
+
+export default {
+  name: "tagsinput",
+  components: {
+    VoerroTagsInput,
+  },
+  props: {
+    tagsInputName: {type: String, required: true},
+    existingTags: {type: Array, required: true},
+    selectedTags: {type: Array, required: true, default: function(){ return []} }
+  },
+
+  data: function(){
+    return {
+      propSelectedTags: this.selectedTags
+    }
+  },
+
+  watch:{
+    selectedTags: function(newValue, oldValue){
+      this.propSelectedTags = newValue;
+    },
+    propSelectedTags: function(newValue, oldValue){
+      this.$emit('update-tags-input', newValue);
+    }
+  },
+}
+</script>
+
+<style scoped>
+  @import '~@voerro/vue-tagsinput/dist/style.css';
+
+  .tags-input input{
+    font-size: 0.75rem;
+  }
+  .tags-input span{
+    margin: 0 0.3rem 0 0;
+  }
+  .typeahead-badges{
+    margin-top: 0.125rem;
+  }
+</style>

--- a/resources/js/components/tagsinput.vue
+++ b/resources/js/components/tagsinput.vue
@@ -45,14 +45,5 @@ export default {
 
 <style scoped>
   @import '~@voerro/vue-tagsinput/dist/style.css';
-
-  .tags-input input{
-    font-size: 0.75rem;
-  }
-  .tags-input span{
-    margin: 0 0.3rem 0 0;
-  }
-  .typeahead-badges{
-    margin-top: 0.125rem;
-  }
+  @import "../../sass/tags-input.scss";
 </style>

--- a/resources/js/components/transfer-modal.vue
+++ b/resources/js/components/transfer-modal.vue
@@ -104,14 +104,12 @@
                 <div class="field is-horizontal">
                     <div class="field-label is-normal"><label class="label">Tags:</label></div>
                     <div class="field-body"><div class="field"><div class="control" v-bind:class="{'is-loading': !areTagsSet}">
-                        <voerro-tags-input
-                            element-id="transfer-tags"
-                            v-model="transferData.tags"
-                            v-bind:existing-tags="listTagsAsObject"
-                            v-bind:only-existing-tags="true"
-                            v-bind:typeahead="true"
-                            v-bind:typeahead-max-results="5"
-                        ></voerro-tags-input>
+                        <tagsinput
+                           tagsInputName="transfer-tags"
+                           v-bind:existingTags="listTags"
+                           v-bind:selected-tags="transferData.tags"
+                           v-on:update-tags-input="transferData.tags = $event"
+                        ></tagsinput>
                     </div></div></div>
                 </div>
 
@@ -153,14 +151,14 @@
     import {SnotifyStyle} from 'vue-snotify';
     import {tagsObjectMixin} from "../mixins/tags-object-mixin";
     import Store from '../store';
-    import VoerroTagsInput from '@voerro/vue-tagsinput';
+    import tagsinput from "./tagsinput";
     import vue2Dropzone from 'vue2-dropzone';
 
     export default {
         name: "transfer-modal",
         mixins: [accountTypesObjectMixin, tagsObjectMixin],
         components: {
-            VoerroTagsInput,
+            tagsinput,
             VueDropzone: vue2Dropzone,
         },
         data: function(){
@@ -337,11 +335,8 @@
                 // tags
                 if(_.isArray(this.transferData.tags)){
                     transferData.tags = [];
-                    this.transferData.tags.forEach(function(tagId){
-                        // each "tag" MUST be an int
-                        if(!_.isArray(tagId) && _.isNumber(parseInt(tagId))){
-                            transferData.tags.push(tagId);
-                        }
+                    this.transferData.tags.forEach(function(tag){
+                      transferData.tags.push(tag.id);
                     });
                 }
                 // attachments

--- a/resources/js/mixins/tags-object-mixin.js
+++ b/resources/js/mixins/tags-object-mixin.js
@@ -18,6 +18,9 @@ export const tagsObjectMixin = {
                 return result;
             }, {});
         },
+        listTags: function(){
+            return this.rawTagsData;
+        },
         areTagsSet: function(){
             return !_.isEmpty(this.rawTagsData);
         },

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -1,6 +1,6 @@
 // Bulma
 @import "~bulma/bulma";
-@import "~bulma-badge/dist/bulma-badge";
+@import "~@creativebulma/bulma-badge";
 @import "~bulma-calendar/dist/css/bulma-calendar.min.css";
 @import "~bulma-checkradio/dist/css/bulma-checkradio";
 

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -1,6 +1,5 @@
 // Bulma
 @import "~bulma/bulma";
-@import "~@creativebulma/bulma-badge";
 @import "~bulma-calendar/dist/css/bulma-calendar.min.css";
 @import "~bulma-checkradio/dist/css/bulma-checkradio";
 

--- a/resources/sass/tags-input.scss
+++ b/resources/sass/tags-input.scss
@@ -2,6 +2,6 @@
 .tags-input input{
   font-size: 0.75rem;
 }
-.tags-input span{
-  margin: 0 0.3rem 0 0;
+.typeahead-badges{
+  margin-top: 0.25rem;
 }

--- a/tests/Browser/StatsTagsTest.php
+++ b/tests/Browser/StatsTagsTest.php
@@ -118,7 +118,7 @@ class StatsTagsTest extends StatsBase {
         });
     }
 
-    public function providerTestGenerateTagsChart(){
+    public function providerTestGenerateTagsChart(): array{
         return [
             //[$datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $tag_count, $include_transfers]
             // defaults account/account-type & tags & date-picker values
@@ -192,7 +192,7 @@ class StatsTagsTest extends StatsBase {
      * @group stats-tags-2
      * test (see provider)/25
      */
-    public function testGenerateTagsChart($datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $tag_count, $include_transfers){
+    public function testGenerateTagsChart($datepicker_start, $datepicker_end, bool $is_switch_toggled, bool $is_random_selector_value, bool $are_disabled_select_options_available, int $tag_count, bool $include_transfers){
         $accounts = collect($this->getApiAccounts());
         $account_types = collect($this->getApiAccountTypes());
         $tags = collect($this->getApiTags());
@@ -281,7 +281,7 @@ class StatsTagsTest extends StatsBase {
      * @param Collection $tags
      * @return array
      */
-    private function standardiseData($entries, $tags){
+    private function standardiseData($entries, $tags): array{
         $standardised_chart_data = [];
 
         foreach($entries as $entry){
@@ -310,11 +310,11 @@ class StatsTagsTest extends StatsBase {
 
     /**
      * @param bool $is_account_type_rather_than_account_toggled
-     * @param int $account_or_account_type_id
+     * @param string|int $account_or_account_type_id
      * @param Collection $account_types
      * @param Collection $tags
      */
-    private function createEntryWithAllTags($is_account_type_rather_than_account_toggled, $account_or_account_type_id, $account_types, $tags){
+    private function createEntryWithAllTags(bool $is_account_type_rather_than_account_toggled, $account_or_account_type_id, $account_types, $tags){
         if(!empty($account_or_account_type_id)){
             if($is_account_type_rather_than_account_toggled){
                 $account_type_id = $account_or_account_type_id;

--- a/tests/Browser/TransferModalTest.php
+++ b/tests/Browser/TransferModalTest.php
@@ -565,7 +565,7 @@ class TransferModalTest extends DuskTestCase {
             $this->waitForLoadingToStop($browser);
             $this->openTransferModal($browser);
             $browser
-                ->with($this->_selector_modal_transfer, function($modal) use ($transfer_entry_data, $browser_locale_date_for_typing){
+                ->with($this->_selector_modal_transfer, function($modal) use ($transfer_entry_data, $browser_locale_date_for_typing, $has_tags){
                     // laravel dusk has an issue typing into input[type="date"] fields
                     // work-around for this is to use individual key-strokes
                     $backspace_count = strlen($modal->value($this->_selector_modal_transfer_field_date));
@@ -581,11 +581,11 @@ class TransferModalTest extends DuskTestCase {
                         ->waitUntilMissing($this->_selector_modal_transfer_field_to_is_loading)
                         ->select($this->_selector_modal_transfer_field_to, $transfer_entry_data['to_account_type_id'])
                         ->type($this->_selector_modal_transfer_field_memo, $transfer_entry_data['memo']);
-                });
 
-            if($has_tags){
-                $this->fillTagsInputUsingAutocomplete($browser, $transfer_entry_data['tag']);
-            }
+                    if($has_tags){
+                        $this->fillTagsInputUsingAutocomplete($modal, $transfer_entry_data['tag']);
+                    }
+                });
 
             if($has_attachments){
                 $this->attachFile($browser, $transfer_entry_data['attachment_path']);
@@ -752,7 +752,7 @@ class TransferModalTest extends DuskTestCase {
                     ->assertSee($entry_switch_expense_label);
 
                 if($has_tags){
-                    $this->assertDefaultStateOfTagsInput($modal);
+                    $modal->assertVisible(self::$SELECTOR_TAGS_INPUT_CONTAINER);
                     $this->assertTagInInput($modal, $transfer_entry_data['tag']);
                 }
 

--- a/tests/Traits/HomePageSelectors.php
+++ b/tests/Traits/HomePageSelectors.php
@@ -48,9 +48,6 @@ trait HomePageSelectors {
     private $_selector_modal_entry_meta = "#entry-account-type-meta";
     private $_selector_modal_entry_field_memo = "textarea#entry-memo";
     private $_selector_modal_entry_field_expense = "#entry-expense";
-    private $_selector_modal_entry_field_tags_container_is_loading = ".field:nth-child(6) .control.is-loading";
-    private $_selector_modal_entry_field_tags = ".tags-input input";
-    private $_selector_modal_entry_field_tags_input_tag = ".tags-input span.badge-pill";
     private $_selector_tags = ".tags";
     private $_selector_tags_tag = ".tags .tag";
     private $_selector_modal_entry_field_upload = "#entry-modal-file-upload";
@@ -82,8 +79,6 @@ trait HomePageSelectors {
     private $_selector_modal_transfer_meta_account_name_to = "#to-account-type-meta-account-name";
     private $_selector_modal_transfer_meta_last_digits_to = "#to-account-type-meta-last-digits";
     private $_selector_modal_transfer_field_memo = "#transfer-memo";
-    private $_selector_modal_transfer_field_tags_container_is_loading = ".field:nth-child(6) .control.is-loading";
-    private $_selector_modal_transfer_field_tags = ".tags-input input";
     private $_selector_modal_transfer_field_upload = "#transfer-modal-file-upload";
     private $_selector_modal_transfer_dropzone_hidden_file_input = "#transfer-modal-hidden-file-input";
     private $_selector_modal_transfer_dropzone_upload_thumbnail = "#transfer-modal-file-upload .dz-complete:last-child";

--- a/yarn.lock
+++ b/yarn.lock
@@ -813,11 +813,6 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@creativebulma/bulma-badge@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@creativebulma/bulma-badge/-/bulma-badge-1.0.1.tgz#7f1c2ec04020a4d18db1d960a644a052e61de9da"
-  integrity sha512-cTMgxPdTOsAfPqd9wbrvKNUTvnIt+pNgwwO9Xzu6MRUIFlvGRtIVApaV51f3wt0/uI78BpKv5FPAtEJbmSTZOg==
-
 "@fortawesome/fontawesome-free@5.15.2":
   version "5.15.2"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.2.tgz#218cd7276ab4f9ab57cc3d2efa2697e6a579f25d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -813,6 +813,11 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@creativebulma/bulma-badge@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@creativebulma/bulma-badge/-/bulma-badge-1.0.1.tgz#7f1c2ec04020a4d18db1d960a644a052e61de9da"
+  integrity sha512-cTMgxPdTOsAfPqd9wbrvKNUTvnIt+pNgwwO9Xzu6MRUIFlvGRtIVApaV51f3wt0/uI78BpKv5FPAtEJbmSTZOg==
+
 "@fortawesome/fontawesome-free@5.15.2":
   version "5.15.2"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.2.tgz#218cd7276ab4f9ab57cc3d2efa2697e6a579f25d"
@@ -1566,11 +1571,6 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
-
-bulma-badge@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/bulma-badge/-/bulma-badge-1.0.1.tgz#855a6b4b8213a67201b4bc40bbc1ce1186674618"
-  integrity sha1-hVprS4ITpnIBtLxAu8HOEYZnRhg=
 
 bulma-calendar@^6.0.7:
   version "6.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -871,12 +871,10 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
-"@voerro/vue-tagsinput@1.9.1":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@voerro/vue-tagsinput/-/vue-tagsinput-1.9.1.tgz#99f984d28248c981e95d4d02312f9e26b631ee16"
-  integrity sha512-90Lelfm1LHQrXUTZVeylt3ga6Oe9TLSDZjkMdG/FBYlHJgmyVXO4R5DFxEQF6Ra1levx8QwcOI/6M2gnW02/cA==
-  dependencies:
-    vue "^2.5.0"
+"@voerro/vue-tagsinput@^2":
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/@voerro/vue-tagsinput/-/vue-tagsinput-2.4.3.tgz#a4e9bdd1cf2f3248584380c8491799059dca5b73"
+  integrity sha512-r+4CJmuzrTgcHWit+vdnuiBdPRoEm7r361DMpSkGBlth/Cvf1vOdF/0WRI1vdstQc0r9j/Ifce34ImuzoFKqLw==
 
 "@vue/component-compiler-utils@^3.1.0":
   version "3.2.0"
@@ -6890,7 +6888,7 @@ vue2-dropzone@3.2.2:
   dependencies:
     dropzone "^5.4.0"
 
-vue@^2.2.1, vue@^2.5.0, vue@^2.5.17:
+vue@^2.2.1, vue@^2.5.17:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
   integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==


### PR DESCRIPTION
- Removing the `bulma-badge` package. 
  - Looks like we don't use the `bulma-badge` CSS at all.
- Bumped `@voerro/vue-tagsinput` version.
  - The bumped version of `@voerro/vue-tagsinput` contained breaking changes. Additional development was required to make it work again.
  - As part of version bump, created a new component for _tagsinput_.
- Updated the _entry-modal_ component to use the new _tagsinput_ component.
- Updated the _transfer-modal_ component to use the new _tagsinput_ component.
- Performing `yarn check` prior to `yarn install` when running tests with github actions.

Resolves #330 