### PR TITLE
feature/github-actions-cache-key-variables

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,26 +107,26 @@ jobs:
         uses: actions/checkout@v2
 
       # retrieve cache
-      - name: Cache Docker images
+      - name: Get Cached Docker images
         id: docker-image-cache
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: jobs.build.outputs.cache-key-docker
+          key: ${{ jobs.build.outputs.cache-key-docker }}
 
-      - name: Cache Composer packages
+      - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: jobs.build.outputs.cache-key-composer
+          key: ${{ jobs.build.outputs.cache-key-composer }}
 
-      - name: Cache npm packages
+      - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: jobs.build.outputs.cache-key-npm
+          key: ${{ jobs.build.outputs.cache-key-npm }}
 
       # NOTE: vue cache not needed for unit tests
 
@@ -184,35 +184,35 @@ jobs:
         uses: actions/checkout@v2
 
       # retrieve cache
-      - name: Cache Docker images
+      - name: Get Cached Docker images
         id: docker-image-cache
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: jobs.build.outputs.cache-key-docker
+          key: ${{ jobs.build.outputs.cache-key-docker }}
 
-      - name: Cache Composer packages
+      - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: jobs.build.outputs.cache-key-composer
+          key: ${{ jobs.build.outputs.cache-key-composer }}
 
-      - name: Cache npm packages
+      - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: jobs.build.outputs.cache-key-npm
+          key: ${{ jobs.build.outputs.cache-key-npm }}
 
-      - name: Cache vue
+      - name: Get Cached vue
         id: vue-cache
         uses: actions/cache@v2
         with:
           path: |
             public/vue
             public/mix-manifest.json
-          key: jobs.build.outputs.cache-key-vue
+          key: ${{ jobs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -244,35 +244,35 @@ jobs:
         uses: actions/checkout@v2
 
       # retrieve cache
-      - name: Cache Docker images
+      - name: Get Cached Docker images
         id: docker-image-cache
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: jobs.build.outputs.cache-key-docker
+          key: ${{ jobs.build.outputs.cache-key-docker }}
 
-      - name: Cache Composer packages
+      - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: jobs.build.outputs.cache-key-composer
+          key: ${{ jobs.build.outputs.cache-key-composer }}
 
-      - name: Cache npm packages
+      - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: jobs.build.outputs.cache-key-npm
+          key: ${{ jobs.build.outputs.cache-key-npm }}
 
-      - name: Cache vue
+      - name: Get Cached vue
         id: vue-cache
         uses: actions/cache@v2
         with:
           path: |
             public/vue
             public/mix-manifest.json
-          key: jobs.build.outputs.cache-key-vue
+          key: ${{ jobs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -304,35 +304,35 @@ jobs:
         uses: actions/checkout@v2
 
       # retrieve cache
-      - name: Cache Docker images
+      - name: Get Cached Docker images
         id: docker-image-cache
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: jobs.build.outputs.cache-key-docker
+          key: ${{ jobs.build.outputs.cache-key-docker }}
 
-      - name: Cache Composer packages
+      - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: jobs.build.outputs.cache-key-composer
+          key: ${{ jobs.build.outputs.cache-key-composer }}
 
-      - name: Cache npm packages
+      - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: jobs.build.outputs.cache-key-npm
+          key: ${{ jobs.build.outputs.cache-key-npm }}
 
-      - name: Cache vue
+      - name: Get Cached vue
         id: vue-cache
         uses: actions/cache@v2
         with:
           path: |
             public/vue
             public/mix-manifest.json
-          key: jobs.build.outputs.cache-key-vue
+          key: ${{ jobs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -373,35 +373,35 @@ jobs:
         uses: actions/checkout@v2
 
       # retrieve cache
-      - name: Cache Docker images
+      - name: Get Cached Docker images
         id: docker-image-cache
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: jobs.build.outputs.cache-key-docker
+          key: ${{ jobs.build.outputs.cache-key-docker }}
 
-      - name: Cache Composer packages
+      - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: jobs.build.outputs.cache-key-composer
+          key: ${{ jobs.build.outputs.cache-key-composer }}
 
-      - name: Cache npm packages
+      - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: jobs.build.outputs.cache-key-npm
+          key: ${{ jobs.build.outputs.cache-key-npm }}
 
-      - name: Cache vue
+      - name: Get Cached vue
         id: vue-cache
         uses: actions/cache@v2
         with:
           path: |
             public/vue
             public/mix-manifest.json
-          key: jobs.build.outputs.cache-key-vue
+          key: ${{ jobs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -436,35 +436,35 @@ jobs:
         uses: actions/checkout@v2
 
       # retrieve cache
-      - name: Cache Docker images
+      - name: Get Cached Docker images
         id: docker-image-cache
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: jobs.build.outputs.cache-key-docker
+          key: ${{ jobs.build.outputs.cache-key-docker }}
 
-      - name: Cache Composer packages
+      - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: jobs.build.outputs.cache-key-composer
+          key: ${{ jobs.build.outputs.cache-key-composer }}
 
-      - name: Cache npm packages
+      - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: jobs.build.outputs.cache-key-npm
+          key: ${{ jobs.build.outputs.cache-key-npm }}
 
-      - name: Cache vue
+      - name: Get Cached vue
         id: vue-cache
         uses: actions/cache@v2
         with:
           path: |
             public/vue
             public/mix-manifest.json
-          key: jobs.build.outputs.cache-key-vue
+          key: ${{ jobs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -499,35 +499,35 @@ jobs:
         uses: actions/checkout@v2
 
       # retrieve cache
-      - name: Cache Docker images
+      - name: Get Cached Docker images
         id: docker-image-cache
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: jobs.build.outputs.cache-key-docker
+          key: ${{ jobs.build.outputs.cache-key-docker }}
 
-      - name: Cache Composer packages
+      - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: jobs.build.outputs.cache-key-composer
+          key: ${{ jobs.build.outputs.cache-key-composer }}
 
-      - name: Cache npm packages
+      - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: jobs.build.outputs.cache-key-npm
+          key: ${{ jobs.build.outputs.cache-key-npm }}
 
-      - name: Cache vue
+      - name: Get Cached vue
         id: vue-cache
         uses: actions/cache@v2
         with:
           path: |
             public/vue
             public/mix-manifest.json
-          key: jobs.build.outputs.cache-key-vue
+          key: ${{ jobs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -562,35 +562,35 @@ jobs:
         uses: actions/checkout@v2
 
       # retrieve cache
-      - name: Cache Docker images
+      - name: Get Cached Docker images
         id: docker-image-cache
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: jobs.build.outputs.cache-key-docker
+          key: ${{ jobs.build.outputs.cache-key-docker }}
 
-      - name: Cache Composer packages
+      - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: jobs.build.outputs.cache-key-composer
+          key: ${{ jobs.build.outputs.cache-key-composer }}
 
-      - name: Cache npm packages
+      - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: jobs.build.outputs.cache-key-npm
+          key: ${{ jobs.build.outputs.cache-key-npm }}
 
-      - name: Cache vue
+      - name: Get Cached vue
         id: vue-cache
         uses: actions/cache@v2
         with:
           path: |
             public/vue
             public/mix-manifest.json
-          key: jobs.build.outputs.cache-key-vue
+          key: ${{ jobs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -622,35 +622,35 @@ jobs:
         uses: actions/checkout@v2
 
       # retrieve cache
-      - name: Cache Docker images
+      - name: Get Cached Docker images
         id: docker-image-cache
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: jobs.build.outputs.cache-key-docker
+          key: ${{ jobs.build.outputs.cache-key-docker }}
 
-      - name: Cache Composer packages
+      - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: jobs.build.outputs.cache-key-composer
+          key: ${{ jobs.build.outputs.cache-key-composer }}
 
-      - name: Cache npm packages
+      - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: jobs.build.outputs.cache-key-npm
+          key: ${{ jobs.build.outputs.cache-key-npm }}
 
-      - name: Cache vue
+      - name: Get Cached vue
         id: vue-cache
         uses: actions/cache@v2
         with:
           path: |
             public/vue
             public/mix-manifest.json
-          key: jobs.build.outputs.cache-key-vue
+          key: ${{ jobs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -682,35 +682,35 @@ jobs:
         uses: actions/checkout@v2
 
       # retrieve cache
-      - name: Cache Docker images
+      - name: Get Cached Docker images
         id: docker-image-cache
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: jobs.build.outputs.cache-key-docker
+          key: ${{ jobs.build.outputs.cache-key-docker }}
 
-      - name: Cache Composer packages
+      - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: jobs.build.outputs.cache-key-composer
+          key: ${{ jobs.build.outputs.cache-key-composer }}
 
-      - name: Cache npm packages
+      - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: jobs.build.outputs.cache-key-npm
+          key: ${{ jobs.build.outputs.cache-key-npm }}
 
-      - name: Cache vue
+      - name: Get Cached vue
         id: vue-cache
         uses: actions/cache@v2
         with:
           path: |
             public/vue
             public/mix-manifest.json
-          key: jobs.build.outputs.cache-key-vue
+          key: ${{ jobs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -745,35 +745,35 @@ jobs:
         uses: actions/checkout@v2
 
       # retrieve cache
-      - name: Cache Docker images
+      - name: Get Cached Docker images
         id: docker-image-cache
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: jobs.build.outputs.cache-key-docker
+          key: ${{ jobs.build.outputs.cache-key-docker }}
 
-      - name: Cache Composer packages
+      - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: jobs.build.outputs.cache-key-composer
+          key: ${{ jobs.build.outputs.cache-key-composer }}
 
-      - name: Cache npm packages
+      - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: jobs.build.outputs.cache-key-npm
+          key: ${{ jobs.build.outputs.cache-key-npm }}
 
-      - name: Cache vue
+      - name: Get Cached vue
         id: vue-cache
         uses: actions/cache@v2
         with:
           path: |
             public/vue
             public/mix-manifest.json
-          key: jobs.build.outputs.cache-key-vue
+          key: ${{ jobs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Docker build
         uses: ./.github/actions/setup-docker
-        if: steps.docker-cache.outputs.cache-hit != 'true'
+        if: steps.docker-image-cache.outputs.cache-hit != 'true'
 
       - name: Cache Composer packages
         id: composer-cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,12 +27,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Generate cache keys [docker]
+        id: cache-key-docker
+        run: echo "::set-output name=value::cache-docker-${{ hashFiles('.docker/*') }}"
+
+      - name: Generate cache keys [composer]
+        id: cache-key-composer
+        run: echo "::set-output name=value::cache-composer-${{ hashFiles('composer.*') }}"
+
+      - name: Generate cache keys [npm]
+        id: cache-key-npm
+        run: echo "::set-output name=value::cache-npm-${{ hashFiles('package*.json') }}"
+
+      - name: Generate cache keys [vue]
+        id: cache-key-vue
+        run: echo "::set-output name=value::cache-vue-${{ hashFiles('package*.json') }}-${{ hashFiles('resources/*') }}"
+
       - name: Cache Docker images
         id: docker-image-cache
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: cache-docker-${{ hashFiles('.docker/*') }}
+          key: steps.cache-key-docker.outputs.value
 
       - name: Docker build
         uses: ./.github/actions/setup-docker
@@ -43,7 +59,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: vendor
-          key: cache-composer-${{ hashFiles('composer.*') }}
+          key: jobs.build.outputs.cache-key-composer
 
       - name: Composer setup
         uses: ./.github/actions/setup-composer
@@ -57,7 +73,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: cache-npm-${{ hashFiles('package*.json') }}
+          key: steps.cache-key-npm.outputs.value
 
       - name: npm setup
         uses: ./.github/actions/setup-npm
@@ -70,11 +86,16 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: cache-vue-${{ hashFiles('package*.json') }}-${{ hashFiles('resources/*') }}
+          key: steps.cache-key-vue.outputs.value
 
       - name: Build Vue
         uses: ./.github/actions/build-vue
         if: steps.vue-cache.outputs.cache-hit != 'true'
+    outputs:
+      cache-key-docker: ${{ steps.cache-key-docker.outputs.value }}
+      cache-key-composer: ${{ steps.cache-key-composer.outputs.value }}
+      cache-key-npm: ${{ steps.cache-key-npm.outputs.value }}
+      cache-key-vue: ${{ steps.cache-key-vue.outputs.value }}
 
   tests-unit:
     needs:
@@ -91,21 +112,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: cache-docker-${{ hashFiles('.docker/*') }}
+          key: jobs.build.outputs.cache-key-docker
 
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: cache-composer-${{ hashFiles('composer.*') }}
+          key: jobs.build.outputs.cache-key-composer
 
       - name: Cache npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: cache-npm-${{ hashFiles('package*.json') }}
+          key: jobs.build.outputs.cache-key-npm
 
       # NOTE: vue cache not needed for unit tests
 
@@ -168,21 +189,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: cache-docker-${{ hashFiles('.docker/*') }}
+          key: jobs.build.outputs.cache-key-docker
 
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: cache-composer-${{ hashFiles('composer.*') }}
+          key: jobs.build.outputs.cache-key-composer
 
       - name: Cache npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: cache-npm-${{ hashFiles('package*.json') }}
+          key: jobs.build.outputs.cache-key-npm
 
       - name: Cache vue
         id: vue-cache
@@ -191,7 +212,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: cache-vue-${{ hashFiles('package*.json') }}-${{ hashFiles('resources/*') }}
+          key: jobs.build.outputs.cache-key-vue
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -228,21 +249,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: cache-docker-${{ hashFiles('.docker/*') }}
+          key: jobs.build.outputs.cache-key-docker
 
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: cache-composer-${{ hashFiles('composer.*') }}
+          key: jobs.build.outputs.cache-key-composer
 
       - name: Cache npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: cache-npm-${{ hashFiles('package*.json') }}
+          key: jobs.build.outputs.cache-key-npm
 
       - name: Cache vue
         id: vue-cache
@@ -251,7 +272,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: cache-vue-${{ hashFiles('package*.json') }}-${{ hashFiles('resources/*') }}
+          key: jobs.build.outputs.cache-key-vue
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -288,21 +309,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: cache-docker-${{ hashFiles('.docker/*') }}
+          key: jobs.build.outputs.cache-key-docker
 
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: cache-composer-${{ hashFiles('composer.*') }}
+          key: jobs.build.outputs.cache-key-composer
 
       - name: Cache npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: cache-npm-${{ hashFiles('package*.json') }}
+          key: jobs.build.outputs.cache-key-npm
 
       - name: Cache vue
         id: vue-cache
@@ -311,7 +332,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: cache-vue-${{ hashFiles('package*.json') }}-${{ hashFiles('resources/*') }}
+          key: jobs.build.outputs.cache-key-vue
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -357,21 +378,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: cache-docker-${{ hashFiles('.docker/*') }}
+          key: jobs.build.outputs.cache-key-docker
 
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: cache-composer-${{ hashFiles('composer.*') }}
+          key: jobs.build.outputs.cache-key-composer
 
       - name: Cache npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: cache-npm-${{ hashFiles('package*.json') }}
+          key: jobs.build.outputs.cache-key-npm
 
       - name: Cache vue
         id: vue-cache
@@ -380,7 +401,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: cache-vue-${{ hashFiles('package*.json') }}-${{ hashFiles('resources/*') }}
+          key: jobs.build.outputs.cache-key-vue
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -420,21 +441,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: cache-docker-${{ hashFiles('.docker/*') }}
+          key: jobs.build.outputs.cache-key-docker
 
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: cache-composer-${{ hashFiles('composer.*') }}
+          key: jobs.build.outputs.cache-key-composer
 
       - name: Cache npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: cache-npm-${{ hashFiles('package*.json') }}
+          key: jobs.build.outputs.cache-key-npm
 
       - name: Cache vue
         id: vue-cache
@@ -443,7 +464,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: cache-vue-${{ hashFiles('package*.json') }}-${{ hashFiles('resources/*') }}
+          key: jobs.build.outputs.cache-key-vue
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -483,21 +504,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: cache-docker-${{ hashFiles('.docker/*') }}
+          key: jobs.build.outputs.cache-key-docker
 
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: cache-composer-${{ hashFiles('composer.*') }}
+          key: jobs.build.outputs.cache-key-composer
 
       - name: Cache npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: cache-npm-${{ hashFiles('package*.json') }}
+          key: jobs.build.outputs.cache-key-npm
 
       - name: Cache vue
         id: vue-cache
@@ -506,7 +527,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: cache-vue-${{ hashFiles('package*.json') }}-${{ hashFiles('resources/*') }}
+          key: jobs.build.outputs.cache-key-vue
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -546,21 +567,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: cache-docker-${{ hashFiles('.docker/*') }}
+          key: jobs.build.outputs.cache-key-docker
 
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: cache-composer-${{ hashFiles('composer.*') }}
+          key: jobs.build.outputs.cache-key-composer
 
       - name: Cache npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: cache-npm-${{ hashFiles('package*.json') }}
+          key: jobs.build.outputs.cache-key-npm
 
       - name: Cache vue
         id: vue-cache
@@ -569,7 +590,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: cache-vue-${{ hashFiles('package*.json') }}-${{ hashFiles('resources/*') }}
+          key: jobs.build.outputs.cache-key-vue
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -606,21 +627,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: cache-docker-${{ hashFiles('.docker/*') }}
+          key: jobs.build.outputs.cache-key-docker
 
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: cache-composer-${{ hashFiles('composer.*') }}
+          key: jobs.build.outputs.cache-key-composer
 
       - name: Cache npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: cache-npm-${{ hashFiles('package*.json') }}
+          key: jobs.build.outputs.cache-key-npm
 
       - name: Cache vue
         id: vue-cache
@@ -629,7 +650,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: cache-vue-${{ hashFiles('package*.json') }}-${{ hashFiles('resources/*') }}
+          key: jobs.build.outputs.cache-key-vue
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -666,21 +687,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: cache-docker-${{ hashFiles('.docker/*') }}
+          key: jobs.build.outputs.cache-key-docker
 
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: cache-composer-${{ hashFiles('composer.*') }}
+          key: jobs.build.outputs.cache-key-composer
 
       - name: Cache npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: cache-npm-${{ hashFiles('package*.json') }}
+          key: jobs.build.outputs.cache-key-npm
 
       - name: Cache vue
         id: vue-cache
@@ -689,7 +710,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: cache-vue-${{ hashFiles('package*.json') }}-${{ hashFiles('resources/*') }}
+          key: jobs.build.outputs.cache-key-vue
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -729,21 +750,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: cache-docker-${{ hashFiles('.docker/*') }}
+          key: jobs.build.outputs.cache-key-docker
 
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: cache-composer-${{ hashFiles('composer.*') }}
+          key: jobs.build.outputs.cache-key-composer
 
       - name: Cache npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: cache-npm-${{ hashFiles('package*.json') }}
+          key: jobs.build.outputs.cache-key-npm
 
       - name: Cache vue
         id: vue-cache
@@ -752,7 +773,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: cache-vue-${{ hashFiles('package*.json') }}-${{ hashFiles('resources/*') }}
+          key: jobs.build.outputs.cache-key-vue
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -777,7 +798,6 @@ jobs:
   notification:
     runs-on: ubuntu-latest
     needs:  # make sure the notification is sent AFTER the jobs you want included have completed
-      - build
       - tests-unit
       - tests-e2e-demo
       - tests-e2e-notifications

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,21 +112,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: ${{ jobs.build.outputs.cache-key-docker }}
+          key: ${{ needs.build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ jobs.build.outputs.cache-key-composer }}
+          key: ${{ needs.build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ jobs.build.outputs.cache-key-npm }}
+          key: ${{ needs.build.outputs.cache-key-npm }}
 
       # NOTE: vue cache not needed for unit tests
 
@@ -189,21 +189,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: ${{ jobs.build.outputs.cache-key-docker }}
+          key: ${{ needs.build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ jobs.build.outputs.cache-key-composer }}
+          key: ${{ needs.build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ jobs.build.outputs.cache-key-npm }}
+          key: ${{ needs.build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
@@ -212,7 +212,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: ${{ jobs.build.outputs.cache-key-vue }}
+          key: ${{ needs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -249,21 +249,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: ${{ jobs.build.outputs.cache-key-docker }}
+          key: ${{ needs.build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ jobs.build.outputs.cache-key-composer }}
+          key: ${{ needs.build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ jobs.build.outputs.cache-key-npm }}
+          key: ${{ needs.build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
@@ -272,7 +272,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: ${{ jobs.build.outputs.cache-key-vue }}
+          key: ${{ needs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -309,21 +309,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: ${{ jobs.build.outputs.cache-key-docker }}
+          key: ${{ needs.build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ jobs.build.outputs.cache-key-composer }}
+          key: ${{ needs.build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ jobs.build.outputs.cache-key-npm }}
+          key: ${{ needs.build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
@@ -332,7 +332,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: ${{ jobs.build.outputs.cache-key-vue }}
+          key: ${{ needs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -378,21 +378,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: ${{ jobs.build.outputs.cache-key-docker }}
+          key: ${{ needs.build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ jobs.build.outputs.cache-key-composer }}
+          key: ${{ needs.build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ jobs.build.outputs.cache-key-npm }}
+          key: ${{ needs.build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
@@ -401,7 +401,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: ${{ jobs.build.outputs.cache-key-vue }}
+          key: ${{ needs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -441,21 +441,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: ${{ jobs.build.outputs.cache-key-docker }}
+          key: ${{ needs.build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ jobs.build.outputs.cache-key-composer }}
+          key: ${{ needs.build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ jobs.build.outputs.cache-key-npm }}
+          key: ${{ needs.build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
@@ -464,7 +464,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: ${{ jobs.build.outputs.cache-key-vue }}
+          key: ${{ needs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -504,21 +504,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: ${{ jobs.build.outputs.cache-key-docker }}
+          key: ${{ needs.build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ jobs.build.outputs.cache-key-composer }}
+          key: ${{ needs.build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ jobs.build.outputs.cache-key-npm }}
+          key: ${{ needs.build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
@@ -527,7 +527,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: ${{ jobs.build.outputs.cache-key-vue }}
+          key: ${{ needs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -567,21 +567,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: ${{ jobs.build.outputs.cache-key-docker }}
+          key: ${{ needs.build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ jobs.build.outputs.cache-key-composer }}
+          key: ${{ needs.build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ jobs.build.outputs.cache-key-npm }}
+          key: ${{ needs.build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
@@ -590,7 +590,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: ${{ jobs.build.outputs.cache-key-vue }}
+          key: ${{ needs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -627,21 +627,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: ${{ jobs.build.outputs.cache-key-docker }}
+          key: ${{ needs.build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ jobs.build.outputs.cache-key-composer }}
+          key: ${{ needs.build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ jobs.build.outputs.cache-key-npm }}
+          key: ${{ needs.build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
@@ -650,7 +650,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: ${{ jobs.build.outputs.cache-key-vue }}
+          key: ${{ needs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -687,21 +687,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: ${{ jobs.build.outputs.cache-key-docker }}
+          key: ${{ needs.build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ jobs.build.outputs.cache-key-composer }}
+          key: ${{ needs.build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ jobs.build.outputs.cache-key-npm }}
+          key: ${{ needs.build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
@@ -710,7 +710,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: ${{ jobs.build.outputs.cache-key-vue }}
+          key: ${{ needs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init
@@ -750,21 +750,21 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: ${{ jobs.build.outputs.cache-key-docker }}
+          key: ${{ needs.build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ jobs.build.outputs.cache-key-composer }}
+          key: ${{ needs.build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: ${{ jobs.build.outputs.cache-key-npm }}
+          key: ${{ needs.build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
@@ -773,7 +773,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: ${{ jobs.build.outputs.cache-key-vue }}
+          key: ${{ needs.build.outputs.cache-key-vue }}
 
       # end-2-end tests
       - uses: ./.github/actions/app-init

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .docker/images
-          key: steps.cache-key-docker.outputs.value
+          key: ${{ steps.cache-key-docker.outputs.value }}
 
       - name: Docker build
         uses: ./.github/actions/setup-docker
@@ -59,7 +59,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: vendor
-          key: jobs.build.outputs.cache-key-composer
+          key: ${{ steps.cache-key-composer.outputs.value }}
 
       - name: Composer setup
         uses: ./.github/actions/setup-composer
@@ -73,7 +73,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: steps.cache-key-npm.outputs.value
+          key: ${{ steps.cache-key-npm.outputs.value }}
 
       - name: npm setup
         uses: ./.github/actions/setup-npm
@@ -86,7 +86,7 @@ jobs:
           path: |
             public/vue
             public/mix-manifest.json
-          key: steps.cache-key-vue.outputs.value
+          key: ${{ steps.cache-key-vue.outputs.value }}
 
       - name: Build Vue
         uses: ./.github/actions/build-vue


### PR DESCRIPTION
Set the cache keys in variables so we don't run the risk of missing a cache in any jobs should the need to change how the cache key is generated.