### PR TITLE
Feat/change-status-code-for-unset-version

### DIFF
--- a/.docker/app.dockerfile
+++ b/.docker/app.dockerfile
@@ -105,7 +105,7 @@ RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
 RUN echo "expose_php = Off" > $PHP_INI_DIR/conf.d/php-expose_php.ini
 RUN echo "allow_url_fopen = Off" > $PHP_INI_DIR/conf.d/php-allow_url_fopen.ini
 # set php error logging
-RUN PHP_ERROR_LOG=$PHP_LOG_DIR/php_errors.log \
+RUN PHP_ERROR_LOG=$PHP_LOG_DIR/errors.log \
   && touch $PHP_ERROR_LOG \
   && chgrp $APACHE_RUN_GROUP $PHP_ERROR_LOG \
   && chmod g+w $PHP_ERROR_LOG
@@ -116,9 +116,5 @@ RUN echo 'date.timezone = "UTC"' > $PHP_INI_DIR/conf.d/php-date.timezone.ini
 # health-check
 COPY .docker/healthcheck/app-health-check.sh /usr/local/bin/app-health-check
 RUN chmod +x /usr/local/bin/app-health-check
-RUN HEALTHCHECK_LOG=$PHP_LOG_DIR/healthcheck.log \
-  && touch $HEALTHCHECK_LOG \
-  && chgrp $APACHE_RUN_GROUP $HEALTHCHECK_LOG \
-  && chmod g+w $HEALTHCHECK_LOG
 HEALTHCHECK --timeout=5s --retries=10 \
   CMD app-health-check

--- a/.docker/healthcheck/app-health-check.sh
+++ b/.docker/healthcheck/app-health-check.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
-echo "[$(date +"%Y-%m-%d %T.%6N %Z")] HEALTHCHECK" >> /var/log/php/healthcheck.log
 http_code=$(curl --silent --write-out '%{http_code}' --output /dev/null http://localhost/api/version)
 
-if [[ $http_code -eq 200 ]]; then
+if [[ $http_code -eq 200 || $http_code -eq 204 ]]; then
   exit 0  # success
 else
   exit 1  # failure

--- a/app/Http/Controllers/Api/VersionController.php
+++ b/app/Http/Controllers/Api/VersionController.php
@@ -3,13 +3,16 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use Symfony\Component\HttpFoundation\Response as HttpStatus;
 
 class VersionController extends Controller {
 
     const CONFIG_VERSION = "app.version";
 
     public function get() {
-        return response(config(self::CONFIG_VERSION));
+        $version = config(self::CONFIG_VERSION);
+        $http_code = empty($version) ? HttpStatus::HTTP_NO_CONTENT : HttpStatus::HTTP_OK;
+        return response($version, $http_code);
     }
 
 }

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -53,3 +53,12 @@ Sometime you will be alerted that you can't clear the cache. This is usually a p
         ```bash
         rm -rf storage/framework/cache/data
         ```
+
+---
+
+### Docker
+
+View docker container healthcheck logs
+```bash
+docker inspect --format "{{json .State.Health }}" <container name> | jq
+```

--- a/tests/Feature/Api/Get/VersionControllerTest.php
+++ b/tests/Feature/Api/Get/VersionControllerTest.php
@@ -12,6 +12,12 @@ class VersionControllerTest extends TestCase {
 
     private string $_base_uri = '/api/version';
 
+    /**
+     * override the RefreshDatabase trait method to prevent the use of said trait in THIS test suite
+     */
+    public function refreshTestDatabase(): void {
+    }
+
     public function testGetVersion() {
         // GIVEN
         $test_version = $this->faker->randomDigit().'.'.$this->faker->randomDigit().'.'.$this->faker->randomDigit().'-test-'.substr($this->faker->sha1(), 0, 7);
@@ -23,6 +29,17 @@ class VersionControllerTest extends TestCase {
         // THEN
         $this->assertResponseStatus($get_response, HttpStatus::HTTP_OK);
         $this->assertEquals($test_version, $get_response->getContent());
+    }
+
+    public function testGetVersionButItHasNotBeenSet() {
+        // GIVEN - version should NOT be set by default
+
+        // WHEN
+        $get_response = $this->get($this->_base_uri);
+
+        // THEN
+        $this->assertResponseStatus($get_response, HttpStatus::HTTP_NO_CONTENT);
+        $this->assertEmpty($get_response->getContent());
     }
 
 }


### PR DESCRIPTION
- If the version is NOT set, then a 204 HTTP Code response is returned. 
- Modified the app-health-check script to:
  - stop logging, essentially nothing, to a file everytime the healthcheck is run.
  - account for the new (204) http status code.
- Added some documentation to the FAQ to show how to view a containers healthcheck logs.