### PR TITLE
Fix/GitHub-actions-deprecation-warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,61 +28,51 @@ jobs:
 
       - name: Generate cache keys [docker]
         id: cache-key-docker
-        run: echo "::set-output name=value::cache-docker-${{ hashFiles('.docker/*') }}1"
+        run: echo "value=cache-docker-${{ hashFiles('.docker/*') }}" >> $GITHUB_OUTPUT
 
       - name: Generate cache keys [composer]
         id: cache-key-composer
-        run: echo "::set-output name=value::cache-composer-${{ hashFiles('composer.*') }}"
+        run: echo "value=cache-composer-${{ hashFiles('composer.*') }}" >> $GITHUB_OUTPUT
 
       - name: Generate cache keys [npm]
         id: cache-key-npm
-        run: echo "::set-output name=value::cache-npm-${{ hashFiles('package*.json') }}"
+        run: echo "value=cache-npm-${{ hashFiles('package*.json') }}" >> $GITHUB_OUTPUT
 
       - name: Generate cache keys [vue]
         id: cache-key-vue
-        run: echo "::set-output name=value::cache-vue-${{ hashFiles('package*.json') }}-${{ hashFiles('resources/*') }}"
+        run: echo "value=cache-vue-${{ hashFiles('package*.json') }}-${{ hashFiles('resources/*') }}-${{ hashFiles('webpack.mix.js') }}" >> $GITHUB_OUTPUT
 
       - name: Generate cache paths [docker]
         id: cache-path-docker
-        run: echo "::set-output name=value::.docker/images"
+        run: echo "value=.docker/images" >> $GITHUB_OUTPUT
 
       - name: Generate cache paths [composer]
         id: cache-path-composer
-        run: echo "::set-output name=value::vendor"
+        run: echo "value=vendor" >> $GITHUB_OUTPUT
 
       - name: Generate cache paths [npm]
         id: cache-path-npm
-        run: echo "::set-output name=value::node_modules"
+        run: echo "value=node_modules" >> $GITHUB_OUTPUT
 
       - name: Generate cache paths [vue]
         id: cache-path-vue
         run: |
-          VUE_CACHE_PATH=$(cat << EOF
-          public/vue
-          public/mix-manifest.json
-          EOF
-          )
-          VUE_CACHE_PATH="${VUE_CACHE_PATH//'%'/'%25'}"
-          VUE_CACHE_PATH="${VUE_CACHE_PATH//$'\n'/'%0A'}"
-          VUE_CACHE_PATH="${VUE_CACHE_PATH//$'\r'/'%0D'}"
-          echo "::set-output name=value::$VUE_CACHE_PATH"
+          echo "value<<EOF" >> $GITHUB_OUTPUT
+          echo "public/vue" >> $GITHUB_OUTPUT 
+          echo "public/mix-manifest.json" >> $GITHUB_OUTPUT 
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Generate failure content paths for artifact upload
         id: failure-artifact-paths
         run: |
-          FAILURE_UPLOAD_PATHS=$(cat <<EOF
-          storage/app/test/downloads/*.csv
-          storage/logs/*.log
-          tests/Browser/console/*.log
-          tests/Browser/db-dump/*.sql
-          tests/Browser/screenshots/
-          !tests/Browser/screenshots/.gitignore
-          EOF
-          )
-          FAILURE_UPLOAD_PATHS="${FAILURE_UPLOAD_PATHS//'%'/'%25'}"
-          FAILURE_UPLOAD_PATHS="${FAILURE_UPLOAD_PATHS//$'\n'/'%0A'}"
-          FAILURE_UPLOAD_PATHS="${FAILURE_UPLOAD_PATHS//$'\r'/'%0D'}"
-          echo "::set-output name=value::$FAILURE_UPLOAD_PATHS"
+          echo "value<<EOF" >> $GITHUB_OUTPUT
+          echo "storage/app/test/downloads/*.csv" >> $GITHUB_OUTPUT
+          echo "storage/logs/*.log" >> $GITHUB_OUTPUT
+          echo "tests/Browser/console/*.log" >> $GITHUB_OUTPUT
+          echo "tests/Browser/db-dump/*.sql" >> $GITHUB_OUTPUT
+          echo "tests/Browser/screenshots/" >> $GITHUB_OUTPUT
+          echo "!tests/Browser/screenshots/.gitignore" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
     outputs:
       cache-key-docker: ${{ steps.cache-key-docker.outputs.value }}
       cache-key-composer: ${{ steps.cache-key-composer.outputs.value }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Cache Docker images
         id: docker-image-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
@@ -118,7 +118,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
@@ -132,7 +132,7 @@ jobs:
 
       - name: Cache npm packages
         id: npm-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
@@ -143,7 +143,7 @@ jobs:
 
       - name: Cache vue
         id: vue-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -165,21 +165,21 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
@@ -255,28 +255,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -312,28 +312,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -369,28 +369,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -441,28 +441,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -508,28 +508,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -570,28 +570,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -642,28 +642,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -699,28 +699,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -756,28 +756,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -818,28 +818,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Generate cache keys [docker]
         id: cache-key-docker
@@ -101,7 +101,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Docker images
         id: docker-image-cache
@@ -160,7 +160,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -250,7 +250,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -307,7 +307,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -364,7 +364,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -436,7 +436,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -503,7 +503,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -565,7 +565,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -637,7 +637,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -694,7 +694,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -751,7 +751,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -813,7 +813,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # retrieve cache
       - name: Get Cached Docker images


### PR DESCRIPTION
- Updated the github actions `actions/checkout` to _v3_.
- Updated the github actions `actions/cache` to _v3_.
- Updated github actions `tests` workflow to use newer method of setting output values. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands for details.