### PR TITLE
feat/truncate-attachment-name

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -243,7 +243,12 @@ class Entry extends BaseModel {
      * @return bool
      */
     public function has_attachments(): bool {
-        return $this->attachments()->count() > 0;
+        try {
+            return $this->attachments()->count() > 0;
+        } catch (\Exception $e) {
+            error_log($e);
+            return false;
+        }
     }
 
     public function has_tags(): bool {
@@ -259,7 +264,12 @@ class Entry extends BaseModel {
      * @return array
      */
     public function get_tag_ids(): array {
-        $collection_of_tags = $this->tags()->getResults();
+        try {
+            $collection_of_tags = $this->tags()->getResults();
+        } catch (\Exception $e) {
+            error_log($e);
+            return [];
+        }
         if (is_null($collection_of_tags) || $collection_of_tags->isEmpty()) {
             return [];
         } else {

--- a/resources/js/components/home/entry-modal-attachment.vue
+++ b/resources/js/components/home/entry-modal-attachment.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="existing-attachment flex justify-between p-2 mb-2 rounded border-t border-gray-100 shadow-md">
-    <div class="attachment-name p-2" v-text="name"></div>
+    <div class="attachment-name p-2 truncate" v-text="name" v-tooltip="tooltipContent"></div>
     <div class="flex">
       <button class="view-attachment inline-flex justify-center rounded-md border border-gray-300 bg-white px-3 py-2 mr-1.5 opacity-75 hover:opacity-100"
           v-on:click="viewEntryAttachment"
@@ -37,6 +37,16 @@ export default {
     return {
       attachmentObject: new Attachment(),
       entryObject: new Entry(),
+    }
+  },
+  computed: {
+    tooltipContent: function(){
+      return {
+        content: this.name,
+        html: true,
+        placement: 'bottom',
+        classes: 'text-xs font-semibold bg-black py-1.5 px-1 rounded rounded-lg text-white tooltip',
+      }
     }
   },
   methods: {

--- a/tests/Browser/NotificationsTest.php
+++ b/tests/Browser/NotificationsTest.php
@@ -621,7 +621,7 @@ class NotificationsTest extends DuskTestCase {
      * @return string
      */
     private function getTableRecreationQuery(string $table_name): string {
-        $create_query = DB::select("SHOW CREATE TABLE ".$table_name);
+        $create_query = DB::select(sprintf("SHOW CREATE TABLE %s", $table_name));
         return $create_query[0]->{"Create Table"};
     }
 


### PR DESCRIPTION
Truncating attachment name displayed in the entry-modal and hovering over the attachment name will display a tooltip containing the full attachment name.