### PR TITLE
hotfix/4.7.4.1

### DIFF
--- a/.docker/cmd/composer.sh
+++ b/.docker/cmd/composer.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker container run --rm -t --volume $PWD:/app composer:2.1 "$@"
+docker container run --rm -t --volume $PWD:/app composer:2.1.11 "$@"


### PR DESCRIPTION
Setting composer docker image version to `2.1.11`. The latest versions in the `2.1` spectrum are using PHP 8.1 which is incompatible with some Laravel packages currently being used.
Will revise usage again when next Laravel LTS version is release and used.