### PR TITLE
fix/reduce-duplicate-query-clauses

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -142,7 +142,7 @@ class Entry extends BaseModel {
      */
     public static function count_collection_of_entries(array $filters = []): int {
         $entries_query = self::filter_entry_collection($filters);
-        return $entries_query->count();
+        return $entries_query->select('entries.id')->count();
     }
 
     /**


### PR DESCRIPTION
perf: Simplified queries for retrieving entries. When querying, eloquent models already ignore records that are "soft" deleted.