### PR TITLE
hotfix/4.7.5.3

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.ref }}
+          fetch-depth: 0
 
       - id: set-release-name
         run: echo "RELEASE_NAME=$(git describe --tags)" >> $GITHUB_ENV


### PR DESCRIPTION
Modified the Github Actions workflow `draft-release` to fetch all branches and tags.