### PR TITLE
Feature/refine-renovate-prs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "prHourlyLimit:1",
+    "stabilityDays:30"
   ]
 }


### PR DESCRIPTION
Modifying the renovate.json file to refine renovate bots PR generation criteria:
- Can only create 1 PR per hour.
- Dependency must be at least 30 days old before even being considered for PR.