### PR TITLE
support/4.4.0.1

### DIFF
--- a/app/Traits/Tests/Dusk/ToggleButton.php
+++ b/app/Traits/Tests/Dusk/ToggleButton.php
@@ -19,7 +19,7 @@ trait ToggleButton {
      * @param string $label
      * @param string|null $color
      */
-    public function assertToggleButtonState(Browser $browser, $selector, $label, $color=null){
+    public function assertToggleButtonState(Browser $browser, string $selector, string $label, $color=null){
         $browser
             ->assertVisible($selector)
             ->assertSeeIn($selector, $label);
@@ -29,7 +29,11 @@ trait ToggleButton {
         }
     }
 
-    public function toggleToggleButton(Browser $browser, $selector){
+    /**
+     * @param Browser $browser
+     * @param string $selector
+     */
+    public function toggleToggleButton(Browser $browser, string $selector){
         $browser
             ->click($selector)
             ->pause(self::$WAIT_HALF_SECOND_IN_MILLISECONDS);   // wait for transition to complete

--- a/database/seeds/UiSampleDatabaseSeeder.php
+++ b/database/seeds/UiSampleDatabaseSeeder.php
@@ -102,6 +102,9 @@ class UiSampleDatabaseSeeder extends Seeder {
         $transfer_from_entries = collect();
         for($transfer_i=0; $transfer_i<self::COUNT_ENTRY; $transfer_i++){
             $transfer_to_entry = $entries_not_disabled
+                ->sortByDesc('entry_date')
+                ->chunk(self::$MAX_ENTRIES_IN_RESPONSE)
+                ->first()
                 ->where('expense', 0)
                 ->whereNull('transfer_entry_id')
                 ->random();


### PR DESCRIPTION
Modified database seeder so that when seeding the database, we select entries to be assigned as transfers from the first 50 entries in `entry_date desc` order