### PR TITLE
Feat/remove-accounts-disabled-columns

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Generate cache keys [docker]
         id: cache-key-docker
-        run: echo "value=cache-docker-${{ hashFiles('docker-compose.yml', '.docker/*') }}" >> $GITHUB_OUTPUT
+        run: echo "value=cache-docker-${{ hashFiles('docker-compose.yml', '.docker/**') }}" >> $GITHUB_OUTPUT
 
       - name: Generate cache keys [composer]
         id: cache-key-composer
@@ -39,7 +39,7 @@ jobs:
 
       - name: Generate cache keys [vue]
         id: cache-key-vue
-        run: echo "value=cache-vue-${{ hashFiles('package*.json', 'resources/*', 'tailwind.config.js', 'webpack.mix.js') }}" >> $GITHUB_OUTPUT
+        run: echo "value=cache-vue-${{ hashFiles('package*.json', 'resources/**', 'tailwind.config.js', 'webpack.mix.js') }}" >> $GITHUB_OUTPUT
 
       - name: Generate cache paths [docker]
         id: cache-path-docker

--- a/app/Http/Controllers/Api/AccountController.php
+++ b/app/Http/Controllers/Api/AccountController.php
@@ -9,6 +9,7 @@ use App\Models\Institution;
 use App\Traits\AccountResponseKeys;
 use Brick\Money\ISOCurrencyProvider;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Symfony\Component\HttpFoundation\Response as HttpStatus;
 
 class AccountController extends Controller {
@@ -16,17 +17,16 @@ class AccountController extends Controller {
 
     /**
      * GET /api/accounts
-     * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
      */
-    public function get_accounts() {
+    public function get_accounts(): Response {
         $accounts = Account::cache()->get(Account::CACHE_KEY_ALL);
         if (is_null($accounts) || $accounts->isEmpty()) {
             return response([], HttpStatus::HTTP_NOT_FOUND);
         } else {
             $accounts->makeHidden([
-                'create_stamp',
-                'modified_stamp',
-                'disabled_stamp'
+                Account::CREATED_AT,
+                Account::DELETED_AT,
+                Account::UPDATED_AT,
             ]);
             $accounts = $accounts->toArray();
             $accounts['count'] = Account::cache()->get(Account::CACHE_KEY_COUNT);
@@ -37,14 +37,10 @@ class AccountController extends Controller {
 
     /**
      * GET /api/account/{account_id}
-     * @param int $account_id
-     * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
      */
-    public function get_account(int $account_id) {
-        $account = Account::find_account_with_types($account_id);
-        if (is_null($account)) {
-            return response([], HttpStatus::HTTP_NOT_FOUND);
-        } else {
+    public function get_account(int $account_id): Response {
+        try {
+            $account = Account::withTrashed()->with('account_types')->findOrFail($account_id);
             $account->account_types->makeHidden([
                 'account_id',    // We already know what account this is. We don't need to re-show it.
                 AccountType::CREATED_AT,
@@ -52,29 +48,53 @@ class AccountController extends Controller {
                 'disabled_stamp',
             ]);
             return response($account, HttpStatus::HTTP_OK);
+        } catch (\Exception $e) {
+            return response([], HttpStatus::HTTP_NOT_FOUND);
         }
     }
 
     /**
      * POST /api/account
-     * @param Request $request
-     * @return \Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\Routing\ResponseFactory|\Illuminate\Http\Response
      */
-    public function create_account(Request $request) {
+    public function create_account(Request $request): Response {
         return $this->modify_account($request);
     }
 
     /**
-     * PUT /api/account/{account_id}
-     * @param Request $request
-     * @param int $account_id
-     * @return \Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\Routing\ResponseFactory|\Illuminate\Http\Response
+     * DELETE /api/account/{accountId}
      */
-    public function update_account(Request $request, int $account_id) {
+    public function disableAccount(int $accountId): Response {
+        try {
+            $account_to_disable = Account::findOrFail($accountId);
+            $account_to_disable->delete();
+            return response('', HttpStatus::HTTP_NO_CONTENT);
+        } catch (\Exception $e) {
+            return response('', HttpStatus::HTTP_NOT_FOUND);
+        }
+    }
+
+    /**
+     * PATCH /api/account/{accountId}
+     */
+    public function reactivateAccount(int $accountId): Response {
+        try {
+            $account_to_reactivate = Account::onlyTrashed()->where('id', $accountId)->firstOrFail();
+        } catch (\Exception $e) {
+            return response('', HttpStatus::HTTP_NOT_FOUND);
+        }
+
+        $account_to_reactivate->restore();
+        return response('', HttpStatus::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * PUT /api/account/{account_id}
+     */
+    public function update_account(Request $request, int $account_id): Response {
         return $this->modify_account($request, $account_id);
     }
 
-    public function modify_account(Request $request, int $account_id=null) {
+    public function modify_account(Request $request, int $account_id=null): Response {
         $request_body = $request->getContent();
         $account_data = json_decode($request_body, true);
 
@@ -124,7 +144,7 @@ class AccountController extends Controller {
             try {
                 // check to make sure account exists. if it doesn't then we can't update it
                 $account_to_modify = Account::findOrFail($account_id);
-            } catch(\Exception $exception) {
+            } catch(\Exception $e) {
                 return response(
                     [self::$RESPONSE_KEY_ID=>self::$ERROR_ID, self::$RESPONSE_KEY_ERROR=>self::$ERROR_MSG_DOES_NOT_EXIST],
                     HttpStatus::HTTP_NOT_FOUND

--- a/app/Http/Controllers/Api/AccountController.php
+++ b/app/Http/Controllers/Api/AccountController.php
@@ -19,7 +19,7 @@ class AccountController extends Controller {
      * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
      */
     public function get_accounts() {
-        $accounts = Account::cache()->get('all');
+        $accounts = Account::cache()->get(Account::CACHE_KEY_ALL);
         if (is_null($accounts) || $accounts->isEmpty()) {
             return response([], HttpStatus::HTTP_NOT_FOUND);
         } else {
@@ -29,7 +29,7 @@ class AccountController extends Controller {
                 'disabled_stamp'
             ]);
             $accounts = $accounts->toArray();
-            $accounts['count'] = Account::cache()->get('count');
+            $accounts['count'] = Account::cache()->get(Account::CACHE_KEY_COUNT);
 
             return response($accounts, HttpStatus::HTTP_OK);
         }

--- a/app/Http/Controllers/Api/InstitutionController.php
+++ b/app/Http/Controllers/Api/InstitutionController.php
@@ -41,14 +41,16 @@ class InstitutionController extends Controller {
     public function get_institution(int $institution_id): Response {
         try {
             $institution = Institution::withTrashed()
-                ->with(Account::getTableName())
+                ->with(Account::getTableName(), function($account) {
+                    return $account->withTrashed();
+                })
                 ->findOrFail($institution_id);
 
             $institution->accounts->makeHidden([
                 'institution_id',    // We already know what institution ID this is. We don't need to re-show it.
-                'create_stamp',
-                'modified_stamp',
-                'disabled_stamp'
+                Account::CREATED_AT,
+                Account::DELETED_AT,
+                Account::UPDATED_AT,
             ]);
             return response($institution, HttpStatus::HTTP_OK);
         } catch (Exception $e) {

--- a/app/Jobs/AdjustAccountTotalUsingAccountType.php
+++ b/app/Jobs/AdjustAccountTotalUsingAccountType.php
@@ -22,7 +22,7 @@ class AdjustAccountTotalUsingAccountType implements ShouldQueue {
      */
     public function __construct($accountTypeId, $rawEntryValue, $isExpense, $addToAccount) {
         $account_type = AccountType::find($accountTypeId);
-        $this->account = $account_type->account;
+        $this->account = $account_type->account()->withTrashed()->first();
         $this->rawValue = $rawEntryValue;
         $this->isExpense = $isExpense;
         $this->addToAccount = $addToAccount;

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -12,6 +12,9 @@ class Account extends BaseModel {
     use HasFactory;
     use LaraCache;
 
+    const CACHE_KEY_ALL = 'all';
+    const CACHE_KEY_COUNT = 'count';
+
     const CREATED_AT = 'create_stamp';
     const UPDATED_AT = 'modified_stamp';
 
@@ -89,10 +92,10 @@ class Account extends BaseModel {
 
     public static function cacheEntities(): array {
         return [
-            CacheEntity::make('all')->forever()->cache(function() {
+            CacheEntity::make(self::CACHE_KEY_ALL)->forever()->cache(function() {
                 return Account::all();
             }),
-            CacheEntity::make('count')->forever()->cache(function() {
+            CacheEntity::make(self::CACHE_KEY_COUNT)->forever()->cache(function() {
                 return Account::count();
             })
         ];

--- a/app/Models/Institution.php
+++ b/app/Models/Institution.php
@@ -34,7 +34,7 @@ class Institution extends BaseModel {
     ];
 
     public function accounts() {
-        return $this->hasMany('App\Models\Account', 'institution_id');
+        return $this->hasMany(Account::class, 'institution_id');
     }
 
     public function getActiveAttribute() {

--- a/app/Traits/Tests/Dusk/AccountOrAccountTypeTogglingSelector.php
+++ b/app/Traits/Tests/Dusk/AccountOrAccountTypeTogglingSelector.php
@@ -97,7 +97,7 @@ trait AccountOrAccountTypeTogglingSelector {
                     ->assertSelectHasOption(self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT, "")
                     ->assertSelectHasOptions(
                         self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT,
-                        collect($accounts)->where('disabled', false)->pluck('id')->toArray()
+                        collect($accounts)->where('active', true)->pluck('id')->toArray()
                     );
 
                 // disable checkbox

--- a/app/Traits/Tests/Dusk/AccountOrAccountTypeTogglingSelector.php
+++ b/app/Traits/Tests/Dusk/AccountOrAccountTypeTogglingSelector.php
@@ -102,7 +102,7 @@ trait AccountOrAccountTypeTogglingSelector {
 
                 // disable checkbox
                 $component->assertMissing($this->getCheckboxShowDisabledAccountOrAccountType($this->_account_or_account_type_toggling_selector_id_label));
-                if (collect($accounts)->where('disabled', true)->count() > 0) {
+                if (collect($accounts)->where('active', false)->count() > 0) {
                     $component->assertVisible($this->getLabelSelectorLabelShowDisabledAccountsOrAccountTypes());
                 } else {
                     $component->assertMissing($this->getLabelSelectorLabelShowDisabledAccountsOrAccountTypes());

--- a/app/Traits/Tests/Dusk/AccountOrAccountTypeTogglingSelector.php
+++ b/app/Traits/Tests/Dusk/AccountOrAccountTypeTogglingSelector.php
@@ -143,13 +143,9 @@ trait AccountOrAccountTypeTogglingSelector {
         });
     }
 
-    /**
-     * @param Browser $browser
-     * @param string|int $selector_value
-     * @throws Exception
-     */
-    public function selectAccountOrAccountTypeValue(Browser $browser, $selector_value) {
+    public function selectAccountOrAccountTypeValue(Browser $browser, ?int $selector_value) {
         $this->assertAccountOrAccountTypeTogglingSelectorIdLabelBeenSet();
+        $selector_value = $selector_value ?? '';
         $browser->within($this->getAccountOrAccountTypeTogglingSelectorComponentId($this->_account_or_account_type_toggling_selector_id_label), function(Browser $component) use ($selector_value) {
             // make sure accounts have finished loading
             $this->waitUntilSelectLoadingIsMissing($component, self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT);

--- a/app/Traits/Tests/Dusk/BatchFilterEntries.php
+++ b/app/Traits/Tests/Dusk/BatchFilterEntries.php
@@ -22,13 +22,7 @@ trait BatchFilterEntries {
         return $filter_data;
     }
 
-    /**
-     * @param array $filter_data
-     * @param bool $is_account_switch_toggled
-     * @param int|null $account_or_account_type_id
-     * @return mixed
-     */
-    private function generateFilterArrayElementAccountOrAccountypeId(array $filter_data, bool $is_account_switch_toggled, $account_or_account_type_id): array {
+    private function generateFilterArrayElementAccountOrAccountypeId(array $filter_data, bool $is_account_switch_toggled, ?int $account_or_account_type_id): array {
         if (!empty($account_or_account_type_id)) {
             if ($is_account_switch_toggled) {
                 $filter_data[self::$FILTER_KEY_ACCOUNT_TYPE] = $account_or_account_type_id;
@@ -39,12 +33,7 @@ trait BatchFilterEntries {
         return $filter_data;
     }
 
-    /**
-     * @param array $filter_data
-     * @param bool $is_expense
-     * @return array
-     */
-    private function generateFilterArrayElementExpense(array $filter_data, $is_expense): array {
+    private function generateFilterArrayElementExpense(array $filter_data, bool $is_expense): array {
         $filter_data[self::$FILTER_KEY_EXPENSE] = $is_expense;
         return $filter_data;
     }

--- a/app/Traits/Tests/Dusk/FilterModal.php
+++ b/app/Traits/Tests/Dusk/FilterModal.php
@@ -90,7 +90,7 @@ trait FilterModal {
                 $this->selectAccountOrAccountTypeValue($modal, $filter_value['id']);
 
                 if ($is_account) {
-                    $account = Account::find_account_with_types($filter_value['id']);
+                    $account = Account::with('account_types')->find($filter_value['id']);
                     $filter_value = $account->account_types->pluck('name')->toArray();
                 } else {
                     $filter_value = $filter_value['name'];

--- a/app/Traits/Tests/Dusk/FilterModal.php
+++ b/app/Traits/Tests/Dusk/FilterModal.php
@@ -81,12 +81,13 @@ trait FilterModal {
                 if ($is_account) {
                     // account
                     $filter_values = $this->getApiAccounts();
+                    $filter_value = collect($filter_values)->where('active', true)->random();
                 } else {
                     // account-type
                     $this->toggleAccountOrAccountTypeSwitch($modal);
                     $filter_values = $this->getApiAccountTypes();
+                    $filter_value = collect($filter_values)->where('disabled', false)->random();
                 }
-                $filter_value = collect($filter_values)->where('disabled', false)->random();
                 $this->selectAccountOrAccountTypeValue($modal, $filter_value['id']);
 
                 if ($is_account) {

--- a/database/factories/AccountFactory.php
+++ b/database/factories/AccountFactory.php
@@ -10,16 +10,24 @@ class AccountFactory extends Factory {
 
     public function definition(): array {
         fake()->addProvider(new ProjectCurrencyCodeProvider(fake()));
-        $account_name = fake()->company().' account';
-        $disabled = fake()->boolean();
         return [
-            'name'=>$account_name,         // this is supposed to be a bank account name
+            'name'=>fake()->company().' account',    // this is supposed to be a bank account name
             'institution_id'=>fake()->randomNumber(FactoryConstants::MAX_RAND_ID_LENGTH, true),
-            'disabled'=>$disabled,
             'currency'=>fake()->currencyCode(),
-            'total'=>fake()->randomFloat(FactoryConstants::CURRENCY_MAX_DECIMAL, -1000, 1000),   // -1000.00 < total < 1000.00
-            'disabled_stamp'=>$disabled ? fake()->date(FactoryConstants::DATE_FORMAT) : null
+            'total'=>fake()->randomFloat(FactoryConstants::CURRENCY_MAX_DECIMAL, -1000, 1000),    // -1000.00 < total < 1000.00
+            'disabled_stamp'=>null
         ];
+    }
+
+    /**
+     * Indicate that an account is "disabled"
+     */
+    public function disabled(): Factory {
+        return $this->state(function() {
+            return [
+                'disabled_stamp'=>fake()->date(FactoryConstants::DATE_FORMAT)
+            ];
+        });
     }
 
 }

--- a/database/factories/InstitutionFactory.php
+++ b/database/factories/InstitutionFactory.php
@@ -20,7 +20,7 @@ class InstitutionFactory extends Factory {
     public function disabled(): Factory {
         return $this->state(function() {
             return [
-                'disabled_stamp'=>$this->faker->date(FactoryConstants::DATE_FORMAT)
+                'disabled_stamp'=>fake()->date(FactoryConstants::DATE_FORMAT)
             ];
         });
     }

--- a/database/migrations/2023_06_12_060207_drop_disabled_column_from_accounts_table.php
+++ b/database/migrations/2023_06_12_060207_drop_disabled_column_from_accounts_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+
+    private static string $TABLE = 'accounts';
+    private static string $DROP_COLUMN = 'disabled';
+    private static string $COLUMN_DISABLED_STAMP = 'disabled_stamp';
+
+    /**
+     * Run the migrations.
+     */
+    public function up() {
+        DB::table(self::$TABLE)->where(self::$DROP_COLUMN, 1)->update([self::$COLUMN_DISABLED_STAMP=>DB::raw("modified_stamp")]);
+        DB::table(self::$TABLE)->where(self::$DROP_COLUMN, 0)->update([self::$COLUMN_DISABLED_STAMP=>null]);
+        Schema::table(self::$TABLE, function(Blueprint $table) {
+            $table->dropColumn(self::$DROP_COLUMN);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down() {
+        Schema::table(self::$TABLE, function(Blueprint $table) {
+            $table->unsignedTinyInteger(self::$DROP_COLUMN)->after('institution_id')->default(0);
+        });
+        DB::table(self::$TABLE)->whereNotNull(self::$COLUMN_DISABLED_STAMP)->update([self::$DROP_COLUMN=>1]);
+        DB::table(self::$TABLE)->whereNull(self::$COLUMN_DISABLED_STAMP)->update([self::$DROP_COLUMN=>0]);
+    }
+
+};

--- a/database/migrations/2023_06_12_142828_delete_trigger_accounts_creation_timestamp.php
+++ b/database/migrations/2023_06_12_142828_delete_trigger_accounts_creation_timestamp.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Reverse of 2017_07_02_224104_create_trigger_accounts_creation_timestamp.php
+ */
+return new class extends Migration {
+
+    private static string $TRIGGER = 'trigger_accounts_creation_timestamp';
+
+    /**
+     * Run the migrations.
+     */
+    public function up() {
+        DB::unprepared("DROP TRIGGER IF EXISTS " . self::$TRIGGER);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down() {
+        DB::unprepared(
+            "CREATE TRIGGER " . self::$TRIGGER . "
+            BEFORE INSERT ON accounts
+            FOR EACH ROW
+            SET NEW.create_stamp = NOW()"
+        );
+    }
+
+};

--- a/database/migrations/2023_06_12_152002_modify_accounts_table_timestamp_defaults_and_updates.php
+++ b/database/migrations/2023_06_12_152002_modify_accounts_table_timestamp_defaults_and_updates.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration {
+
+    private static string $TABLE = 'accounts';
+    private static string $COLUMN_TIMESTAMP_CREATE = 'create_stamp';
+    private static string $COLUMN_TIMESTAMP_MODIFY = 'modified_stamp';
+
+    /**
+     * Run the migrations.
+     */
+    public function up() {
+        // laravel currently can not handle table schema updates using an ORM approach
+        $update_create_stamp_column_query = "ALTER TABLE %s CHANGE %s %s TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;";
+        DB::statement(sprintf($update_create_stamp_column_query, self::$TABLE, self::$COLUMN_TIMESTAMP_CREATE, self::$COLUMN_TIMESTAMP_CREATE));
+
+        $update_modify_stamp_column_query = "ALTER TABLE %s CHANGE %s %s TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;";
+        DB::statement(sprintf($update_modify_stamp_column_query, self::$TABLE, self::$COLUMN_TIMESTAMP_MODIFY, self::$COLUMN_TIMESTAMP_MODIFY));
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down() {
+        // laravel currently can not handle table schema updates using an ORM approach
+        $update_create_stamp_column_query = "ALTER TABLE %s CHANGE %s %s TIMESTAMP NULL DEFAULT NULL;";
+        DB::statement(sprintf($update_create_stamp_column_query, self::$TABLE, self::$COLUMN_TIMESTAMP_CREATE, self::$COLUMN_TIMESTAMP_CREATE));
+
+        $update_modify_stamp_column_query = "ALTER TABLE %s CHANGE %s %s TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;";
+        DB::statement(sprintf($update_modify_stamp_column_query, self::$TABLE, self::$COLUMN_TIMESTAMP_MODIFY, self::$COLUMN_TIMESTAMP_MODIFY));
+    }
+
+};

--- a/database/seeders/UiSampleDatabaseSeeder.php
+++ b/database/seeders/UiSampleDatabaseSeeder.php
@@ -51,9 +51,9 @@ class UiSampleDatabaseSeeder extends Seeder {
         // ***** ACCOUNTS *****
         $accounts = collect();
         foreach ($institutions as $institution) {
-            $accounts = $this->addAccountToCollection($accounts, ['institution_id'=>$institution->id, 'disabled'=>false]);
+            $accounts = $this->addAccountToCollection($accounts, ['institution_id'=>$institution->id]);
         }
-        $accounts = $this->addAccountToCollection($accounts, ['institution_id'=>$institutions->random()->id, 'disabled'=>true]);
+        $accounts = $this->addAccountToCollection($accounts, ['institution_id'=>$institutions->random()->id, Account::DELETED_AT=>now()]);
         $currencies = CurrencyHelper::fetchCurrencies();
         foreach ($currencies as $currency) {
             $accounts = $this->addAccountToCollection($accounts, ['institution_id'=>$institutions->random()->id, 'currency'=>$currency->code]);
@@ -65,8 +65,8 @@ class UiSampleDatabaseSeeder extends Seeder {
         foreach ($accounts->pluck('id') as $account_id) {
             $account_types = $this->addAccountTypeToCollection($account_types, ['account_id'=>$account_id, 'disabled'=>false]);
         }
-        $account_types = $this->addAccountTypeToCollection($account_types, ['account_id'=>$accounts->where('disabled', false)->pluck('id')->random(), 'disabled'=>true]);
-        $account_types = $this->addAccountTypeToCollection($account_types, ['account_id'=>$accounts->where('disabled', true)->pluck('id')->random(), 'disabled'=>true]);
+        $account_types = $this->addAccountTypeToCollection($account_types, ['account_id'=>$accounts->where('active', true)->pluck('id')->random(), 'disabled'=>true]);
+        $account_types = $this->addAccountTypeToCollection($account_types, ['account_id'=>$accounts->where('active', false)->pluck('id')->random(), 'disabled'=>true]);
         $this->command->line(self::CLI_OUTPUT_PREFIX."Account-types seeded [".$account_types->count()."]");
 
         // ***** ENTRIES *****

--- a/resources/js/account-types.js
+++ b/resources/js/account-types.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import {Accounts} from "./accounts";
 import {ObjectBaseClass} from "./objectBaseClass";
 import {SnotifyStyle} from "vue-snotify";
@@ -76,5 +77,14 @@ export class AccountTypes extends ObjectBaseClass {
     } else {
       return "";  // couldn't find the account_type.name associated with the provided ID
     }
+  }
+
+  get retrieve(){
+    // TODO: remove when account-types.disabled has been removed
+    let accountTypes = _.cloneDeep(super.retrieve)
+    accountTypes.map(function(accountType){
+      return accountType.active = !accountType.disabled
+    })
+    return accountTypes;
   }
 }

--- a/resources/js/account-types.js
+++ b/resources/js/account-types.js
@@ -37,7 +37,7 @@ export class AccountTypes extends ObjectBaseClass {
 
   get retrieveTypes(){
     this.storeType = this.apiStoreTypes.types;
-    let types = this.retrieve;
+    let types = super.retrieve;
     this.storeType = this.apiStoreTypes.default;
     return types;
   }

--- a/resources/js/account.js
+++ b/resources/js/account.js
@@ -61,7 +61,7 @@ export class Account extends ObjectBaseClass {
   axiosSuccess(response){
     switch(response.config.method.toUpperCase()){
       case 'DELETE':
-        return {type: SnotifyStyle.success, message: "Account was disabled"};
+        return {type: SnotifyStyle.success, message: "Account has been disabled"};
       case 'GET':
         this.assign = this.processSuccessfulResponseData(response.data);
         return {fetched: true, notification: {}};

--- a/resources/js/account.js
+++ b/resources/js/account.js
@@ -28,6 +28,18 @@ export class Account extends ObjectBaseClass {
     }
   }
 
+  disable(accountId){
+    return Axios.delete(this.uri+accountId)
+      .then(this.axiosSuccess)
+      .catch(this.axiosFailure);
+  }
+
+  enable(accountId){
+    return Axios.patch(this.uri+accountId)
+      .then(this.axiosSuccess)
+      .catch(this.axiosFailure);
+  }
+
   fetch(accountId){
     return Axios.get(this.uri+accountId)
       .then(this.axiosSuccess.bind(this)) // NOTE: _DO NOT_ remove the ".bind(this)". Will not work without.
@@ -48,17 +60,19 @@ export class Account extends ObjectBaseClass {
 
   axiosSuccess(response){
     switch(response.config.method.toUpperCase()){
+      case 'DELETE':
+        return {type: SnotifyStyle.success, message: "Account was disabled"};
       case 'GET':
         this.assign = this.processSuccessfulResponseData(response.data);
         return {fetched: true, notification: {}};
+      case 'PATCH':
+        return {type: SnotifyStyle.success, message: "Account has been reactivated"};
       case "POST":
         return {type: SnotifyStyle.success, message: "New account created"};
       case "PUT":
         return {type: SnotifyStyle.success, message: "Account updated"};
-      // case "DELETE":
-      //   return {deleted: true, notification: {type: SnotifyStyle.success, message: "Account was deleted"}}
       default:
-        // do nothing
+        return {};
     }
   }
 
@@ -85,18 +99,22 @@ export class Account extends ObjectBaseClass {
     }
   }
 
-  // axiosFailure(error){
-  //     if(error.response){
-  //         switch(error.response.status){
-  //             case 404:
-  //                 this.assign = [];
-  //                 return {type: SnotifyStyle.info, message: "No accounts currently available"};
-  //             case 500:
-  //             default:
-  //                 return {type: SnotifyStyle.error, message: "An error occurred while attempting to retrieve accounts"};
-  //         }
-  //     }
-  // }
+  axiosFailure(error){
+    if(error.response){
+      switch(error.response.config.method.toUpperCase()){
+        case 'GET':
+          switch(error.response.status){
+            case 404:
+              return {fetched: false, notification: {type: SnotifyStyle.info, message: "Account not found"}};
+            case 500:
+            default:
+              return {fetched: false, notification: {type: SnotifyStyle.error, message: "An error occurred while attempting to retrieve an account"}};
+          }
+        default:
+          return {};
+      }
+    }
+  }
 
   // getInstitution(accountId){
   //     accountId = parseInt(accountId);

--- a/resources/js/app-settings.js
+++ b/resources/js/app-settings.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import Store from './store';
 
 import Snotify from 'vue-snotify';
-Vue.use(Snotify, {toast: {timeout: 8000}});    // 8 seconds
+Vue.use(Snotify, {toast: {timeout: 10000}});    // 10 seconds
 
 // import VTooltip from 'v-tooltip';
 // Vue.use(VTooltip);

--- a/resources/js/components/account-account-type-toggling-selector.vue
+++ b/resources/js/components/account-account-type-toggling-selector.vue
@@ -112,7 +112,7 @@ export default {
       return !_.isEmpty(this.listAccountOrAccountTypes)
         && this.listAccountOrAccountTypes
           .filter(function(accountOrAccountTypeObject){
-            return !accountOrAccountTypeObject.active  // FIXME: this breaks "account-type" displays
+            return !accountOrAccountTypeObject.active
           }).length > 0;
     },
 
@@ -161,7 +161,7 @@ export default {
     processListOfObjects: function(listOfObjects, canShowDisabled=true){
       if(!canShowDisabled){
         listOfObjects = listOfObjects.filter(function(object){
-          return object.active;  // FIXME: this breaks "account-type" displays
+          return object.active;
         });
       }
       return _.orderBy(listOfObjects, 'name');

--- a/resources/js/components/account-account-type-toggling-selector.vue
+++ b/resources/js/components/account-account-type-toggling-selector.vue
@@ -112,7 +112,7 @@ export default {
       return !_.isEmpty(this.listAccountOrAccountTypes)
         && this.listAccountOrAccountTypes
           .filter(function(accountOrAccountTypeObject){
-            return accountOrAccountTypeObject.disabled
+            return !accountOrAccountTypeObject.active  // FIXME: this breaks "account-type" displays
           }).length > 0;
     },
 
@@ -161,7 +161,7 @@ export default {
     processListOfObjects: function(listOfObjects, canShowDisabled=true){
       if(!canShowDisabled){
         listOfObjects = listOfObjects.filter(function(object){
-          return !object.disabled;
+          return object.active;  // FIXME: this breaks "account-type" displays
         });
       }
       return _.orderBy(listOfObjects, 'name');

--- a/resources/js/components/home/entry-modal.vue
+++ b/resources/js/components/home/entry-modal.vue
@@ -532,7 +532,7 @@ export default {
       this.accountTypeMeta.accountName = account.name;
       let accountType = this.accountTypesObject.find(this.entryData.account_type_id);
       this.accountTypeMeta.lastDigits = accountType.last_digits;
-      this.accountTypeMeta.isEnabled = !accountType.disabled && !account.disabled;
+      this.accountTypeMeta.isEnabled = !accountType.disabled && account.active;
 
       this.accountTypeMeta.currencyHtml = this.currencyObject.getHtmlFromCode(account.currency);
     },

--- a/resources/js/components/home/filter-modal.vue
+++ b/resources/js/components/home/filter-modal.vue
@@ -136,7 +136,7 @@
         <div class="col-span-3 relative text-gray-700">
           <input id="filter-min-value" name="filter-min-value" type="text" placeholder="999.99" autocomplete="off" class="placeholder-gray-400 placeholder-opacity-80 rounded w-full pl-6 filter-modal-element"
               v-model="filterData.minValue"
-              v-on:change="decimaliseValue('minValue')"
+              v-on:change="decimaliseFilterValue('minValue')"
           />
           <span class="currency-symbol absolute left-3 inset-y-2 mt-px text-gray-400 font-medium" v-html="accountCurrencyHtml" ></span>
         </div>
@@ -146,7 +146,7 @@
         <div class="col-span-3 relative text-gray-700">
           <input id="filter-max-value" name="filter-max-value" type="text" placeholder="999.99" autocomplete="off" class="placeholder-gray-400 placeholder-opacity-80 rounded w-full pl-6 filter-modal-element"
               v-model="filterData.maxValue"
-              v-on:change="decimaliseValue('maxValue')"
+              v-on:change="decimaliseFilterValue('maxValue')"
           />
           <span class="currency-symbol absolute left-3 inset-y-2 mt-px text-gray-400 font-medium" v-html="accountCurrencyHtml" ></span>
         </div>
@@ -193,6 +193,8 @@
 <script lang="js">
 // utilities
 import _ from 'lodash';
+import {SnotifyStyle} from "vue-snotify";
+import axios from "axios";
 import Store from '../../store';
 // mixins
 import {accountsObjectMixin} from "../../mixins/accounts-object-mixin";
@@ -202,12 +204,10 @@ import {tagsObjectMixin} from "../../mixins/tags-object-mixin";
 import {tailwindColorsMixin} from "../../mixins/tailwind-colors-mixin";
 // objects
 import {Currency} from "../../currency";
-// conponents
+// components
 import AccountAccountTypeTogglingSelector from "../account-account-type-toggling-selector";
 import TagsInput from '../tags-input';
 import ToggleButton from '../toggle-button';
-import {SnotifyStyle} from "vue-snotify";
-import axios from "axios";
 
 export default {
   name: "filter-modal",
@@ -290,11 +290,8 @@ export default {
       this.setModalState(Store.getters.STORE_MODAL_NONE);
       this.isVisible = false;
     },
-    decimaliseValue: function(valueField){
-      if(!_.isEmpty(this.filterData[valueField])){
-        let cleanedValue = this.filterData[valueField].replace(/[^0-9.]/g, '');
-        this.filterData[valueField] = parseFloat(cleanedValue).toFixed(2);
-      }
+    decimaliseFilterValue: function(valueField){
+      this.filterData[valueField] = this.decimaliseValue(this.filterData[valueField])
     },
     exportData: function(){
       this.$eventHub.broadcast(this.$eventHub.EVENT_NOTIFICATION, {type: SnotifyStyle.info, message: "Export Process started"});

--- a/resources/js/components/home/institutions-panel.vue
+++ b/resources/js/components/home/institutions-panel.vue
@@ -83,7 +83,7 @@ export default {
     },
     inactiveAccounts: function(){
       return this.rawAccountsData.filter(function(account){
-        return account.disabled;
+        return !account.active;
       }).sort(function(a, b){
         if (a.name < b.name)
           return -1;

--- a/resources/js/components/home/transfer-modal.vue
+++ b/resources/js/components/home/transfer-modal.vue
@@ -381,7 +381,7 @@ export default {
       this.accountTypeMeta[accountTypeSelect].accountName = account.name;
       let accountType = this.accountTypesObject.find(this.transferData[accountTypeSelect+'_account_type_id']);
       this.accountTypeMeta[accountTypeSelect].lastDigits = accountType.last_digits;
-      this.accountTypeMeta[accountTypeSelect].isEnabled = !account.disabled && !accountType.disabled;
+      this.accountTypeMeta[accountTypeSelect].isEnabled = account.active && !accountType.disabled;
     },
   },
   created: function(){

--- a/resources/js/components/settings/settings-institutions.vue
+++ b/resources/js/components/settings/settings-institutions.vue
@@ -122,7 +122,7 @@ export default {
     resetFormAfterActiveStateToggle(institutionId){
       // this is called AFTER toggle-state has been updated
       let institutionData = {}
-      if(_.isNull(this.form.id)){
+      if(_.isNull(institutionId)){
         institutionData = _.clone(this.defaultFormData)
       } else {
         institutionData = _.clone(this.institutionObject.find(institutionId));
@@ -139,7 +139,8 @@ export default {
           this.fillForm(institutionData);
           this.$eventHub.broadcast(this.$eventHub.EVENT_LOADING_HIDE);
         } else {
-          this.institutionObject.fetch(institutionId)
+          this.institutionObject
+            .fetch(institutionId)
             .then(function(fetchResult){
               if(fetchResult.fetched){
                 let freshlyFetchedInstitutionData = this.institutionsObject.find(institutionId);
@@ -163,7 +164,8 @@ export default {
         this.setFormDefaults();
       }
     },
-    sanitiseData(data){
+    sanitiseData(originalData){
+      let data = _.clone(originalData)
       Object.keys(data).forEach(function(k){
         switch(k){
           case 'create_stamp':

--- a/resources/js/mixins/accounts-object-mixin.js
+++ b/resources/js/mixins/accounts-object-mixin.js
@@ -12,6 +12,9 @@ export const accountsObjectMixin = {
     areAccountsAvailable: function(){
       return !_.isEmpty(this.rawAccountsData);
     },
+    listAccounts: function(){
+      return _.orderBy(this.rawAccountsData, ['active', 'name'], ['desc', 'asc']);
+    },
   },
 
   methods: {

--- a/resources/js/mixins/decimalise-input-mixin.js
+++ b/resources/js/mixins/decimalise-input-mixin.js
@@ -5,7 +5,7 @@ export const decimaliseInputMixin = {
   methods: {
     decimaliseValue: function(inputValue){
       if(!_.isEmpty(inputValue)){
-        let sanitisedValue = inputValue.replace(/[^0-9.]/g, '');
+        let sanitisedValue = inputValue.replace(/[^\d.-]/g, '');
         return parseFloat(sanitisedValue).toFixed(2);
       } else {
         return '';

--- a/routes/api.php
+++ b/routes/api.php
@@ -54,6 +54,20 @@ Route::controller(InstitutionController::class)->group(function() {
     });
 });
 
+Route::controller(AccountController::class)->group(function() {
+    // /api/accounts
+    Route::get('accounts', 'get_accounts')->name('accounts');
+
+    // /api/account/{?}
+    Route::prefix('account/')->name('account.')->group(function() {
+        Route::delete('{accountId}', 'disableAccount')->name('delete');
+        Route::get('{account_id}', 'get_account')->name('get');
+        Route::patch('{accountId}', 'reactivateAccount')->name('patch');
+        Route::post('', 'create_account')->name('post');
+        Route::put('{account_id}', 'update_account')->name('put');
+    });
+});
+
 // GET /api/tags
 Route::get('tags', [TagController::class, 'get_tags'])
     ->name('tags');
@@ -63,19 +77,6 @@ Route::post('tag', [TagController::class, 'createTag'])
 // PUT /api/tag/{tag_id}
 Route::put('tag/{tag_id}', [TagController::class, 'updateTag'])
     ->name('tag.put');
-
-// GET /api/accounts
-Route::get('accounts', [AccountController::class, 'get_accounts'])
-    ->name('accounts');
-// GET /api/account/{account_id}
-Route::get('account/{account_id}', [AccountController::class, 'get_account'])
-    ->name('account.get');
-// POST /api/account
-Route::post('account', [AccountController::class, 'create_account'])
-    ->name('account.post');
-// PUT /api/account/{account_id}
-Route::put('account/{account_id}', [AccountController::class, 'update_account'])
-    ->name('account.put');
 
 // GET /api/account-types
 Route::get('account-types', [AccountTypeController::class, 'list_account_types'])

--- a/tests/Browser/EntryModalNewEntryTest.php
+++ b/tests/Browser/EntryModalNewEntryTest.php
@@ -347,7 +347,7 @@ class EntryModalNewEntryTest extends DuskTestCase {
         $account_types = AccountType::all();
         $disabled_account_type = [];
         if ($account_type_method == $this->method_account) {
-            $disabled_account = Account::where('disabled', true)->get()->random();
+            $disabled_account = Account::onlyTrashed()->get()->random();
             $disabled_account_type = $account_types->where('account_id', $disabled_account['id'])->random();
         } elseif ($account_type_method == $this->method_account_type) {
             $disabled_account_type = $account_types->where('disabled', true)->random();

--- a/tests/Browser/FilterModalTest.php
+++ b/tests/Browser/FilterModalTest.php
@@ -341,15 +341,15 @@ class FilterModalTest extends DuskTestCase {
         $institutions = $this->getApiInstitutions();
         $institution_id = collect($institutions)->pluck('id')->random(1)->first();
 
-        Account::factory()->count(3)->create(['disabled'=>0, 'institution_id'=>$institution_id]);
+        Account::factory()->count(3)->create(['institution_id'=>$institution_id]);
         if ($has_disabled_account) {
-            Account::factory()->count(1)->create(['disabled'=>1, 'institution_id'=>$institution_id]);
+            Account::factory()->count(1)->disabled()->create(['institution_id'=>$institution_id]);
         }
         $accounts = $this->getApiAccounts();
 
-        AccountType::factory()->count(3)->create(['disabled'=>0, 'account_id'=>collect($accounts)->pluck('id')->random(1)->first()]);
+        AccountType::factory()->count(3)->create(['account_id'=>collect($accounts)->pluck('id')->random(1)->first()]);
         if ($has_disabled_account_type) {
-            AccountType::factory()->count(1)->create(['disabled'=>1, 'account_id'=>collect($accounts)->pluck('id')->random(1)->first()]);
+            AccountType::factory()->count(1)->disabled()->create(['account_id'=>collect($accounts)->pluck('id')->random(1)->first()]);
         }
         $account_types = $this->getApiAccountTypes();
 
@@ -376,7 +376,7 @@ class FilterModalTest extends DuskTestCase {
                     $this->assertValueFieldCurrency($modal, $this->_selector_modal_filter_field_max_value, $this->_default_currency_character);
 
                     // select an account and confirm the name in the select changes
-                    $account_to_select = collect($accounts)->where('disabled', 0)->random();
+                    $account_to_select = collect($accounts)->where('active', true)->random();
                     $this->selectAccountOrAccountTypeValue($modal, $account_to_select['id']);
                     $modal->assertSeeIn(self::$SELECTOR_FIELD_ACCOUNT_AND_ACCOUNT_TYPE_SELECT, $account_to_select['name']);
 
@@ -425,7 +425,7 @@ class FilterModalTest extends DuskTestCase {
         });
     }
 
-    private function assertValueFieldCurrency(Browser $modal, string $selector, string $currency_symbol) {
+    private function assertValueFieldCurrency(Browser $modal, string $selector, string $currency_symbol): void {
         $value_currency = $modal->text($selector." + span.currency-symbol");
         $this->assertStringContainsString($currency_symbol, $value_currency);
     }
@@ -443,9 +443,6 @@ class FilterModalTest extends DuskTestCase {
 
     /**
      * @dataProvider providerFlipSwitch
-     * @param string $switch_selector
-     *
-     * @throws Throwable
      *
      * @group filter-modal-1
      * test (see provider)/20
@@ -473,9 +470,6 @@ class FilterModalTest extends DuskTestCase {
 
     /**
      * @dataProvider providerRangeValueConvertsIntoDecimalOfTwoPlaces
-     * @param $field_selector
-     *
-     * @throws Throwable
      *
      * @group filter-modal-1
      * test (see provider)/20
@@ -506,10 +500,6 @@ class FilterModalTest extends DuskTestCase {
 
     /**
      * @dataProvider providerFlippingCompanionSwitches
-     * @param string $init_switch_selector
-     * @param string $companion_switch_selector
-     *
-     * @throws Throwable
      *
      * @group filter-modal-2
      * test (see provider)/20
@@ -630,7 +620,7 @@ class FilterModalTest extends DuskTestCase {
                 // modify all (or at least most) fields
                 ->within($this->_selector_modal_filter.' '.$this->_selector_modal_body, function(Browser $modal) use (&$filter_value) {
                     $accounts = $this->getApiAccounts();
-                    $filter_value = collect($accounts)->where('disabled', 0)->random();
+                    $filter_value = collect($accounts)->where('active', true)->random();
                     $this->selectAccountOrAccountTypeValue($modal, $filter_value['id']);
                 })
 

--- a/tests/Browser/FilterModalTest.php
+++ b/tests/Browser/FilterModalTest.php
@@ -54,8 +54,6 @@ class FilterModalTest extends DuskTestCase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group filter-modal-1
      * test 1/20
      */
@@ -74,8 +72,6 @@ class FilterModalTest extends DuskTestCase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group filter-modal-1
      * test 2/20
      */
@@ -197,8 +193,6 @@ class FilterModalTest extends DuskTestCase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group filter-modal-1
      * test 3/20
      */
@@ -221,8 +215,6 @@ class FilterModalTest extends DuskTestCase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group filter-modal-1
      * test 4/20
      */
@@ -242,8 +234,6 @@ class FilterModalTest extends DuskTestCase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group filter-modal-1
      * test 5/20
      */
@@ -261,8 +251,6 @@ class FilterModalTest extends DuskTestCase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group filter-modal-1
      * test 6/20
      */
@@ -280,8 +268,6 @@ class FilterModalTest extends DuskTestCase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group filter-modal-1
      * test 7/20
      */
@@ -298,8 +284,6 @@ class FilterModalTest extends DuskTestCase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group filter-modal-1
      * test 8/20
      */
@@ -326,10 +310,6 @@ class FilterModalTest extends DuskTestCase {
 
     /**
      * @dataProvider providerFlipAccountAndAccountTypeSwitch
-     * @param boolean $has_disabled_account
-     * @param boolean $has_disabled_account_type
-     *
-     * @throws Throwable
      *
      * @group filter-modal-1
      * test (see provider)/20
@@ -347,9 +327,9 @@ class FilterModalTest extends DuskTestCase {
         }
         $accounts = $this->getApiAccounts();
 
-        AccountType::factory()->count(3)->create(['account_id'=>collect($accounts)->pluck('id')->random(1)->first()]);
+        AccountType::factory()->count(3)->create(['disabled'=>false, 'account_id'=>collect($accounts)->pluck('id')->random(1)->first()]);
         if ($has_disabled_account_type) {
-            AccountType::factory()->count(1)->disabled()->create(['account_id'=>collect($accounts)->pluck('id')->random(1)->first()]);
+            AccountType::factory()->count(1)->create(['disabled'=>true, 'account_id'=>collect($accounts)->pluck('id')->random(1)->first()]);
         }
         $account_types = $this->getApiAccountTypes();
 
@@ -526,8 +506,6 @@ class FilterModalTest extends DuskTestCase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group filter-modal-2
      * test 5/20
      */
@@ -605,8 +583,6 @@ class FilterModalTest extends DuskTestCase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group filter-modal-2
      * test 6/20
      */

--- a/tests/Browser/SettingsAccountTypesTest.php
+++ b/tests/Browser/SettingsAccountTypesTest.php
@@ -257,7 +257,7 @@ class SettingsAccountTypesTest extends SettingsBase {
                 } while ($node->name == $name || $account_types->contains('name', $name));
                 $section
                     ->clear($selector)
-                    ->type($selector, fake()->word());
+                    ->type($selector, $name);
                 break;
             case self::$SELECTOR_SETTINGS_FORM_SELECT_TYPE:
                 do {

--- a/tests/Browser/SettingsAccountTypesTest.php
+++ b/tests/Browser/SettingsAccountTypesTest.php
@@ -138,19 +138,19 @@ class SettingsAccountTypesTest extends SettingsBase {
         $this->assertSaveButtonDefault($section);
     }
 
-    protected function assertFormWithExistingData(Browser $section, BaseModel $node) {
-        $this->assertObjectIsOfType($node, AccountType::class);
+    protected function assertFormWithExistingData(Browser $section, BaseModel $object) {
+        $this->assertObjectIsOfType($object, AccountType::class);
 
         $section
             ->scrollIntoView(self::$SELECTOR_SETTINGS_HEADER)
 
-            ->assertInputValue(self::$SELECTOR_SETTINGS_FORM_INPUT_NAME, $node->name)
+            ->assertInputValue(self::$SELECTOR_SETTINGS_FORM_INPUT_NAME, $object->name)
             ->waitUntilMissing(self::$SELECTOR_SETTINGS_FORM_LOADING_TYPE, self::$WAIT_SECONDS)
-            ->assertSelected(self::$SELECTOR_SETTINGS_FORM_SELECT_TYPE, $node->type)
-            ->assertInputValue(self::$SELECTOR_SETTINGS_FORM_INPUT_LAST_DIGITS, $node->last_digits)
+            ->assertSelected(self::$SELECTOR_SETTINGS_FORM_SELECT_TYPE, $object->type)
+            ->assertInputValue(self::$SELECTOR_SETTINGS_FORM_INPUT_LAST_DIGITS, $object->last_digits)
             ->waitUntilMissing(self::$SELECTOR_SETTINGS_FORM_LOADING_ACCOUNT, self::$WAIT_SECONDS)
-            ->assertSelected(self::$SELECTOR_SETTINGS_FORM_SELECT_ACCOUNT, $node->account_id);
-        if ($node->disabled) {
+            ->assertSelected(self::$SELECTOR_SETTINGS_FORM_SELECT_ACCOUNT, $object->account_id);
+        if ($object->disabled) {
             $this->assertActiveStateToggleInactive($section, self::$SELECTOR_SETTINGS_FORM_TOGGLE_ACTIVE);
         } else {
             $this->assertActiveStateToggleActive($section, self::$SELECTOR_SETTINGS_FORM_TOGGLE_ACTIVE);
@@ -158,14 +158,14 @@ class SettingsAccountTypesTest extends SettingsBase {
 
         $section
             ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_LABEL_CREATED, self::$LABEL_SETTINGS_LABEL_CREATED)
-            ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_CREATED, $this->convertDateToECMA262Format($node->create_stamp))
+            ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_CREATED, $this->convertDateToECMA262Format($object->create_stamp))
             ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_LABEL_MODIFIED, self::$LABEL_SETTINGS_LABEL_MODIFIED)
-            ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_MODIFIED, $this->convertDateToECMA262Format($node->modified_stamp))
+            ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_MODIFIED, $this->convertDateToECMA262Format($object->modified_stamp))
             ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_LABEL_DISABLED, self::$LABEL_SETTINGS_LABEL_DISABLED);
-        if (is_null($node->disabled_stamp)) {
+        if (is_null($object->disabled_stamp)) {
             $section->assertMissing(self::$SELECTOR_SETTINGS_FORM_DISABLED);
         } else {
-            $section->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_DISABLED, $this->convertDateToECMA262Format($node->disabled_stamp));
+            $section->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_DISABLED, $this->convertDateToECMA262Format($object->disabled_stamp));
         }
 
         $this->assertSaveButtonDisabled($section);

--- a/tests/Browser/SettingsAccountsTest.php
+++ b/tests/Browser/SettingsAccountsTest.php
@@ -168,18 +168,18 @@ class SettingsAccountsTest extends SettingsBase {
         $this->assertSaveButtonDefault($section);
     }
 
-    protected function assertFormWithExistingData(Browser $section, BaseModel $node) {
-        $this->assertObjectIsOfType($node, Account::class);
-        $currency = CurrencyHelper::fetchCurrencies()->where('code', $node->currency)->first();
+    protected function assertFormWithExistingData(Browser $section, BaseModel $object) {
+        $this->assertObjectIsOfType($object, Account::class);
+        $currency = CurrencyHelper::fetchCurrencies()->where('code', $object->currency)->first();
         $section
-            ->assertInputValue(self::$SELECTOR_SETTINGS_FORM_INPUT_NAME, $node->name)
+            ->assertInputValue(self::$SELECTOR_SETTINGS_FORM_INPUT_NAME, $object->name)
             ->waitUntilMissing(self::$SELECTOR_SETTINGS_FORM_LOADING_INSTITUTION, self::$WAIT_SECONDS)
-            ->assertSelected(self::$SELECTOR_SETTINGS_FORM_SELECT_INSTITUTION, $node->institution_id)
+            ->assertSelected(self::$SELECTOR_SETTINGS_FORM_SELECT_INSTITUTION, $object->institution_id)
             ->assertRadioSelected(sprintf(self::$TEMPLATE_SELECTOR_SETTINGS_FORM_RADIO_CURRENCY_INPUT, $currency->label), $currency->code)
-            ->assertInputValue(self::$SELECTOR_SETTINGS_FORM_INPUT_TOTAL, $node->total)
+            ->assertInputValue(self::$SELECTOR_SETTINGS_FORM_INPUT_TOTAL, $object->total)
             ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_CURRENCY_TOTAL, CurrencyHelper::convertCurrencyHtmlToCharacter($currency->html));
-        ;
-        if ($node->disabled) {
+
+        if ($object->disabled) {
             $this->assertActiveStateToggleInactive($section, self::$SELECTOR_SETTINGS_FORM_TOGGLE_ACTIVE);
         } else {
             $this->assertActiveStateToggleActive($section, self::$SELECTOR_SETTINGS_FORM_TOGGLE_ACTIVE);
@@ -187,15 +187,15 @@ class SettingsAccountsTest extends SettingsBase {
 
         $section
             ->assertVisible(self::$SELECTOR_SETTINGS_FORM_LABEL_CREATED)
-            ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_CREATED, $this->convertDateToECMA262Format($node->create_stamp))
+            ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_CREATED, $this->convertDateToECMA262Format($object->create_stamp))
             ->assertVisible(self::$SELECTOR_SETTINGS_FORM_LABEL_MODIFIED)
-            ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_MODIFIED, $this->convertDateToECMA262Format($node->modified_stamp))
+            ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_MODIFIED, $this->convertDateToECMA262Format($object->modified_stamp))
             ->assertVisible(self::$SELECTOR_SETTINGS_FORM_LABEL_DISABLED);
 
-        if (is_null($node->disabled_stamp)) {
+        if (is_null($object->disabled_stamp)) {
             $section->assertMissing(self::$SELECTOR_SETTINGS_FORM_DISABLED);
         } else {
-            $section->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_DISABLED, $this->convertDateToECMA262Format($node->disabled_stamp));
+            $section->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_DISABLED, $this->convertDateToECMA262Format($object->disabled_stamp));
         }
 
         $this->assertSaveButtonDisabled($section);

--- a/tests/Browser/SettingsAccountsTest.php
+++ b/tests/Browser/SettingsAccountsTest.php
@@ -249,13 +249,8 @@ class SettingsAccountsTest extends SettingsBase {
             ->assertInputValueIsNot(self::$SELECTOR_SETTINGS_FORM_INPUT_TOTAL, '')
             ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_CURRENCY_TOTAL, CurrencyHelper::convertCurrencyHtmlToCharacter($currency->html));
 
-        $is_account_active = fake()->boolean();
-        if (!$is_account_active) {
-            $this->interactWithFormElement($section, self::$SELECTOR_SETTINGS_FORM_TOGGLE_ACTIVE);
-            $this->assertActiveStateToggleInactive($section, self::$SELECTOR_SETTINGS_FORM_TOGGLE_ACTIVE);
-        } else {
-            $this->assertActiveStateToggleActive($section, self::$SELECTOR_SETTINGS_FORM_TOGGLE_ACTIVE);
-        }
+        // don't interact with the "active" toggle button
+        // doing so would clear the form
     }
 
     protected function generateObject(bool $isInitObjectActive): BaseModel {

--- a/tests/Browser/SettingsAccountsTest.php
+++ b/tests/Browser/SettingsAccountsTest.php
@@ -35,8 +35,8 @@ class SettingsAccountsTest extends SettingsBase {
     private static string $SELECTOR_SETTINGS_FORM_LABEL_TOTAL = "label[for='settings-account-total']:nth-child(7)";
     private static string $SELECTOR_SETTINGS_FORM_INPUT_TOTAL = 'div:nth-child(8) input#settings-account-total';
     private static string $SELECTOR_SETTINGS_FORM_CURRENCY_TOTAL = 'div:nth-child(8) input#settings-account-total+span';
-    private static string $SELECTOR_SETTINGS_FORM_LABEL_ACTIVE = "label[for='settings-account-disabled']:nth-child(9)";
-    protected static string $SELECTOR_SETTINGS_FORM_TOGGLE_ACTIVE = "div:nth-child(10) #settings-account-disabled";
+    private static string $SELECTOR_SETTINGS_FORM_LABEL_ACTIVE = "label[for='settings-account-active']:nth-child(9)";
+    protected static string $SELECTOR_SETTINGS_FORM_TOGGLE_ACTIVE = "div:nth-child(10) #settings-account-active";
     private static string $SELECTOR_SETTINGS_FORM_LABEL_CREATED = "div:nth-child(11)";
     private static string $SELECTOR_SETTINGS_FORM_CREATED = "div:nth-child(12)";
     private static string $SELECTOR_SETTINGS_FORM_LABEL_MODIFIED = "div:nth-child(13)";
@@ -51,8 +51,8 @@ class SettingsAccountsTest extends SettingsBase {
 
     protected static string $LABEL_SETTINGS_NOTIFICATION_NEW = 'New account created';
     protected static string $LABEL_SETTINGS_NOTIFICATION_UPDATE = 'Account updated';
-    protected static string $LABEL_SETTINGS_NOTIFICATION_RESTORE = 'Account has been enabled';  // TODO: confirm
-    protected static string $LABEL_SETTINGS_NOTIFICATION_DELETE = 'Account has been disabled';  // TODO: confirm
+    protected static string $LABEL_SETTINGS_NOTIFICATION_RESTORE = 'Account has been enabled';
+    protected static string $LABEL_SETTINGS_NOTIFICATION_DELETE = 'Account has been disabled';
 
     private Currency $default_currency;
     private string $color_currency_active;

--- a/tests/Browser/SettingsAccountsTest.php
+++ b/tests/Browser/SettingsAccountsTest.php
@@ -70,16 +70,18 @@ class SettingsAccountsTest extends SettingsBase {
     }
 
     public function providerDisablingOrRestoringAccount(): array {
-        return [];
+        return [
+            'disabling account'=>['isInitAccountActive'=>true],     // test 7/20
+            'restoring account'=>['isInitAccountActive'=>false],    // test 8/20
+        ];
     }
 
     public function providerSaveExistingSettingNode(): array {
         return [
-            'name'=>[self::$SELECTOR_SETTINGS_FORM_INPUT_NAME],                         // test 7/20
-            'institution'=>[self::$SELECTOR_SETTINGS_FORM_SELECT_INSTITUTION],          // test 8/20
-            'currency'=>[self::$TEMPLATE_SELECTOR_SETTINGS_FORM_RADIO_CURRENCY_INPUT],  // test 9/20
-            'total'=>[self::$SELECTOR_SETTINGS_FORM_INPUT_TOTAL],                       // test 10/20
-            'active'=>[self::$SELECTOR_SETTINGS_FORM_TOGGLE_ACTIVE],                    // test 11/20
+            'name'=>[self::$SELECTOR_SETTINGS_FORM_INPUT_NAME],                         // test 9/20
+            'institution'=>[self::$SELECTOR_SETTINGS_FORM_SELECT_INSTITUTION],          // test 10/20
+            'currency'=>[self::$TEMPLATE_SELECTOR_SETTINGS_FORM_RADIO_CURRENCY_INPUT],  // test 11/20
+            'total'=>[self::$SELECTOR_SETTINGS_FORM_INPUT_TOTAL],                       // test 12/20
         ];
     }
 

--- a/tests/Browser/SettingsAccountsTest.php
+++ b/tests/Browser/SettingsAccountsTest.php
@@ -271,7 +271,7 @@ class SettingsAccountsTest extends SettingsBase {
     }
 
     protected function getAllObjects(): Collection {
-        return Account::all();
+        return Account::withTrashed()->get();
     }
 
     protected function interactWithObjectListItem(Browser $section, BaseModel $node, bool $is_fresh_load=true) {

--- a/tests/Browser/SettingsAccountsTest.php
+++ b/tests/Browser/SettingsAccountsTest.php
@@ -202,7 +202,7 @@ class SettingsAccountsTest extends SettingsBase {
     }
 
     protected function assertNodesVisible(Browser $section) {
-        $accounts = Account::all();
+        $accounts = Account::withTrashed()->get();
         $this->assertCount($accounts->count(), $section->elements('hr~ul li'));
         foreach ($accounts as $account) {
             $selector_account_id = sprintf(self::$TEMPLATE_SELECTOR_SETTINGS_NODE_ID, $account->id);
@@ -212,12 +212,12 @@ class SettingsAccountsTest extends SettingsBase {
             $class_is_disabled = 'is-disabled';
             $class_is_active = 'is-active';
             $account_node_classes = $section->attribute($selector_account_id, 'class');
-            if ($account->disabled) {
-                $this->assertStringContainsString($class_is_disabled, $account_node_classes);
-                $this->assertStringNotContainsString($class_is_active, $account_node_classes);
-            } else {
+            if ($account->active) {
                 $this->assertStringContainsString($class_is_active, $account_node_classes);
                 $this->assertStringNotContainsString($class_is_disabled, $account_node_classes);
+            } else {
+                $this->assertStringContainsString($class_is_disabled, $account_node_classes);
+                $this->assertStringNotContainsString($class_is_active, $account_node_classes);
             }
         }
     }

--- a/tests/Browser/SettingsBase.php
+++ b/tests/Browser/SettingsBase.php
@@ -167,15 +167,15 @@ abstract class SettingsBase extends DuskTestCase {
                 $settings_display->within(static::$SELECTOR_SETTINGS_DISPLAY_SECTION, function(Browser $section) {
                     $section->waitUntilMissing(static::$SELECTOR_SETTINGS_LOADING_OBJECTS, self::$WAIT_SECONDS);
 
-                    $node = $this->getObject();
-                    $this->interactWithObjectListItem($section, $node);
-                    $this->assertFormWithExistingData($section, $node);
+                    $object = $this->getObject();
+                    $this->interactWithObjectListItem($section, $object);
+                    $this->assertFormWithExistingData($section, $object);
 
                     $this->clickClearButton($section);
                     $this->assertFormDefaults($section);
 
-                    $this->interactWithObjectListItem($section, $node, false);
-                    $this->assertFormWithExistingData($section, $node);
+                    $this->interactWithObjectListItem($section, $object, false);
+                    $this->assertFormWithExistingData($section, $object);
                 });
             });
         });
@@ -330,7 +330,7 @@ abstract class SettingsBase extends DuskTestCase {
 
     abstract protected function assertFormDefaultsFull(Browser $section);
 
-    abstract protected function assertFormWithExistingData(Browser $section, BaseModel $node);
+    abstract protected function assertFormWithExistingData(Browser $section, BaseModel $object);
 
     abstract protected function assertNodesVisible(Browser $section);
 

--- a/tests/Browser/SettingsBase.php
+++ b/tests/Browser/SettingsBase.php
@@ -220,11 +220,11 @@ abstract class SettingsBase extends DuskTestCase {
                     $this->assertFormDefaults($section);
                     $section->waitUntilMissing(static::$SELECTOR_SETTINGS_LOADING_OBJECTS, self::$WAIT_SECONDS);
 
-                    $node = $this->getObject();
-                    $this->interactWithObjectListItem($section, $node);
-                    $this->assertFormWithExistingData($section, $node);
+                    $object = $this->getObject();
+                    $this->interactWithObjectListItem($section, $object);
+                    $this->assertFormWithExistingData($section, $object);
 
-                    $this->interactWithFormElement($section, $form_element, $node);
+                    $this->interactWithFormElement($section, $form_element, $object);
 
                     $this->assertSaveButtonEnabled($section);
                     $this->clickSaveButton($section);
@@ -236,9 +236,9 @@ abstract class SettingsBase extends DuskTestCase {
                     });
                     $this->assertFormDefaults($section);
 
-                    $node = $this->getObject($node->id);    // get updated data
-                    $this->interactWithObjectListItem($section, $node);
-                    $this->assertFormWithExistingData($section, $node);
+                    $object = $this->getObject($object->id);    // get updated data
+                    $this->interactWithObjectListItem($section, $object);
+                    $this->assertFormWithExistingData($section, $object);
                 });
             });
         });

--- a/tests/Browser/SettingsBase.php
+++ b/tests/Browser/SettingsBase.php
@@ -13,7 +13,6 @@ use Illuminate\Database\Eloquent\Collection;
 use Laravel\Dusk\Browser;
 use Tests\Browser\Pages\SettingsPage;
 use Tests\DuskWithMigrationsTestCase as DuskTestCase;
-use Throwable;
 
 abstract class SettingsBase extends DuskTestCase {
     use DuskTraitToggleButton;
@@ -69,8 +68,6 @@ abstract class SettingsBase extends DuskTestCase {
     // ------------ ------------ ------------
 
     /**
-     * @throws Throwable
-     *
      * test 1/20
      */
     public function testDefaultSettingsPageState() {
@@ -94,8 +91,6 @@ abstract class SettingsBase extends DuskTestCase {
     }
 
     /**
-     * @throws Throwable
-     *
      * test 2/20
      */
     public function testNavigateToSpecificSettingsAndAssertForm() {
@@ -113,8 +108,6 @@ abstract class SettingsBase extends DuskTestCase {
     }
 
     /**
-     * @throws Throwable
-     *
      * test 3/20
      */
     public function testObjectsListedUnderFormAreVisible() {
@@ -132,8 +125,6 @@ abstract class SettingsBase extends DuskTestCase {
     }
 
     /**
-     * @throws Throwable
-     *
      * test 4/20
      */
     public function testFormFieldInteractionAndClearButtonFunctionality() {
@@ -154,8 +145,6 @@ abstract class SettingsBase extends DuskTestCase {
     }
 
     /**
-     * @throws Throwable
-     *
      * test 5/20
      */
     public function testClickExistingNodeWillDisplayDataInFormThenClearFormAndReclickSameNode() {
@@ -182,8 +171,6 @@ abstract class SettingsBase extends DuskTestCase {
     }
 
     /**
-     * @throws Throwable
-     *
      * test 6/20
      */
     public function testSaveNewSettingObject() {
@@ -193,7 +180,7 @@ abstract class SettingsBase extends DuskTestCase {
             $browser->within(self::$SELECTOR_SETTINGS_DISPLAY, function(Browser $settings_display) {
                 $this->assertSettingsSectionDisplayed($settings_display);
                 $settings_display->within(static::$SELECTOR_SETTINGS_DISPLAY_SECTION, function(Browser $section) {
-                    $nodes = $this->getAllObjects();
+                    $objects = $this->getAllObjects();
                     $this->fillForm($section);
 
                     $this->assertSaveButtonEnabled($section);
@@ -207,12 +194,12 @@ abstract class SettingsBase extends DuskTestCase {
 
                     $this->assertFormDefaults($section);
 
-                    $new_node =$this->getAllObjects()->diff($nodes)->first();
-                    $this->interactWithObjectListItem($section, $new_node);
+                    $new_object =$this->getAllObjects()->diff($objects)->first();
+                    $this->interactWithObjectListItem($section, $new_object);
                     $section->elsewhere(self::$SELECTOR_PRIMARY_DIV, function(Browser $body) {
                         $this->waitForLoadingToStop($body);
                     });
-                    $this->assertFormWithExistingData($section, $new_node);
+                    $this->assertFormWithExistingData($section, $new_object);
                 });
             });
         });
@@ -220,7 +207,6 @@ abstract class SettingsBase extends DuskTestCase {
 
     /**
      * @dataProvider providerSaveExistingSettingNode
-     * @throws Throwable
      *
      * test ?/20
      */
@@ -260,7 +246,6 @@ abstract class SettingsBase extends DuskTestCase {
 
     /**
      * @dataProvider providerDisablingOrRestoringAccount
-     * @throws \Throwable
      *
      * test ?/25
      */

--- a/tests/Browser/SettingsBase.php
+++ b/tests/Browser/SettingsBase.php
@@ -266,7 +266,7 @@ abstract class SettingsBase extends DuskTestCase {
      */
     public function testDisablingOrRestoringObject(bool $isInitObjectActive) {
         // TODO: remove as soon as other objects have been updated
-        if (!in_array(get_class(), ['SettingsAccountsTest', 'SettingsAccountTypesTest', 'SettingsTagsTest'])) {
+        if (!in_array(get_class(), ['SettingsAccountTypesTest', 'SettingsTagsTest'])) {
             $this->markTestSkipped();
         }
 

--- a/tests/Browser/SettingsInstitutionsTest.php
+++ b/tests/Browser/SettingsInstitutionsTest.php
@@ -149,6 +149,8 @@ class SettingsInstitutionsTest extends SettingsBase {
     protected function fillForm(Browser $section) {
         $this->interactWithFormElement($section, self::$SELECTOR_SETTINGS_FORM_INPUT_NAME);
         $section->assertInputValueIsNot(self::$SELECTOR_SETTINGS_FORM_INPUT_NAME, '');
+        // don't interact with the "active" toggle button
+        // doing so would clear the form
     }
 
     protected function generateObject(bool $isInitObjectActive): BaseModel {

--- a/tests/Browser/SettingsInstitutionsTest.php
+++ b/tests/Browser/SettingsInstitutionsTest.php
@@ -169,7 +169,7 @@ class SettingsInstitutionsTest extends SettingsBase {
     }
 
     protected function getAllObjects(): Collection {
-        return Institution::all();
+        return Institution::withTrashed()->get();
     }
 
     protected function interactWithObjectListItem(Browser $section, BaseModel $node, bool $is_fresh_load=true) {

--- a/tests/Browser/SettingsInstitutionsTest.php
+++ b/tests/Browser/SettingsInstitutionsTest.php
@@ -101,10 +101,10 @@ class SettingsInstitutionsTest extends SettingsBase {
         $this->assertSaveButtonDisabled($section);
     }
 
-    protected function assertFormWithExistingData(Browser $section, BaseModel $node): void {
-        $this->assertObjectIsOfType($node, Institution::class);
-        $section->assertInputValue(self::$SELECTOR_SETTINGS_FORM_INPUT_NAME, $node->name);
-        if ($node->active) {
+    protected function assertFormWithExistingData(Browser $section, BaseModel $object): void {
+        $this->assertObjectIsOfType($object, Institution::class);
+        $section->assertInputValue(self::$SELECTOR_SETTINGS_FORM_INPUT_NAME, $object->name);
+        if ($object->active) {
             $this->assertActiveStateToggleActive($section, self::$SELECTOR_SETTINGS_FORM_TOGGLE_ACTIVE);
         } else {
             $this->assertActiveStateToggleInactive($section, self::$SELECTOR_SETTINGS_FORM_TOGGLE_ACTIVE);
@@ -112,14 +112,14 @@ class SettingsInstitutionsTest extends SettingsBase {
 
         $section
             ->assertVisible(self::$SELECTOR_SETTINGS_FORM_LABEL_CREATED)
-            ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_CREATED, $this->convertDateToECMA262Format($node->create_stamp))
+            ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_CREATED, $this->convertDateToECMA262Format($object->create_stamp))
             ->assertVisible(self::$SELECTOR_SETTINGS_FORM_LABEL_MODIFIED)
-            ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_MODIFIED, $this->convertDateToECMA262Format($node->modified_stamp))
+            ->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_MODIFIED, $this->convertDateToECMA262Format($object->modified_stamp))
             ->assertVisible(self::$SELECTOR_SETTINGS_FORM_LABEL_DISABLED);
-        if($node->active) {
+        if($object->active) {
             $section->assertMissing(self::$SELECTOR_SETTINGS_FORM_DISABLED);
         } else {
-            $section->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_DISABLED, $this->convertDateToECMA262Format($node->disabled_stamp));
+            $section->assertSeeIn(self::$SELECTOR_SETTINGS_FORM_DISABLED, $this->convertDateToECMA262Format($object->disabled_stamp));
         }
 
         $this->assertSaveButtonDisabled($section);

--- a/tests/Browser/SettingsTagsTest.php
+++ b/tests/Browser/SettingsTagsTest.php
@@ -69,12 +69,12 @@ class SettingsTagsTest extends SettingsBase {
         $this->assertSaveButtonDefault($section);
     }
 
-    protected function assertFormWithExistingData(Browser $section, BaseModel $node) {
-        $this->assertObjectIsOfType($node, Tag::class);
+    protected function assertFormWithExistingData(Browser $section, BaseModel $object) {
+        $this->assertObjectIsOfType($object, Tag::class);
 
         $section
             ->scrollIntoView(self::$SELECTOR_SETTINGS_HEADER)
-            ->assertInputValue(self::$SELECTOR_SETTINGS_FORM_INPUT_NAME, $node->name);
+            ->assertInputValue(self::$SELECTOR_SETTINGS_FORM_INPUT_NAME, $object->name);
         $this->assertSaveButtonDisabled($section);
     }
 

--- a/tests/Browser/StatsBase.php
+++ b/tests/Browser/StatsBase.php
@@ -112,7 +112,7 @@ class StatsBase extends DuskTestCase {
         if (!empty($filter_data[self::$FILTER_KEY_ACCOUNT_TYPE])) {
             $new_entry_data['account_type_id'] = $filter_data[self::$FILTER_KEY_ACCOUNT_TYPE];
         } elseif (!empty($filter_data[self::$FILTER_KEY_ACCOUNT])) {
-            $account = Account::find_account_with_types($filter_data[self::$FILTER_KEY_ACCOUNT]);
+            $account = Account::with('account_types')->find($filter_data[self::$FILTER_KEY_ACCOUNT]);
             $new_entry_data['account_type_id'] = $account->account_types->first()->id;
         } else {
             // Can't leave the assignment up to RNG in the factory.

--- a/tests/Browser/StatsBase.php
+++ b/tests/Browser/StatsBase.php
@@ -15,7 +15,6 @@ use Illuminate\Support\Collection;
 use Laravel\Dusk\Browser;
 use Tests\Browser\Pages\StatsPage;
 use Tests\DuskWithMigrationsTestCase as DuskTestCase;
-use Throwable;
 
 class StatsBase extends DuskTestCase {
     use DuskTraitLoading;

--- a/tests/Browser/StatsBase.php
+++ b/tests/Browser/StatsBase.php
@@ -101,7 +101,9 @@ class StatsBase extends DuskTestCase {
         if (!empty($filter_data[self::$FILTER_KEY_ACCOUNT_TYPE])) {
             $new_entry_data['account_type_id'] = $filter_data[self::$FILTER_KEY_ACCOUNT_TYPE];
         } elseif (!empty($filter_data[self::$FILTER_KEY_ACCOUNT])) {
-            $account = Account::with('account_types')->find($filter_data[self::$FILTER_KEY_ACCOUNT]);
+            $account = Account::withTrashed()
+                ->with('account_types')
+                ->findOrFail($filter_data[self::$FILTER_KEY_ACCOUNT]);
             $new_entry_data['account_type_id'] = $account->account_types->first()->id;
         } else {
             // Can't leave the assignment up to RNG in the factory.

--- a/tests/Browser/StatsBase.php
+++ b/tests/Browser/StatsBase.php
@@ -53,13 +53,6 @@ class StatsBase extends DuskTestCase {
         $this->month_end = date("Y-m-t");
     }
 
-    /**
-     * @param string $side_panel_selector
-     * @param string $stats_form_selector
-     * @param string $stats_results_selector
-     *
-     * @throws Throwable
-     */
     protected function generatingADifferentChartWontCauseSummaryTablesToBecomeVisible(string $side_panel_selector, string $stats_form_selector, string $stats_results_selector) {
         // TODO: rewrite this to accept any stats component; not just redirect to the stats-summary component
         // TODO: wait until all other stats components have been adjusted
@@ -92,9 +85,6 @@ class StatsBase extends DuskTestCase {
     /**
      * Sometimes we select a collection of filter parameters that result in no entries being available.
      * In those situations, we need to make sure that at least one entry does exist.
-     *
-     * @param array $filter_data
-     * @param string $memo
      */
     protected function generateEntryFromFilterData(array $filter_data, string $memo = '') {
         $new_entry_data = ['disabled'=>false];

--- a/tests/Browser/StatsDistributionTest.php
+++ b/tests/Browser/StatsDistributionTest.php
@@ -232,7 +232,7 @@ class StatsDistributionTest extends StatsBase {
                         $account_or_account_type_id = ($is_random_selector_value) ? $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
                     } else {
                         // stay with accounts
-                        $account_or_account_type_id = ($is_random_selector_value) ? $accounts->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
+                        $account_or_account_type_id = ($is_random_selector_value) ? $accounts->where('active', !$are_disabled_select_options_available)->pluck('id')->random() : '';
                     }
 
                     $this->selectAccountOrAccountTypeValue($form, $account_or_account_type_id);

--- a/tests/Browser/StatsDistributionTest.php
+++ b/tests/Browser/StatsDistributionTest.php
@@ -229,10 +229,10 @@ class StatsDistributionTest extends StatsBase {
                     if ($is_account_switch_toggled) {
                         // switch to account-types
                         $this->toggleAccountOrAccountTypeSwitch($form);
-                        $account_or_account_type_id = ($is_random_selector_value) ? $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
+                        $account_or_account_type_id = ($is_random_selector_value) ? $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : null;
                     } else {
                         // stay with accounts
-                        $account_or_account_type_id = ($is_random_selector_value) ? $accounts->where('active', !$are_disabled_select_options_available)->pluck('id')->random() : '';
+                        $account_or_account_type_id = ($is_random_selector_value) ? $accounts->where('active', !$are_disabled_select_options_available)->pluck('id')->random() : null;
                     }
 
                     $this->selectAccountOrAccountTypeValue($form, $account_or_account_type_id);
@@ -314,11 +314,11 @@ class StatsDistributionTest extends StatsBase {
      * So instead for these tests, we'll create a disabled with all the tags
      *
      * @param bool $is_account_type_rather_than_account_toggled
-     * @param int $account_or_account_type_id
+     * @param int|null $account_or_account_type_id
      * @param Collection $account_types
      * @param Collection $tags
      */
-    private function createEntryWithAllTags(bool $is_account_type_rather_than_account_toggled, $account_or_account_type_id, $account_types, $tags) {
+    private function createEntryWithAllTags(bool $is_account_type_rather_than_account_toggled, ?int $account_or_account_type_id, $account_types, $tags) {
         if (!empty($account_or_account_type_id)) {
             if ($is_account_type_rather_than_account_toggled) {
                 $account_type_id = $account_or_account_type_id;

--- a/tests/Browser/StatsDistributionTest.php
+++ b/tests/Browser/StatsDistributionTest.php
@@ -10,7 +10,6 @@ use App\Traits\Tests\Dusk\StatsSidePanel as DuskTraitStatsSidePanel;
 use Illuminate\Support\Collection;
 use Laravel\Dusk\Browser;
 use Tests\Browser\Pages\StatsPage;
-use Throwable;
 
 /**
  * Class StatsDistributionTest
@@ -51,8 +50,6 @@ class StatsDistributionTest extends StatsBase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group stats-distribution-1
      * test 1/20
      */
@@ -68,8 +65,6 @@ class StatsDistributionTest extends StatsBase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group stats-distribution-1
      * test 2/20
      */
@@ -102,8 +97,6 @@ class StatsDistributionTest extends StatsBase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group stats-distribution-1
      * test 3/20
      */
@@ -121,8 +114,6 @@ class StatsDistributionTest extends StatsBase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group stats-distribution-1
      * test 4/20
      */
@@ -137,73 +128,63 @@ class StatsDistributionTest extends StatsBase {
     public function providerGenerateDistributionChart(): array {
         //[$datepicker_start, $datepicker_end, $is_account_switch_toggled, $is_expense_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $include_transfers]
         return [
-            //  default state of account/account-types; expense; default date range
-            [null, null, false, false, false, false, false],                   // test 1/20
-            //  default state of account/account-types; expense; default date range; include transfers
-            [null, null, false, false, false, false, true],                   // test 2/20
-            // default state of account/account-types; income; default date range
-            [null, null, false, true, false, false, false],                    // test 3/20
-            // default state of account/account-types; income; default date range; include transfers
-            [null, null, false, true, false, false, true],                    // test 4/20
-            // default state of account/account-types; expense; date range a year past to today
-            [$this->previous_year_start, $this->today, false, false, false, false, false], // test 5/20
-            // default state of account/account-types; expense; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, false, false, false, false, true], // test 6/20
-            // default state of account/account-types; income; date range a year past to today
-            [$this->previous_year_start, $this->today, false, true, false, false, false],  // test 7/20
-            // default state of account/account-types; income; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, false, true, false, false, true],  // test 8/20
-            // random account; expense; date range a year past to today
-            [$this->previous_year_start, $this->today, false, false, true, false, false],  // test 9/20
-            // random account; expense; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, false, false, true, false, true],  // test 10/20
-            // random account; income; date range a year past to today
-            [$this->previous_year_start, $this->today, false, true, true, false, false],   // test 11/20
-            // random account; income; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, false, true, true, false, true],   // test 12/20
-            // random account-type; expense; date range a year past to today
-            [$this->previous_year_start, $this->today, true, false, true, false, false],   // test 13/20
-            // random account-type; expense; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, true, false, true, false, true],   // test 14/20
-            // random account-type; income; date range a year past to today
-            [$this->previous_year_start, $this->today, true, true, true, false, false],    // test 15/20
-            // random account-type; income; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, true, true, true, false, true],    // test 16/20
-            // random disabled account; expense; date range a year past to today
-            [$this->previous_year_start, $this->today, false, false, true, true, false],   // test 17/20
-            // random disabled account; expense; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, false, false, true, true, true],   // test 18/20
-            // random disabled account; income; date range a year past to today
-            [$this->previous_year_start, $this->today, false, true, true, true, false],    // test 19/20
-            // random disabled account; income; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, false, true, true, true, true],    // test 20/20
-            // random disabled account-type; expense; date range a year past to today
-            [$this->previous_year_start, $this->today, true, false, true, true, false],    // test 21/20
-            // random disabled account-type; expense; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, true, false, true, true, true],    // test 22/20
-            // random disabled account-type; income; date range a year past to today
-            [$this->previous_year_start, $this->today, true, true, true, true, false],     // test 23/20
-            // random disabled account-type; income; date range a year past to today; include transfers
-            [$this->previous_year_start, $this->today, true, true, true, true, true],     // test 24/20
-            //  default state of account/account-types; expense; date range today only
-            [$this->today, $this->today, false, false, false, false, false],              // test 25/20
-            //  default state of account/account-types; expense; date range today only; include transfers
-            [$this->today, $this->today, false, false, false, false, true],               // test 26/20
+            // test 1/20
+            'default state of account/account-types; expense; default date range'=>[null, null, false, false, false, false, false],
+            // test 2/20
+            'default state of account/account-types; expense; default date range; include transfers'=>[null, null, false, false, false, false, true],
+            // test 3/20
+            'default state of account/account-types; income; default date range'=>[null, null, false, true, false, false, false],
+            // test 4/20
+            'default state of account/account-types; income; default date range; include transfers'=>[null, null, false, true, false, false, true],
+            // test 5/20
+            'default state of account/account-types; expense; date range a year past to today'=>[$this->previous_year_start, $this->today, false, false, false, false, false],
+            // test 6/20
+            'default state of account/account-types; expense; date range a year past to today; include transfers'=>[$this->previous_year_start, $this->today, false, false, false, false, true],
+            // test 7/20
+            'default state of account/account-types; income; date range a year past to today'=>[$this->previous_year_start, $this->today, false, true, false, false, false],
+            // test 8/20
+            'default state of account/account-types; income; date range a year past to today; include transfers'=>[$this->previous_year_start, $this->today, false, true, false, false, true],
+            // test 9/20
+            'random account; expense; date range a year past to today'=>[$this->previous_year_start, $this->today, false, false, true, false, false],
+            // test 10/20
+            'random account; expense; date range a year past to today; include transfers'=>[$this->previous_year_start, $this->today, false, false, true, false, true],
+            // test 11/20
+            'random account; income; date range a year past to today'=>[$this->previous_year_start, $this->today, false, true, true, false, false],
+            // test 12/20
+            'random account; income; date range a year past to today; include transfers'=>[$this->previous_year_start, $this->today, false, true, true, false, true],
+            // test 13/20
+            'random account-type; expense; date range a year past to today'=>[$this->previous_year_start, $this->today, true, false, true, false, false],
+            // test 14/20
+            'random account-type; expense; date range a year past to today; include transfers'=>[$this->previous_year_start, $this->today, true, false, true, false, true],
+            // test 15/20
+            'random account-type; income; date range a year past to today'=>[$this->previous_year_start, $this->today, true, true, true, false, false],
+            // test 16/20
+            'random account-type; income; date range a year past to today; include transfers'=>[$this->previous_year_start, $this->today, true, true, true, false, true],
+            // test 17/20
+            'random disabled account; expense; date range a year past to today'=>[$this->previous_year_start, $this->today, false, false, true, true, false],
+            // test 18/20
+            'random disabled account; expense; date range a year past to today; include transfers'=>[$this->previous_year_start, $this->today, false, false, true, true, true],
+            // test 19/20
+            'random disabled account; income; date range a year past to today'=>[$this->previous_year_start, $this->today, false, true, true, true, false],
+            // test 20/20
+            'random disabled account; income; date range a year past to today; include transfers'=>[$this->previous_year_start, $this->today, false, true, true, true, true],
+            // test 21/20
+            'random disabled account-type; expense; date range a year past to today'=>[$this->previous_year_start, $this->today, true, false, true, true, false],
+            // test 22/20
+            'random disabled account-type; expense; date range a year past to today; include transfers'=>[$this->previous_year_start, $this->today, true, false, true, true, true],
+            // test 23/20
+            'random disabled account-type; income; date range a year past to today'=>[$this->previous_year_start, $this->today, true, true, true, true, false],
+            // test 24/20
+            'random disabled account-type; income; date range a year past to today; include transfers'=>[$this->previous_year_start, $this->today, true, true, true, true, true],
+            // test 25/20
+            'default state of account/account-types; expense; date range today only'=>[$this->today, $this->today, false, false, false, false, false],
+            // test 26/20
+            'default state of account/account-types; expense; date range today only; include transfers'=>[$this->today, $this->today, false, false, false, false, true],
         ];
     }
 
     /**
      * @dataProvider providerGenerateDistributionChart
-     *
-     * @param string|null $datepicker_start
-     * @param string|null $datepicker_end
-     * @param bool $is_account_switch_toggled
-     * @param bool $is_expense_switch_toggled
-     * @param bool $is_random_selector_value
-     * @param bool $are_disabled_select_options_available
-     * @param bool $include_transfers
-     *
-     * @throws Throwable
      *
      * @group stats-distribution-2
      * test (see provider)/20

--- a/tests/Browser/StatsSummaryTest.php
+++ b/tests/Browser/StatsSummaryTest.php
@@ -149,17 +149,13 @@ class StatsSummaryTest extends StatsBase {
                     if ($are_disabled_select_options_available) {
                         $this->toggleShowDisabledAccountOrAccountTypeCheckbox($form);
                     }
-                    if($is_random_selector_value) {
-                        if ($is_switch_toggled) {
-                            // switch to account-types
-                            $this->toggleAccountOrAccountTypeSwitch($form);
-                            $account_or_account_type_id = $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random();
-                        } else {
-                            // stay with accounts
-                            $account_or_account_type_id = $accounts->where('active', !$are_disabled_select_options_available)->pluck('id')->random();
-                        }
+                    if ($is_switch_toggled) {
+                        // switch to account-types
+                        $this->toggleAccountOrAccountTypeSwitch($form);
+                        $account_or_account_type_id = ($is_random_selector_value) ? $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
                     } else {
-                        $account_or_account_type_id = '';
+                        // stay with accounts
+                        $account_or_account_type_id = ($is_random_selector_value) ? $accounts->where('active', !$are_disabled_select_options_available)->pluck('id')->random() : '';
                     }
 
                     $this->selectAccountOrAccountTypeValue($form, $account_or_account_type_id);

--- a/tests/Browser/StatsSummaryTest.php
+++ b/tests/Browser/StatsSummaryTest.php
@@ -12,7 +12,6 @@ use Facebook\WebDriver\WebDriverBy;
 use Illuminate\Support\Collection;
 use Tests\Browser\Pages\StatsPage;
 use Laravel\Dusk\Browser;
-use Throwable;
 
 /**
  * Class StatsSummaryTest
@@ -41,8 +40,6 @@ class StatsSummaryTest extends StatsBase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group stats-summary-1
      * test 1/20
      */
@@ -57,8 +54,6 @@ class StatsSummaryTest extends StatsBase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group stats-summary-1
      * test 2/20
      */
@@ -87,8 +82,6 @@ class StatsSummaryTest extends StatsBase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group stats-summary-1
      * test 3/20
      */
@@ -138,15 +131,6 @@ class StatsSummaryTest extends StatsBase {
 
     /**
      * @dataProvider providerTestGenerateStatsTables
-     *
-     * @param string|null $datepicker_start
-     * @param string|null $datepicker_end
-     * @param bool $is_switch_toggled
-     * @param bool $is_random_selector_value
-     * @param bool $are_disabled_select_options_available
-     * @param bool $include_transfers
-     *
-     * @throws Throwable
      *
      * @group stats-summary-1
      * test (see provider)/20

--- a/tests/Browser/StatsSummaryTest.php
+++ b/tests/Browser/StatsSummaryTest.php
@@ -152,10 +152,10 @@ class StatsSummaryTest extends StatsBase {
                     if ($is_switch_toggled) {
                         // switch to account-types
                         $this->toggleAccountOrAccountTypeSwitch($form);
-                        $account_or_account_type_id = ($is_random_selector_value) ? $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
+                        $account_or_account_type_id = ($is_random_selector_value) ? $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : null;
                     } else {
                         // stay with accounts
-                        $account_or_account_type_id = ($is_random_selector_value) ? $accounts->where('active', !$are_disabled_select_options_available)->pluck('id')->random() : '';
+                        $account_or_account_type_id = ($is_random_selector_value) ? $accounts->where('active', !$are_disabled_select_options_available)->pluck('id')->random() : null;
                     }
 
                     $this->selectAccountOrAccountTypeValue($form, $account_or_account_type_id);

--- a/tests/Browser/StatsSummaryTest.php
+++ b/tests/Browser/StatsSummaryTest.php
@@ -96,36 +96,36 @@ class StatsSummaryTest extends StatsBase {
     }
 
     public function providerTestGenerateStatsTables(): array {
-        //[$datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available]
+        //[$datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $include_transfers]
         return [
-            // defaults account/account-type & date-picker values
-            [null, null, false, false, false, false],  // test 4/20
-            // defaults account/account-type & date-picker values & include transfers
-            [null, null, false, false, false, true],  // test 5/20
-            // date-picker previous year start to present & default account/account-type
-            [$this->previous_year_start, $this->today, false, false, false, false],    // test 6/20
-            // date-picker previous year start to present & default account/account-type & include transfers
-            [$this->previous_year_start, $this->today, false, false, false, true],    // test 7/20
-            // date-picker previous year start to present & random account
-            [$this->previous_year_start, $this->today, false, true, false, false],     // test 8/20
-            // date-picker previous year start to present & random account & include transfers
-            [$this->previous_year_start, $this->today, false, true, false, true],     // test 9/20
-            // date-picker previous year start to present & random account-type
-            [$this->previous_year_start, $this->today, true, true, false, false],     // test 10/20
-            // date-picker previous year start to present & random account-type & include transfers
-            [$this->previous_year_start, $this->today, true, true, false, true],      // test 11/20
-            // date-picker previous year start to present & random disabled account
-            [$this->previous_year_start, $this->today, false, true, false, false],    // test 12/20
-            // date-picker previous year start to present & random disabled account & include transfers
-            [$this->previous_year_start, $this->today, false, true, false, true],     // test 13/20
-            // date-picker previous year start to present & random disabled account-type
-            [$this->previous_year_start, $this->today, true, true, false, false],     // test 14/20
-            // date-picker previous year start to present & random disabled account-type & include transfers
-            [$this->previous_year_start, $this->today, true, true, false, true],      // test 15/20
-            // defaults account/account-type & date-picker values; date range today only
-            [$this->today, $this->today, false, false, false, false],                 // test 16/20
-            // defaults account/account-type & date-picker values; date range today only; include transfers
-            [$this->today, $this->today, false, false, false, true],                  // test 17/20
+            // test 4/20
+            'defaults account/account-type & date-picker values'=>[null, null, false, false, false, false],
+            // test 5/20
+            'defaults account/account-type & date-picker values & include transfers'=>[null, null, false, false, false, true],
+            // test 6/20
+            'date-picker previous year start to present & default account/account-type'=>[$this->previous_year_start, $this->today, false, false, false, false],
+            // test 7/20
+            'date-picker previous year start to present & default account/account-type & include transfers'=>[$this->previous_year_start, $this->today, false, false, false, true],
+            // test 8/20
+            'date-picker previous year start to present & random account'=>[$this->previous_year_start, $this->today, false, true, false, false],
+            // test 9/20
+            'date-picker previous year start to present & random account & include transfers'=>[$this->previous_year_start, $this->today, false, true, false, true],
+            // test 10/20
+            'date-picker previous year start to present & random account-type'=>[$this->previous_year_start, $this->today, true, true, false, false],
+            // test 11/20
+            'date-picker previous year start to present & random account-type & include transfers'=>[$this->previous_year_start, $this->today, true, true, false, true],
+            // test 12/20
+            'date-picker previous year start to present & random disabled account'=>[$this->previous_year_start, $this->today, false, true, false, false],
+            // test 13/20
+            'date-picker previous year start to present & random disabled account & include transfers'=>[$this->previous_year_start, $this->today, false, true, false, true],
+            // test 14/20
+            'date-picker previous year start to present & random disabled account-type'=>[$this->previous_year_start, $this->today, true, true, false, false],
+            // test 15/20
+            'date-picker previous year start to present & random disabled account-type & include transfers'=>[$this->previous_year_start, $this->today, true, true, false, true],
+            // test 16/20
+            'defaults account/account-type & date-picker values; date range today only'=>[$this->today, $this->today, false, false, false, false],
+            // test 17/20
+            'defaults account/account-type & date-picker values; date range today only; include transfers'=>[$this->today, $this->today, false, false, false, true],
         ];
     }
 

--- a/tests/Browser/StatsSummaryTest.php
+++ b/tests/Browser/StatsSummaryTest.php
@@ -165,14 +165,19 @@ class StatsSummaryTest extends StatsBase {
                     if ($are_disabled_select_options_available) {
                         $this->toggleShowDisabledAccountOrAccountTypeCheckbox($form);
                     }
-                    if ($is_switch_toggled) {
-                        // switch to account-types
-                        $this->toggleAccountOrAccountTypeSwitch($form);
-                        $account_or_account_type_id = ($is_random_selector_value) ? $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
+                    if($is_random_selector_value) {
+                        if ($is_switch_toggled) {
+                            // switch to account-types
+                            $this->toggleAccountOrAccountTypeSwitch($form);
+                            $account_or_account_type_id = $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random();
+                        } else {
+                            // stay with accounts
+                            $account_or_account_type_id = $accounts->where('active', !$are_disabled_select_options_available)->pluck('id')->random();
+                        }
                     } else {
-                        // stay with accounts
-                        $account_or_account_type_id = ($is_random_selector_value) ? $accounts->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
+                        $account_or_account_type_id = '';
                     }
+
                     $this->selectAccountOrAccountTypeValue($form, $account_or_account_type_id);
                     $filter_data = $this->generateFilterArrayElementAccountOrAccountypeId($filter_data, $is_switch_toggled, $account_or_account_type_id);
 

--- a/tests/Browser/StatsTagsTest.php
+++ b/tests/Browser/StatsTagsTest.php
@@ -229,10 +229,10 @@ class StatsTagsTest extends StatsBase {
                     if ($is_switch_toggled) {
                         // switch to account-types
                         $this->toggleAccountOrAccountTypeSwitch($form);
-                        $account_or_account_type_id = $is_random_selector_value ? $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
+                        $account_or_account_type_id = $is_random_selector_value ? $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : null;
                     } else {
                         // stay with accounts
-                        $account_or_account_type_id = $is_random_selector_value ? $accounts->where('active', !$are_disabled_select_options_available)->pluck('id')->random() : '';
+                        $account_or_account_type_id = $is_random_selector_value ? $accounts->where('active', !$are_disabled_select_options_available)->pluck('id')->random() : null;
                     }
                     $this->selectAccountOrAccountTypeValue($form, $account_or_account_type_id);
                     $filter_data = $this->generateFilterArrayElementAccountOrAccountypeId($filter_data, $is_switch_toggled, $account_or_account_type_id);
@@ -317,11 +317,11 @@ class StatsTagsTest extends StatsBase {
 
     /**
      * @param bool $is_account_type_rather_than_account_toggled
-     * @param string|int $account_or_account_type_id
+     * @param int|null $account_or_account_type_id
      * @param Collection $account_types
      * @param Collection $tags
      */
-    private function createEntryWithAllTags(bool $is_account_type_rather_than_account_toggled, $account_or_account_type_id, $account_types, $tags) {
+    private function createEntryWithAllTags(bool $is_account_type_rather_than_account_toggled, ?int $account_or_account_type_id, $account_types, $tags) {
         if (!empty($account_or_account_type_id)) {
             if ($is_account_type_rather_than_account_toggled) {
                 $account_type_id = $account_or_account_type_id;

--- a/tests/Browser/StatsTagsTest.php
+++ b/tests/Browser/StatsTagsTest.php
@@ -232,7 +232,7 @@ class StatsTagsTest extends StatsBase {
                         $account_or_account_type_id = $is_random_selector_value ? $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
                     } else {
                         // stay with accounts
-                        $account_or_account_type_id = $is_random_selector_value ? $accounts->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
+                        $account_or_account_type_id = $is_random_selector_value ? $accounts->where('active', !$are_disabled_select_options_available)->pluck('id')->random() : '';
                     }
                     $this->selectAccountOrAccountTypeValue($form, $account_or_account_type_id);
                     $filter_data = $this->generateFilterArrayElementAccountOrAccountypeId($filter_data, $is_switch_toggled, $account_or_account_type_id);

--- a/tests/Browser/StatsTrendingTest.php
+++ b/tests/Browser/StatsTrendingTest.php
@@ -113,34 +113,34 @@ class StatsTrendingTest extends StatsBase {
     public function providerTestGenerateTrendingChart(): array {
         return [
             //[$datepicker_start, $datepicker_end, $is_switch_toggled, $is_random_selector_value, $are_disabled_select_options_available, $include_transfers]
-            // defaults account/account-type & date-picker values
-            [null, null, false, false, false, false],  // test 4/20
-            // defaults account/account-type & date-picker values & include transfers checkbox button clicked
-            [null, null, false, false, false, true],  // test 5/20
-            // date-picker previous year start to present & default account/account-type
-            [$this->previous_year_start, $this->today, false, false, false, false],    // test 6/20
-            // date-picker previous year start to present & default account/account-type & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, false, false, false, true],    // test 7/20
-            // date-picker previous year start to present & random account
-            [$this->previous_year_start, $this->today, false, true, false, false],     // test 8/20
-            // date-picker previous year start to present & random account & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, false, true, false, true],     // test 9/20
-            // date-picker previous year start to present & random account-type
-            [$this->previous_year_start, $this->today, true, true, false, false],      // test 10/20
-            // date-picker previous year start to present & random account-type & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, true, true, false, true],      // test 11/20
-            // date-picker previous year start to present & random disabled account
-            [$this->previous_year_start, $this->today, false, true, false, false],     // test 12/20
-            // date-picker previous year start to present & random disabled account & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, false, true, false, true],     // test 13/20
-            // date-picker previous year start to present & random disabled account-type
-            [$this->previous_year_start, $this->today, true, true, false, false],      // test 14/20
-            // date-picker previous year start to present & random disabled account-type & include transfers checkbox button clicked
-            [$this->previous_year_start, $this->today, true, true, false, true],      // test 15/20
-            // defaults account/account-type; date-picker today ONLY
-            [$this->today, $this->today, false, false, false, false],  // test 16/20
-            // defaults account/account-type; date-picker today ONLY; include transfers
-            [$this->today, $this->today, false, false, false, true],  // test 17/20
+            // test 4/20
+            'defaults account/account-type & date-picker values'=>[null, null, false, false, false, false],
+            // test 5/20
+            'defaults account/account-type & date-picker values & include transfers checkbox button clicked'=>[null, null, false, false, false, true],
+            // test 6/20
+            'date-picker previous year start to present & default account/account-type'=>[$this->previous_year_start, $this->today, false, false, false, false],
+            // test 7/20
+            'date-picker previous year start to present & default account/account-type & include transfers checkbox button clicked'=>[$this->previous_year_start, $this->today, false, false, false, true],
+            // test 8/20
+            'date-picker previous year start to present & random account'=>[$this->previous_year_start, $this->today, false, true, false, false],
+            // test 9/20
+            'date-picker previous year start to present & random account & include transfers checkbox button clicked'=>[$this->previous_year_start, $this->today, false, true, false, true],
+            // test 10/20
+            'date-picker previous year start to present & random account-type'=>[$this->previous_year_start, $this->today, true, true, false, false],
+            // test 11/20
+            'date-picker previous year start to present & random account-type & include transfers checkbox button clicked'=>[$this->previous_year_start, $this->today, true, true, false, true],
+            // test 12/20
+            'date-picker previous year start to present & random disabled account'=>[$this->previous_year_start, $this->today, false, true, false, false],
+            // test 13/20
+            'date-picker previous year start to present & random disabled account & include transfers checkbox button clicked'=>[$this->previous_year_start, $this->today, false, true, false, true],
+            // test 14/20
+            'date-picker previous year start to present & random disabled account-type'=>[$this->previous_year_start, $this->today, true, true, false, false],
+            // test 15/20
+            'date-picker previous year start to present & random disabled account-type & include transfers checkbox button clicked'=>[$this->previous_year_start, $this->today, true, true, false, true],
+            // test 16/20
+            'defaults account/account-type; date-picker today ONLY'=>[$this->today, $this->today, false, false, false, false],
+            // test 17/20
+            'defaults account/account-type; date-picker today ONLY; include transfers'=>[$this->today, $this->today, false, false, false, true],
         ];
     }
 

--- a/tests/Browser/StatsTrendingTest.php
+++ b/tests/Browser/StatsTrendingTest.php
@@ -11,7 +11,6 @@ use Brick\Money\Money;
 use Illuminate\Support\Collection;
 use Laravel\Dusk\Browser;
 use Tests\Browser\Pages\StatsPage;
-use Throwable;
 
 /**
  * Class StatsTrendingTest
@@ -44,8 +43,6 @@ class StatsTrendingTest extends StatsBase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group stats-trending-1
      * test 1/20
      */
@@ -61,8 +58,6 @@ class StatsTrendingTest extends StatsBase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group stats-trending-1
      * test 2/20
      */
@@ -97,8 +92,6 @@ class StatsTrendingTest extends StatsBase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group stats-trending-1
      * test 3/20
      */
@@ -154,15 +147,6 @@ class StatsTrendingTest extends StatsBase {
     /**
      * @dataProvider providerTestGenerateTrendingChart
      *
-     * @param string|null $datepicker_start
-     * @param string|null $datepicker_end
-     * @param bool $is_switch_toggled
-     * @param bool $is_random_selector_value
-     * @param bool $are_disabled_select_options_available
-     * @param bool $include_transfers
-     *
-     * @throws Throwable
-     *
      * @group stats-trending-1
      * test (see provider)/20
      */
@@ -187,7 +171,7 @@ class StatsTrendingTest extends StatsBase {
                         $account_or_account_type_id = ($is_random_selector_value) ? $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
                     } else {
                         // stay with accounts
-                        $account_or_account_type_id = ($is_random_selector_value) ? $accounts->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
+                        $account_or_account_type_id = ($is_random_selector_value) ? $accounts->where('active', !$are_disabled_select_options_available)->pluck('id')->random() : '';
                     }
 
                     $this->selectAccountOrAccountTypeValue($form, $account_or_account_type_id);
@@ -244,8 +228,6 @@ class StatsTrendingTest extends StatsBase {
     }
 
     /**
-     * @throws Throwable
-     *
      * @group stats-trending-1
      * test 18/20
      */

--- a/tests/Browser/StatsTrendingTest.php
+++ b/tests/Browser/StatsTrendingTest.php
@@ -168,10 +168,10 @@ class StatsTrendingTest extends StatsBase {
                     if ($is_switch_toggled) {
                         // switch to account-types
                         $this->toggleAccountOrAccountTypeSwitch($form);
-                        $account_or_account_type_id = ($is_random_selector_value) ? $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : '';
+                        $account_or_account_type_id = ($is_random_selector_value) ? $account_types->where('disabled', $are_disabled_select_options_available)->pluck('id')->random() : null;
                     } else {
                         // stay with accounts
-                        $account_or_account_type_id = ($is_random_selector_value) ? $accounts->where('active', !$are_disabled_select_options_available)->pluck('id')->random() : '';
+                        $account_or_account_type_id = ($is_random_selector_value) ? $accounts->where('active', !$are_disabled_select_options_available)->pluck('id')->random() : null;
                     }
 
                     $this->selectAccountOrAccountTypeValue($form, $account_or_account_type_id);

--- a/tests/Browser/TransferModalTest.php
+++ b/tests/Browser/TransferModalTest.php
@@ -381,7 +381,7 @@ class TransferModalTest extends DuskTestCase {
         $account_types = AccountType::all();
         $disabled_account_type = [];
         if ($account_type_method == self::$METHOD_ACCOUNT) {
-            $disabled_account = Account::where('disabled', true)->get()->random();
+            $disabled_account = Account::onlyTrashed()->get()->random();
             $disabled_account_type = $account_types->where('account_id', $disabled_account['id'])->random();
         } elseif ($account_type_method == self::$METHOD_ACCOUNT_TYPE) {
             $disabled_account_type = $account_types->where('disabled', true)->random();

--- a/tests/Browser/UpdateAccountTotalTest.php
+++ b/tests/Browser/UpdateAccountTotalTest.php
@@ -245,10 +245,6 @@ class UpdateAccountTotalTest extends DuskTestCase {
 
     /**
      * @dataProvider providerUpdateAccountTotalsWithNewTransferEntries
-     * @param bool $is_from_account_external
-     * @param bool $is_to_account_external
-     *
-     * @throws Throwable
      *
      * @group navigation-5
      * test (see provider)/20
@@ -267,7 +263,7 @@ class UpdateAccountTotalTest extends DuskTestCase {
                     ->where('account_id', '!=', $account['from']['id'])
                     ->random();
                 $account['to'] = $this->getAccount($account_type['account_id']);
-            } while ($account['to']['disabled']);
+            } while (!$account['to']['active']);
             $account['to']['account_type_id'] = $account_type['id'];
         } elseif ($is_to_account_external) {
             $account['to']['id'] = 0;
@@ -376,7 +372,7 @@ class UpdateAccountTotalTest extends DuskTestCase {
         $accounts = $this->getApiAccounts();
         $accounts_collection = collect($accounts);
         if ($is_institution_id) {
-            return $accounts_collection->where('disabled', false)->where('institution_id', $id)->random();
+            return $accounts_collection->where('active', true)->where('institution_id', $id)->random();
         } else {
             return $accounts_collection->where('id', $id)->first();
         }

--- a/tests/Feature/Api/Delete/DeleteAccountTest.php
+++ b/tests/Feature/Api/Delete/DeleteAccountTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Api\Delete;
+
+use App\Models\Account;
+use Illuminate\Foundation\Testing\WithFaker;
+use Symfony\Component\HttpFoundation\Response as HttpStatus;
+use Tests\TestCase;
+
+class DeleteAccountTest extends TestCase {
+    use WithFaker;
+
+    private const PLACEHOLDER_URI_ACCOUNT = '/api/account/%d';
+
+    public function testDisablingAccountThatDoesNotExist() {
+        // GIVEN - account_type does not exist
+        $account_id = fake()->randomNumber();
+        // confirm account does not exist
+        $dummy_account = Account::find($account_id);
+        $this->assertNull($dummy_account);
+
+        // WHEN
+        $response = $this->delete(sprintf(self::PLACEHOLDER_URI_ACCOUNT, $account_id));
+
+        // THEN
+        // confirm we got the right response
+        $this->assertResponseStatus($response, HttpStatus::HTTP_NOT_FOUND);
+        $this->assertEmpty($response->getContent());
+    }
+
+    public function testDisablingAccountThatIsAlreadyDisabled() {
+        // GIVEN
+        $generated_account = Account::factory()->disabled()->create();
+
+        // WHEN
+        $response = $this->delete(sprintf(self::PLACEHOLDER_URI_ACCOUNT, $generated_account->id));
+
+        // THEN
+        // confirm we got the right response
+        $this->assertResponseStatus($response, HttpStatus::HTTP_NOT_FOUND);
+        $this->assertEmpty($response->getContent());
+    }
+
+    public function testDisablingAccount() {
+        // GIVEN
+        $generated_account = Account::factory()->create();
+        $account_uri = sprintf(self::PLACEHOLDER_URI_ACCOUNT, $generated_account->id);
+
+        // confirm account is NOT disabled
+        // WHEN
+        $account_response1 = $this->get($account_uri);
+
+        // THEN
+        $this->assertResponseStatus($account_response1, HttpStatus::HTTP_OK);
+        $account_response1_as_array = $account_response1->json();
+        $error_msg = "Content:".$account_response1->getContent();
+        $this->assertNotEmpty($account_response1_as_array, $error_msg);
+        $this->assertArrayHasKey('active', $account_response1_as_array, $error_msg);
+        $this->assertTrue($account_response1_as_array['active'], $error_msg);
+        $this->assertArrayHasKey(Account::DELETED_AT, $account_response1_as_array, $error_msg);
+        $this->assertNull($account_response1_as_array[Account::DELETED_AT], $error_msg);
+
+        // disable account
+        // WHEN
+        $disabled_response = $this->delete($account_uri);
+
+        // THEN
+        $this->assertResponseStatus($disabled_response, HttpStatus::HTTP_NO_CONTENT);
+        $this->assertEmpty($disabled_response->getContent());
+
+        // confirm account is disabled
+        // WHEN
+        $account_response2 = $this->get($account_uri);
+
+        // THEN
+        $this->assertResponseStatus($account_response2, HttpStatus::HTTP_OK);
+        $account_response2_as_array = $account_response2->json();
+        $error_msg = "Content:".$account_response2->getContent();
+        $this->assertNotEmpty($account_response2_as_array, $error_msg);
+        $this->assertArrayHasKey('active', $account_response2_as_array, $error_msg);
+        $this->assertFalse($account_response2_as_array['active'], $error_msg);
+        $this->assertArrayHasKey(Account::DELETED_AT, $account_response1_as_array, $error_msg);
+        $this->assertNotNull($account_response2_as_array[Account::DELETED_AT], $error_msg);
+        $this->assertDatetimeWithinOneSecond(now()->toAtomString(), $account_response2_as_array[Account::DELETED_AT], $error_msg);
+    }
+
+}

--- a/tests/Feature/Api/Delete/DeleteAttachmentTest.php
+++ b/tests/Feature/Api/Delete/DeleteAttachmentTest.php
@@ -43,9 +43,9 @@ class DeleteAttachmentTest extends TestCase {
         // THEN
         $get_response1->assertStatus(Response::HTTP_OK);
         $get_response1_as_array = $get_response1->json();
-        $this->assertTrue(is_array($get_response1_as_array));
+        $this->assertIsArray($get_response1_as_array);
         $this->assertArrayHasKey('attachments', $get_response1_as_array);
-        $this->assertTrue(is_array($get_response1_as_array['attachments']));
+        $this->assertIsArray($get_response1_as_array['attachments']);
         $attachment_exists = false;
         foreach ($get_response1_as_array['attachments'] as $attachment_in_response) {
             $this->assertArrayHasKey('uuid', $attachment_in_response);
@@ -61,9 +61,9 @@ class DeleteAttachmentTest extends TestCase {
 
         $get_response2->assertStatus(Response::HTTP_OK);
         $get_response2_as_array = $get_response2->json();
-        $this->assertTrue(is_array($get_response2_as_array));
+        $this->assertIsArray($get_response2_as_array);
         $this->assertArrayHasKey('attachments', $get_response2_as_array);
-        $this->assertTrue(is_array($get_response2_as_array['attachments']));
+        $this->assertIsArray($get_response2_as_array['attachments']);
         $attachment_exists = false;
         foreach ($get_response2_as_array['attachments'] as $attachment_in_response) {
             $this->assertArrayHasKey('uuid', $attachment_in_response);

--- a/tests/Feature/Api/Get/GetAccountTest.php
+++ b/tests/Feature/Api/Get/GetAccountTest.php
@@ -100,8 +100,8 @@ class GetAccountTest extends TestCase {
      * @param Account $generated_account
      * @param int $account_type_count
      */
-    private function assertAccountDetailsOK(array $response_as_array, $generated_account, int $account_type_count) {
-        $expected_elements = ['id', 'name', 'institution_id', 'disabled', 'total', 'currency', 'account_types', Account::CREATED_AT, Account::UPDATED_AT, 'disabled_stamp'];
+    private function assertAccountDetailsOK(array $response_as_array, $generated_account, int $account_type_count): void {
+        $expected_elements = ['id', 'name', 'institution_id', 'active', 'total', 'currency', 'account_types', Account::CREATED_AT, Account::UPDATED_AT, Account::DELETED_AT];
         $this->assertEqualsCanonicalizing($expected_elements, array_keys($response_as_array));
         foreach ($expected_elements as $expected_element) {
             switch ($expected_element) {
@@ -118,14 +118,14 @@ class GetAccountTest extends TestCase {
                 case Account::UPDATED_AT:
                     $this->assertDateFormat($response_as_array[$expected_element], DATE_ATOM, $response_as_array[$expected_element]." not in correct format");
                     break;
-                case 'disabled_stamp':
-                    if ($response_as_array['disabled']) {
-                        $this->assertDateFormat($response_as_array[$expected_element], DATE_ATOM, $response_as_array[$expected_element]." not in correct format");
-                    } else {
+                case Account::DELETED_AT:
+                    if ($response_as_array['active']) {
                         $this->assertNull($response_as_array[$expected_element]);
+                    } else {
+                        $this->assertDateFormat($response_as_array[$expected_element], DATE_ATOM, $response_as_array[$expected_element]." not in correct format");
                     }
                     break;
-                case 'disabled':
+                case 'active':
                     $this->assertIsBool($response_as_array[$expected_element]);
                     $this->assertEquals($generated_account->$expected_element, $response_as_array[$expected_element]);
                     break;

--- a/tests/Feature/Api/Get/GetAccountsTest.php
+++ b/tests/Feature/Api/Get/GetAccountsTest.php
@@ -15,7 +15,7 @@ class GetAccountsTest extends TestCase {
         $account_count = fake()->randomDigitNotZero();
         $generated_accounts = Account::factory()->count($account_count)->create();
         // These nodes are not in the response output. Let's hide them from the object collection.
-        $generated_accounts->makeHidden([Account::UPDATED_AT, Account::CREATED_AT, 'disabled_stamp']);
+        $generated_accounts->makeHidden([Account::UPDATED_AT, Account::CREATED_AT, Account::DELETED_AT]);
 
         // WHEN
         $response = $this->get($this->_uri);

--- a/tests/Feature/Api/Get/GetAccountsTest.php
+++ b/tests/Feature/Api/Get/GetAccountsTest.php
@@ -28,7 +28,7 @@ class GetAccountsTest extends TestCase {
         $this->assertEquals($account_count, $response_body_as_array['count']);
         unset($response_body_as_array['count']);
 
-        $expected_array_keys = ['id', 'name', 'institution_id', 'disabled', 'total', 'currency'];
+        $expected_array_keys = ['id', 'name', 'institution_id', 'active', 'total', 'currency'];
         foreach ($response_body_as_array as $account_in_response) {
             $this->assertEqualsCanonicalizing($expected_array_keys, array_keys($account_in_response));
             $generated_account = $generated_accounts->where('id', $account_in_response['id'])->first();

--- a/tests/Feature/Api/Get/GetEntriesTest.php
+++ b/tests/Feature/Api/Get/GetEntriesTest.php
@@ -75,7 +75,7 @@ class GetEntriesTest extends ListEntriesBase {
             $response->assertStatus(HttpStatus::HTTP_OK);
             $response_body_as_array = $response->json();
 
-            $this->assertTrue(is_array($response_body_as_array));
+            $this->assertIsArray($response_body_as_array);
             $this->assertArrayHasKey('count', $response_body_as_array);
             $this->assertEquals($generate_entry_count, $response_body_as_array['count']);
             unset($response_body_as_array['count']);

--- a/tests/Feature/Api/Get/GetInstitutionTest.php
+++ b/tests/Feature/Api/Get/GetInstitutionTest.php
@@ -49,7 +49,7 @@ class GetInstitutionTest extends TestCase {
         $generated_institution = Institution::factory()->create();
         $generated_accounts = Account::factory()->count($generated_account_count)->for($generated_institution)->create();
         // These nodes are not in the response output. Let's hide them from the object collection.
-        $generated_accounts->makeHidden(['institution_id', Account::CREATED_AT, Account::UPDATED_AT, 'disabled_stamp']);
+        $generated_accounts->makeHidden(['institution_id', Account::CREATED_AT, Account::UPDATED_AT, Account::DELETED_AT]);
 
         // WHEN
         $response = $this->get(sprintf($this->_base_uri, $generated_institution->id));
@@ -67,7 +67,7 @@ class GetInstitutionTest extends TestCase {
         }
     }
 
-    public function assertInstitutionNode(array $institute_in_response, Institution $generated_institution) {
+    public function assertInstitutionNode(array $institute_in_response, Institution $generated_institution): void {
         $expected_elements = ['id', 'name', 'active', Institution::CREATED_AT, Institution::UPDATED_AT, Institution::DELETED_AT, 'accounts'];
         $this->assertEqualsCanonicalizing($expected_elements, array_keys($institute_in_response));
 
@@ -95,8 +95,8 @@ class GetInstitutionTest extends TestCase {
         }
     }
 
-    public function assertInstitutionAccountNodesOK($institution_account_in_response, $generated_accounts) {
-        $expected_elements = ['id', 'name', 'disabled', 'total', 'currency'];
+    public function assertInstitutionAccountNodesOK($institution_account_in_response, $generated_accounts): void {
+        $expected_elements = ['id', 'name', 'active', 'total', 'currency'];
         $this->assertEqualsCanonicalizing($expected_elements, array_keys($institution_account_in_response));
 
         $generated_account = $generated_accounts->where('id', $institution_account_in_response['id'])->first();

--- a/tests/Feature/Api/Patch/PatchAccountTest.php
+++ b/tests/Feature/Api/Patch/PatchAccountTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature\Api\Patch;
+
+use App\Models\Account;
+use App\Models\Institution;
+use Illuminate\Foundation\Testing\WithFaker;
+use Symfony\Component\HttpFoundation\Response as HttpStatus;
+use Tests\TestCase;
+
+class PatchAccountTest extends TestCase {
+    use WithFaker;
+
+    private const PLACEHOLDER_URI_ACCOUNT = '/api/account/%d';
+
+    public function testRestoringAccountThatDoesNotExist() {
+        // GIVEN - no account exists
+        $account_id = $this->faker->randomNumber();
+
+        // WHEN
+        $response = $this->patch(sprintf(self::PLACEHOLDER_URI_ACCOUNT, $account_id));
+
+        // THEN
+        $this->assertResponseStatus($response, HttpStatus::HTTP_NOT_FOUND);
+        $this->assertEmpty($response->getContent());
+    }
+
+    public function testRestoringUndeletedAccount() {
+        // GIVEN
+        $generated_institution = Institution::factory()->create();
+        $generated_account = Account::factory()->for($generated_institution)->create();
+
+        // WHEN
+        $response = $this->patch(sprintf(self::PLACEHOLDER_URI_ACCOUNT, $generated_account->id));
+
+        // THEN
+        $this->assertResponseStatus($response, HttpStatus::HTTP_NOT_FOUND);
+        $this->assertEmpty($response->getContent());
+    }
+
+    public function testRestoringAccount() {
+        // GIVEN
+        $generated_institution = Institution::factory()->create();
+        $generated_account = Account::factory()->for($generated_institution)->disabled()->create();
+        $account_uri = sprintf(self::PLACEHOLDER_URI_ACCOUNT, $generated_account->id);
+
+        // WHEN
+        $get_response1 = $this->get($account_uri);
+
+        // THEN
+        $this->assertResponseStatus($get_response1, HttpStatus::HTTP_OK);
+        $this->assertNotEmpty($get_response1->getContent());
+        $this->assertFalse($get_response1->json('active'));
+        $this->assertNotNull($get_response1->json(Account::DELETED_AT));
+
+        // WHEN
+        $patch_response = $this->patch($account_uri);
+
+        // THEN
+        $this->assertResponseStatus($patch_response, HttpStatus::HTTP_NO_CONTENT);
+        $this->assertEmpty($patch_response->getContent());
+
+        // WHEN
+        $get_response2 = $this->get($account_uri);
+
+        // THEN
+        $this->assertResponseStatus($get_response2, HttpStatus::HTTP_OK);
+        $this->assertNotEmpty($get_response2->getContent());
+        $this->assertTrue($get_response2->json('active'));
+        $this->assertNull($get_response2->json(Account::DELETED_AT));
+    }
+
+}

--- a/tests/Feature/Api/Post/PostAccountTest.php
+++ b/tests/Feature/Api/Post/PostAccountTest.php
@@ -120,11 +120,10 @@ class PostAccountTest extends TestCase {
     }
 
     private function generateDummyAccountData(): array {
-        $account_data = Account::factory()->make(['disabled'=>false]);
+        $account_data = Account::factory()->make();
         return [
             'name'=>$account_data->name,
             'institution_id'=>$account_data->institution_id,
-            'disabled'=>$account_data->disabled,
             'total'=>$account_data->total,
             'currency'=>$account_data->currency
         ];

--- a/tests/Feature/Api/Post/PostAccountTest.php
+++ b/tests/Feature/Api/Post/PostAccountTest.php
@@ -135,7 +135,7 @@ class PostAccountTest extends TestCase {
         return $account_data;
     }
 
-    private function assertFailedPostResponse(TestResponse $response, $expected_response_status, $expected_error_message) {
+    private function assertFailedPostResponse(TestResponse $response, $expected_response_status, $expected_error_message): void {
         $failure_message = "POST Response is ".$response->getContent();
         $this->assertResponseStatus($response, $expected_response_status, $failure_message);
         $response_as_array = $response->json();
@@ -143,12 +143,12 @@ class PostAccountTest extends TestCase {
         $this->assertFailedPostResponseContent($response_as_array, $expected_error_message, $failure_message);
     }
 
-    private function assertPostResponseHasCorrectKeys(array $response_as_array, string $failure_message) {
+    private function assertPostResponseHasCorrectKeys(array $response_as_array, string $failure_message): void {
         $this->assertArrayHasKey(self::$RESPONSE_KEY_ID, $response_as_array, $failure_message);
         $this->assertArrayHasKey(self::$RESPONSE_KEY_ERROR, $response_as_array, $failure_message);
     }
 
-    private function assertFailedPostResponseContent(array $response_as_array, string $expected_error_msg, string $failure_message) {
+    private function assertFailedPostResponseContent(array $response_as_array, string $expected_error_msg, string $failure_message): void {
         $this->assertEquals(self::$ERROR_ID, $response_as_array[self::$RESPONSE_KEY_ID], $failure_message);
         $this->assertNotEmpty($response_as_array[self::$RESPONSE_KEY_ERROR], $failure_message);
         $this->assertStringContainsString($expected_error_msg, $response_as_array[self::$RESPONSE_KEY_ERROR], $failure_message);

--- a/tests/Feature/Api/Post/PostAccountTypeTest.php
+++ b/tests/Feature/Api/Post/PostAccountTypeTest.php
@@ -72,7 +72,7 @@ class PostAccountTypeTest extends TestCase {
     public function testCreateAccountMissingProperty(array $account_type_data, string $error_message) {
         // GIVEN: see providerCreateAccountMissingProperty()
         if (isset($account_type_data['account_id'])) {
-            $account_type_data['account_id'] = Account::where('disabled', false)->get()->random()->id;
+            $account_type_data['account_id'] = Account::all()->random()->id;
         }
 
         // WHEN
@@ -97,7 +97,7 @@ class PostAccountTypeTest extends TestCase {
     public function testCreateAccountWithInvalidType() {
         // GIVEN
         $account_type_data = $this->generateDummyAccountTypeData();
-        $account_type_data['account_id'] = Account::where('disabled', false)->get()->random()->id;
+        $account_type_data['account_id'] = Account::all()->random()->id;
         $account_type_data['type'] = fake()->word();
 
         // WHEN
@@ -110,7 +110,7 @@ class PostAccountTypeTest extends TestCase {
     public function testCreateAccount() {
         // GIVEN
         $account_type_data = $this->generateDummyAccountTypeData();
-        $account_type_data['account_id'] = Account::where('disabled', false)->get()->random()->id;
+        $account_type_data['account_id'] = Account::all()->random()->id;
 
         // WHEN
         $response = $this->postJson($this->_base_uri, $account_type_data);

--- a/tests/Feature/Api/Post/PostAccountTypeTest.php
+++ b/tests/Feature/Api/Post/PostAccountTypeTest.php
@@ -19,7 +19,6 @@ class PostAccountTypeTest extends TestCase {
         parent::setUp();
         Account::factory()
             ->count(3)
-            ->state(['disabled'=>false])
             ->for(Institution::factory())
             ->create();
     }

--- a/tests/Feature/Api/Post/PostEntriesTest.php
+++ b/tests/Feature/Api/Post/PostEntriesTest.php
@@ -133,7 +133,7 @@ class PostEntriesTest extends ListEntriesBase {
         // THEN
         $response->assertStatus(HttpStatus::HTTP_OK);
         $response_as_array = $response->json();
-        $this->assertEquals(count($generated_entries), $response_as_array['count']);
+        $this->assertCount($response_as_array['count'], $generated_entries);
         unset($response_as_array['count']);
         $this->runEntryListAssertions(count($generated_entries), $response_as_array, $generated_entries);
     }

--- a/tests/Feature/Api/Put/PutAccountTest.php
+++ b/tests/Feature/Api/Put/PutAccountTest.php
@@ -19,7 +19,6 @@ class PutAccountTest extends TestCase {
 
         Account::factory()
             ->count(10)
-            ->state(['disabled'=>false])
             ->for(Institution::factory())
             ->create();
     }
@@ -76,7 +75,7 @@ class PutAccountTest extends TestCase {
         $account_data['institution_id'] = $this->getExistingActiveInstitutionId();
 
         // WHEN
-        $response = $this->putJson(sprintf($this->_base_uri, $account_id), $account_data->toArray());
+        $response = $this->putJson(sprintf($this->_base_uri, $account_id), $account_data);
 
         // THEN
         $this->assertFailedPostResponse($response, HttpStatus::HTTP_NOT_FOUND, self::$ERROR_MSG_DOES_NOT_EXIST);
@@ -84,12 +83,12 @@ class PutAccountTest extends TestCase {
 
     public function providerUpdateAccountEachProperty(): array {
         $this->initialiseApplication();
-        $dummy_account_data = $this->generateAccountData();
+        $account_data = $this->generateAccountData();
         $required_fields = Account::getRequiredFieldsForUpdate();
 
         $test_cases = [];
         foreach ($required_fields as $required_field) {
-            $test_cases[$required_field]['data'] = [$required_field=>$dummy_account_data->{$required_field}];
+            $test_cases[$required_field]['data'] = [$required_field=>$account_data[$required_field]];
         }
         return $test_cases;
     }
@@ -134,11 +133,13 @@ class PutAccountTest extends TestCase {
     }
 
     private function getRandomActiveExistingAccount() {
-        return Account::where('disabled', false)->get()->random();
+        return Account::get()->random();
     }
 
-    private function generateAccountData() {
-        return Account::factory()->make();
+    private function generateAccountData(): array {
+        $data = Account::factory()->make()->toArray();
+        unset($data['active'], $data['disabled_stamp']);
+        return $data;
     }
 
     private function getExistingActiveInstitutionId(): int {

--- a/tests/Feature/Api/Put/PutAccountTypeTest.php
+++ b/tests/Feature/Api/Put/PutAccountTypeTest.php
@@ -21,7 +21,6 @@ class PutAccountTypeTest extends TestCase {
 
         $accounts = Account::factory()
             ->count(3)
-            ->state(['disabled' => false])
             ->for(Institution::factory())
             ->create();
         AccountType::factory()

--- a/tests/Feature/Api/Put/PutAccountTypeTest.php
+++ b/tests/Feature/Api/Put/PutAccountTypeTest.php
@@ -153,7 +153,7 @@ class PutAccountTypeTest extends TestCase {
     }
 
     private function getExistingActiveAccountId(): int {
-        return Account::where('disabled', false)->get()->random()->id;
+        return Account::all()->random()->id;
     }
 
     private function assertFailedPostResponse(TestResponse $response, $expected_response_status, $expected_error_message): void {

--- a/tests/Feature/Console/AccountTotalSanityCheckTest.php
+++ b/tests/Feature/Console/AccountTotalSanityCheckTest.php
@@ -46,7 +46,7 @@ class AccountTotalSanityCheckTest extends TestCase {
     }
 
     public function testSanityCheckOutputtingToScreenAndWithoutNotifyingDiscord() {
-        $accounts = Account::factory()->count(3)->create(['disabled'=>true, 'total'=>0]);
+        $accounts = Account::factory()->count(3)->disabled()->create(['total'=>0]);
         $account_types = collect();
         foreach ($accounts as $account) {
             $account_type = AccountType::factory()->for($account)->create(['disabled'=>0]);
@@ -64,7 +64,7 @@ class AccountTotalSanityCheckTest extends TestCase {
     public function testSanityCheckIndividualAccountIdOutputtingToScreenAndWithoutNotifyingDiscord() {
         $this->seedDatabaseAndMaybeTruncateTable('entries');
 
-        $accounts = Account::where('disabled', 0);
+        $accounts = Account::all();
         $accounts->update(['total'=>0]);
         $account = $accounts->get()->random();
         $account_type = AccountType::where(['account_id'=>$account->id, 'disabled'=>0])->get()->random();

--- a/tests/Feature/Web/ExportsTest.php
+++ b/tests/Feature/Web/ExportsTest.php
@@ -42,7 +42,6 @@ class ExportsTest extends ListEntriesBase {
 
     /**
      * @dataProvider providerExportRequestMethodNotAllowed
-     * @param string $method
      */
     public function testExportRequestMethodNotAllowed(string $method) {
         // GIVEN - see provider
@@ -61,7 +60,6 @@ class ExportsTest extends ListEntriesBase {
 
     /**
      * @dataProvider providerExportPostRequest
-     * @param array $filter
      */
     public function testExportPostRequest(array $filter) {
         // GIVEN - see provider


### PR DESCRIPTION
- Increased the scope by which Github actions can generate a cache key.
- Added constants to contain keys used for Account model cache.
- Modified the accounts table and object to handle disabling/enabling an account.