### PR TITLE
Feature/set-composer-php-version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,10 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "platform": {
+            "php": "7.3"
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Setting php platform version in composer.json to hopefully stabilise future PRs resulting from dependency updates.