### PR TITLE
Fix/test-long-attachment–name

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -3,6 +3,7 @@
 $finder = PhpCsFixer\Finder::create()
     ->files()
     ->in(__DIR__)
+    ->notPath('_ide_helper.php')
     ->exclude('bootstrap/cache')
     ->exclude('database/snapshots')
     ->exclude('docs')

--- a/app/Traits/Tests/Dusk/Tooltip.php
+++ b/app/Traits/Tests/Dusk/Tooltip.php
@@ -9,61 +9,61 @@ trait Tooltip {
     private static string $SELECTOR_TOOLTIP = '.tooltip';
     private static string $TEMPLATE_SELECTOR_TOOLTIP_ID = '.tooltip#%s';
 
-    protected function assertTooltipMissing(Browser $browser){
-        $browser->elsewhere('', function(Browser $body){
+    protected function assertTooltipMissing(Browser $browser) {
+        $browser->elsewhere('', function(Browser $body) {
             $body->assertMissing(self::$SELECTOR_TOOLTIP);
         });
     }
 
-    protected function assertTooltipVisible(Browser $browser, string $tooltipId=null){
+    protected function assertTooltipVisible(Browser $browser, string $tooltipId=null) {
         $tooltip_selector = $this->getTooltipElementSelector($tooltipId);
-        $browser->elsewhere('', function(Browser $body) use ($tooltip_selector){
+        $browser->elsewhere('', function(Browser $body) use ($tooltip_selector) {
             $body->assertVisible($tooltip_selector);
         });
     }
 
-    protected function assertTooltipVisibleByTriggerElement(Browser $browser, string $triggerElementSelector){
+    protected function assertTooltipVisibleByTriggerElement(Browser $browser, string $triggerElementSelector) {
         $tooltip_id = $this->getTooltipIdFromTriggerElement($browser, $triggerElementSelector);
         $this->assertTooltipVisible($browser, $tooltip_id);
     }
 
-    protected function assertStringInTooltipContents(Browser $browser, string $expectedStringInTooltipContents, string $tooltipId=null){
+    protected function assertStringInTooltipContents(Browser $browser, string $expectedStringInTooltipContents, string $tooltipId=null) {
         $tooltip_selector = $this->getTooltipElementSelector($tooltipId);
-        $browser->elsewhere('', function(Browser $body) use ($tooltip_selector, $expectedStringInTooltipContents){
+        $browser->elsewhere('', function(Browser $body) use ($tooltip_selector, $expectedStringInTooltipContents) {
             $body
                 ->assertVisible($tooltip_selector)
                 ->assertSeeIn($tooltip_selector, $expectedStringInTooltipContents);
         });
     }
 
-    protected function assertStringInTooltipContentsByTriggerElement(Browser $browser, string $expectedStringInTooltipContents, string $triggerElementSelector){
+    protected function assertStringInTooltipContentsByTriggerElement(Browser $browser, string $expectedStringInTooltipContents, string $triggerElementSelector) {
         $tooltip_id = $this->getTooltipIdFromTriggerElement($browser, $triggerElementSelector);
         $this->assertStringInTooltipContents($browser, $expectedStringInTooltipContents, $tooltip_id);
     }
 
-    protected function assertStringNotInTooltipContents(Browser $browser, string $expectedStringNotInTooltipContents, string $tooltipId=null){
+    protected function assertStringNotInTooltipContents(Browser $browser, string $expectedStringNotInTooltipContents, string $tooltipId=null) {
         $tooltip_selector = $this->getTooltipElementSelector($tooltipId);
-        $browser->elsewhere('', function(Browser $body) use ($tooltip_selector, $expectedStringNotInTooltipContents){
+        $browser->elsewhere('', function(Browser $body) use ($tooltip_selector, $expectedStringNotInTooltipContents) {
             $body
                 ->assertVisible($tooltip_selector)
                 ->assertDontSeeIn($tooltip_selector, $expectedStringNotInTooltipContents);
         });
     }
 
-    protected function assertStringNotInTooltipContentsByTriggerElement(Browser $browser, string $expectedStringNotInTooltipContents, string $triggerElementSelector){
+    protected function assertStringNotInTooltipContentsByTriggerElement(Browser $browser, string $expectedStringNotInTooltipContents, string $triggerElementSelector) {
         $tooltip_id = $this->getTooltipIdFromTriggerElement($browser, $triggerElementSelector);
         $this->assertStringNotInTooltipContents($browser, $expectedStringNotInTooltipContents, $tooltip_id);
     }
 
-    protected function interactWithElementToTriggerTooltip(Browser $browser, string $triggerElementSelector) : void {
+    protected function interactWithElementToTriggerTooltip(Browser $browser, string $triggerElementSelector): void {
         $browser->mouseover($triggerElementSelector);
     }
 
-    private function getTooltipIdFromTriggerElement(Browser $browser, string $triggerElementSelector) : string{
+    private function getTooltipIdFromTriggerElement(Browser $browser, string $triggerElementSelector): string {
         return $browser->element($triggerElementSelector)->getAttribute('aria-describedby');
     }
 
-    private function getTooltipElementSelector(string $tooltipId=null): string{
+    private function getTooltipElementSelector(string $tooltipId=null): string {
         return is_null($tooltipId) ? self::$SELECTOR_TOOLTIP : sprintf(self::$TEMPLATE_SELECTOR_TOOLTIP_ID, $tooltipId);
     }
 

--- a/app/Traits/Tests/Dusk/Tooltip.php
+++ b/app/Traits/Tests/Dusk/Tooltip.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Traits\Tests\Dusk;
+
+use Laravel\Dusk\Browser;
+
+trait Tooltip {
+
+    private static string $SELECTOR_TOOLTIP = '.tooltip';
+    private static string $TEMPLATE_SELECTOR_TOOLTIP_ID = '.tooltip#%s';
+
+    protected function assertTooltipMissing(Browser $browser){
+        $browser->elsewhere('', function(Browser $body){
+            $body->assertMissing(self::$SELECTOR_TOOLTIP);
+        });
+    }
+
+    protected function assertTooltipVisible(Browser $browser, string $tooltipId=null){
+        $tooltip_selector = $this->getTooltipElementSelector($tooltipId);
+        $browser->elsewhere('', function(Browser $body) use ($tooltip_selector){
+            $body->assertVisible($tooltip_selector);
+        });
+    }
+
+    protected function assertTooltipVisibleByTriggerElement(Browser $browser, string $triggerElementSelector){
+        $tooltip_id = $this->getTooltipIdFromTriggerElement($browser, $triggerElementSelector);
+        $this->assertTooltipVisible($browser, $tooltip_id);
+    }
+
+    protected function assertStringInTooltipContents(Browser $browser, string $expectedStringInTooltipContents, string $tooltipId=null){
+        $tooltip_selector = $this->getTooltipElementSelector($tooltipId);
+        $browser->elsewhere('', function(Browser $body) use ($tooltip_selector, $expectedStringInTooltipContents){
+            $body
+                ->assertVisible($tooltip_selector)
+                ->assertSeeIn($tooltip_selector, $expectedStringInTooltipContents);
+        });
+    }
+
+    protected function assertStringInTooltipContentsByTriggerElement(Browser $browser, string $expectedStringInTooltipContents, string $triggerElementSelector){
+        $tooltip_id = $this->getTooltipIdFromTriggerElement($browser, $triggerElementSelector);
+        $this->assertStringInTooltipContents($browser, $expectedStringInTooltipContents, $tooltip_id);
+    }
+
+    protected function assertStringNotInTooltipContents(Browser $browser, string $expectedStringNotInTooltipContents, string $tooltipId=null){
+        $tooltip_selector = $this->getTooltipElementSelector($tooltipId);
+        $browser->elsewhere('', function(Browser $body) use ($tooltip_selector, $expectedStringNotInTooltipContents){
+            $body
+                ->assertVisible($tooltip_selector)
+                ->assertDontSeeIn($tooltip_selector, $expectedStringNotInTooltipContents);
+        });
+    }
+
+    protected function assertStringNotInTooltipContentsByTriggerElement(Browser $browser, string $expectedStringNotInTooltipContents, string $triggerElementSelector){
+        $tooltip_id = $this->getTooltipIdFromTriggerElement($browser, $triggerElementSelector);
+        $this->assertStringNotInTooltipContents($browser, $expectedStringNotInTooltipContents, $tooltip_id);
+    }
+
+    protected function interactWithElementToTriggerTooltip(Browser $browser, string $triggerElementSelector) : void {
+        $browser->mouseover($triggerElementSelector);
+    }
+
+    private function getTooltipIdFromTriggerElement(Browser $browser, string $triggerElementSelector) : string{
+        return $browser->element($triggerElementSelector)->getAttribute('aria-describedby');
+    }
+
+    private function getTooltipElementSelector(string $tooltipId=null): string{
+        return is_null($tooltipId) ? self::$SELECTOR_TOOLTIP : sprintf(self::$TEMPLATE_SELECTOR_TOOLTIP_ID, $tooltipId);
+    }
+
+}

--- a/app/Traits/Tests/TruncateDatabaseTables.php
+++ b/app/Traits/Tests/TruncateDatabaseTables.php
@@ -9,7 +9,7 @@ trait TruncateDatabaseTables {
     /**
      * Truncates all database tables related to this connection, except for the "migrations" table
      * @link http://stackoverflow.com/a/18910102/4152012
-     * Allow truncating tables with forenign keys
+     * Allow truncating tables with foreign keys
      * @link https://stackoverflow.com/a/5452798/4152012
      */
     private function truncateDatabaseTables(array $ignore_tables=[]) {

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
             "php artisan ide-helper:meta",
             "php artisan ide-helper:eloquent"
         ],
-        "lint:php": "vendor/bin/php-cs-fixer fix --dry-run --verbose --diff",
+        "lint:php": "vendor/bin/php-cs-fixer fix --dry-run --verbose --diff --stop-on-violation",
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -1274,7 +1274,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
      *
      * @group entry-modal-2
      */
-    public function testLongAttachmentNameIsTruncatedAndHoveringOverAttachmentNameShowsTooltip(){
+    public function testLongAttachmentNameIsTruncatedAndHoveringOverAttachmentNameShowsTooltip() {
         $account_type_id = AccountType::all()->pluck('id')->random();
         $entry = Entry::factory()->create([
             'entry_date'=>Carbon::today()->format('Y-m-d'),

--- a/tests/Browser/InstitutionsPanelTest.php
+++ b/tests/Browser/InstitutionsPanelTest.php
@@ -5,6 +5,7 @@ namespace Tests\Browser;
 use App\Models\Account;
 use App\Models\Institution;
 use App\Traits\Tests\Dusk\Loading as DuskTraitLoading;
+use App\Traits\Tests\Dusk\Tooltip as DuskTraitTooltip;
 use App\Traits\Tests\WaitTimes;
 use Facebook\WebDriver\WebDriverBy;
 use Illuminate\Support\Collection;
@@ -27,6 +28,7 @@ class InstitutionsPanelTest extends DuskTestCase {
     use WaitTimes;
     use HomePageSelectors;
     use DuskTraitLoading;
+    use DuskTraitTooltip;
 
     /**
      * @throws Throwable
@@ -251,28 +253,21 @@ class InstitutionsPanelTest extends DuskTestCase {
         $this->assertAccountNodeName($account_node, $account_name);
 
         // hover over account element
-        $account_node->mouseover('');
+        $this->interactWithElementToTriggerTooltip($account_node, '');
 
         if ($has_tooltip) {
             // account-types tooltip appears to right
-            $account_node_tooltip_id = $account_node->attribute('', 'aria-describedby');    // get the tooltip element id
-            $account_node
-                ->pause(self::$WAIT_HALF_SECOND_IN_MILLISECONDS)
-                ->assertVisible('#'.$account_node_tooltip_id);
-            $account_types_tooltip_text = $account_node->text('#'.$account_node_tooltip_id);
+            $this->assertTooltipVisibleByTriggerElement($account_node, '');
             foreach ($account_types_collection as $account_account_type) {
                 $account_type_record_tooltip_text = $account_account_type['name']." (".$account_account_type['last_digits'].")";
                 if ($account_account_type['disabled']) {
-                    $this->assertStringNotContainsString($account_type_record_tooltip_text, $account_types_tooltip_text);
+                    $this->assertStringNotInTooltipContentsByTriggerElement($account_node, $account_type_record_tooltip_text, '');
                 } else {
-                    $this->assertStringContainsString($account_type_record_tooltip_text, $account_types_tooltip_text);
+                    $this->assertStringInTooltipContentsByTriggerElement($account_node, $account_type_record_tooltip_text, '');
                 }
             }
         } else {
-            $account_css_prefix = $account_node->resolver->prefix;
-            $account_node->resolver->prefix = '';
-            $account_node->assertMissing('body .tooltip');
-            $account_node->resolver->prefix = $account_css_prefix;
+            $this->assertTooltipMissing($account_node);
         }
     }
 


### PR DESCRIPTION
- Added test to check if a long attachment name is truncated in the UI.
- Created a trait to aid in testing tooltips.