### PR TITLE
Perf/entry-tags

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate cache keys [docker]
         id: cache-key-docker
@@ -98,7 +98,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Cache: Docker images"
         id: cache-docker-image
@@ -175,7 +175,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -264,7 +264,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -329,7 +329,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -394,7 +394,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -468,7 +468,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -539,7 +539,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -604,7 +604,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -675,7 +675,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # retrieve cache
       - name: Get Cached Docker images
@@ -752,7 +752,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # retrieve cache
       - name: Get Cached Docker images

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -249,7 +249,7 @@ jobs:
         if: always()
 
       - name: Failure upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ github.sha }}-unit
@@ -314,7 +314,7 @@ jobs:
         if: always()
 
       - name: Failure upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ github.sha }}-e2e-demo
@@ -379,7 +379,7 @@ jobs:
         if: always()
 
       - name: Failure upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ github.sha }}-e2e-notifications
@@ -453,7 +453,7 @@ jobs:
         if: always()
 
       - name: Failure upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ github.sha }}-e2e-nav
@@ -524,7 +524,7 @@ jobs:
         if: always()
 
       - name: Failure upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ github.sha }}-e2e-entry-modal
@@ -589,7 +589,7 @@ jobs:
         if: always()
 
       - name: Failure upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ github.sha }}-e2e-transfer-modal
@@ -660,7 +660,7 @@ jobs:
         if: always()
 
       - name: Failure upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ github.sha }}-e2e-filter-modal
@@ -737,7 +737,7 @@ jobs:
         if: always()
 
       - name: Failure upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ github.sha }}-e2e-stats
@@ -808,7 +808,7 @@ jobs:
         if: always()
 
       - name: Failure upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ github.sha }}-e2e-settings

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: "Cache: Docker images"
         id: cache-docker-image
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: "Cache: Composer packages"
         id: cache-composer
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: "Cache: npm packages"
         id: cache-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
@@ -146,7 +146,7 @@ jobs:
 
       - name: "Cache: vue"
         id: cache-vue
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -180,21 +180,21 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
@@ -269,28 +269,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -334,28 +334,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -399,28 +399,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -473,28 +473,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -544,28 +544,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -609,28 +609,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -680,28 +680,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}
@@ -757,28 +757,28 @@ jobs:
       # retrieve cache
       - name: Get Cached Docker images
         id: docker-image-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-docker }}
           key: ${{ needs.pre-build.outputs.cache-key-docker }}
 
       - name: Get Cached Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-composer }}
           key: ${{ needs.pre-build.outputs.cache-key-composer }}
 
       - name: Get Cached npm packages
         id: npm-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-npm }}
           key: ${{ needs.pre-build.outputs.cache-key-npm }}
 
       - name: Get Cached vue
         id: vue-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ needs.pre-build.outputs.cache-path-vue }}
           key: ${{ needs.pre-build.outputs.cache-key-vue }}

--- a/app/Http/Controllers/Api/EntryController.php
+++ b/app/Http/Controllers/Api/EntryController.php
@@ -404,8 +404,8 @@ class EntryController extends Controller {
             return response([], HttpStatus::HTTP_NOT_FOUND);
         } else {
             $entries_collection->transform(function(Entry $entry) {
+                $entry->tags = empty($entry->tags) ? [] : array_map('intval', explode(',', $entry->tags));
                 $entry->has_attachments = $entry->attachments_exists;
-                $entry->tags = $entry->get_tag_ids();
                 $entry->is_transfer = !is_null($entry->transfer_entry_id);
                 unset($entry->transfer_entry_id, $entry->attachments_exists);
                 $entry->makeHidden(['accountType']);

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -129,9 +129,9 @@ class Entry extends BaseModel {
      */
     public static function get_collection_of_entries(array $filters = [], int $limit=10, int $offset=0, string $sort_by=self::DEFAULT_SORT_PARAMETER, string $sort_direction=self::DEFAULT_SORT_DIRECTION) {
         $entries_query = self::filter_entry_collection($filters);
-        // this makes sure that the correct ID is present if a JOIN is required
         $entries_query
             ->distinct()->select("entries.*")
+            ->selectSub("SELECT GROUP_CONCAT(COALESCE(entry_tags.tag_id, '')) FROM entry_tags WHERE entry_tags.entry_id=entries.id", "tags")
             ->withExists("attachments")
             ->orderBy($sort_by, $sort_direction)
             ->latest(self::CREATED_AT);

--- a/docs/UPDATE-PROD.md
+++ b/docs/UPDATE-PROD.md
@@ -79,6 +79,7 @@ php artisan app:version $MOST_RECENT_TAG
 # setup new cache
 php artisan optimize
 php artisan view:cache
+php artisan events:cache
 
 # re-sync schedule monitoring
 php artisan schedule-monitor:sync

--- a/resources/js/components/home/entry-modal.vue
+++ b/resources/js/components/home/entry-modal.vue
@@ -529,6 +529,7 @@ export default {
         this.unlockModal();
       } else {
         this.entryData = _.clone(this.entriesStore.find(this.entryData.id));
+        this.entryData.entry_value = this.decimaliseValue(this.entryData.entry_value);
         this.lockModal();
       }
     },

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -126,7 +126,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                     $entry_id = $entry_modal->inputValue($this->_selector_modal_entry_field_entry_id);
                     $this->assertNotEmpty($entry_id);
                     $entry_data = $this->getApiEntry($entry_id);
-                    $entry_data['entry_value'] = number_format($entry_data['entry_value'], 2);
+                    $entry_data['entry_value'] = number_format($entry_data['entry_value'], 2, '.', '');
 
                     $entry_modal
                         ->within($this->_selector_modal_head, function(Browser $modal_head) {
@@ -187,7 +187,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                     $entry_id = $entry_modal->inputValue($this->_selector_modal_entry_field_entry_id);
                     $this->assertNotEmpty($entry_id);
                     $entry_data = $this->getApiEntry($entry_id);
-                    $entry_data['entry_value'] = number_format($entry_data['entry_value'], 2);
+                    $entry_data['entry_value'] = number_format($entry_data['entry_value'], 2, '.', '');
 
                     $entry_modal
                         ->within($this->_selector_modal_head, function(Browser $modal_head) {
@@ -740,7 +740,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                     $entry_modal
                         ->within($this->_selector_modal_body, function(Browser $modal_body) use ($transfer_entry_data) {
                             $this->assertEntryModalDate($modal_body, $transfer_entry_data['entry_date']);
-                            $transfer_entry_data['entry_value'] = number_format($transfer_entry_data['entry_value'], 2);
+                            $transfer_entry_data['entry_value'] = number_format($transfer_entry_data['entry_value'], 2, '.', '');
                             $this->assertEntryModalValue($modal_body, $transfer_entry_data['entry_value']);
                             $this->assertEntryModalAccountType($modal_body, $transfer_entry_data['account_type_id']);
                             $this->assertEntryModalMemo($modal_body, $transfer_entry_data['memo']);
@@ -764,7 +764,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                     $entry_modal
                         ->within($this->_selector_modal_body, function(Browser $modal_body) use ($entry_data) {
                             $this->assertEntryModalDate($modal_body, $entry_data['entry_date']);
-                            $entry_data['entry_value'] = number_format($entry_data['entry_value'], 2);
+                            $entry_data['entry_value'] = number_format($entry_data['entry_value'], 2, '.', '');
                             $this->assertEntryModalValue($modal_body, $entry_data['entry_value']);
                             $this->assertEntryModalAccountType($modal_body, $entry_data['account_type_id']);
                             $this->assertEntryModalMemo($modal_body, $entry_data['memo']);
@@ -1234,7 +1234,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                     // retrieve entry data prior to input changes to avoid worry of values changing unintentionally
                     $entry_id = $this->getEntryIdFromSelector($entry_selector);
                     $entry_data = $this->getApiEntry($entry_id);
-                    $entry_data['entry_value'] = number_format($entry_data['entry_value'], 2);
+                    $entry_data['entry_value'] = number_format($entry_data['entry_value'], 2, '.', '');
 
                     // unlock modal
                     $entry_modal->within($this->_selector_modal_foot, function(Browser $modal_foot) {

--- a/tests/Browser/EntryModalExistingEntryTest.php
+++ b/tests/Browser/EntryModalExistingEntryTest.php
@@ -126,6 +126,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                     $entry_id = $entry_modal->inputValue($this->_selector_modal_entry_field_entry_id);
                     $this->assertNotEmpty($entry_id);
                     $entry_data = $this->getApiEntry($entry_id);
+                    $entry_data['entry_value'] = number_format($entry_data['entry_value'], 2);
 
                     $entry_modal
                         ->within($this->_selector_modal_head, function(Browser $modal_head) {
@@ -186,6 +187,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                     $entry_id = $entry_modal->inputValue($this->_selector_modal_entry_field_entry_id);
                     $this->assertNotEmpty($entry_id);
                     $entry_data = $this->getApiEntry($entry_id);
+                    $entry_data['entry_value'] = number_format($entry_data['entry_value'], 2);
 
                     $entry_modal
                         ->within($this->_selector_modal_head, function(Browser $modal_head) {
@@ -738,6 +740,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                     $entry_modal
                         ->within($this->_selector_modal_body, function(Browser $modal_body) use ($transfer_entry_data) {
                             $this->assertEntryModalDate($modal_body, $transfer_entry_data['entry_date']);
+                            $transfer_entry_data['entry_value'] = number_format($transfer_entry_data['entry_value'], 2);
                             $this->assertEntryModalValue($modal_body, $transfer_entry_data['entry_value']);
                             $this->assertEntryModalAccountType($modal_body, $transfer_entry_data['account_type_id']);
                             $this->assertEntryModalMemo($modal_body, $transfer_entry_data['memo']);
@@ -761,6 +764,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                     $entry_modal
                         ->within($this->_selector_modal_body, function(Browser $modal_body) use ($entry_data) {
                             $this->assertEntryModalDate($modal_body, $entry_data['entry_date']);
+                            $entry_data['entry_value'] = number_format($entry_data['entry_value'], 2);
                             $this->assertEntryModalValue($modal_body, $entry_data['entry_value']);
                             $this->assertEntryModalAccountType($modal_body, $entry_data['account_type_id']);
                             $this->assertEntryModalMemo($modal_body, $entry_data['memo']);
@@ -1230,6 +1234,7 @@ class EntryModalExistingEntryTest extends DuskTestCase {
                     // retrieve entry data prior to input changes to avoid worry of values changing unintentionally
                     $entry_id = $this->getEntryIdFromSelector($entry_selector);
                     $entry_data = $this->getApiEntry($entry_id);
+                    $entry_data['entry_value'] = number_format($entry_data['entry_value'], 2);
 
                     // unlock modal
                     $entry_modal->within($this->_selector_modal_foot, function(Browser $modal_foot) {

--- a/tests/Browser/NotificationsTest.php
+++ b/tests/Browser/NotificationsTest.php
@@ -15,6 +15,7 @@ use App\Traits\Tests\Dusk\EntryModal as DuskTraitEntryModal;
 use App\Traits\Tests\Dusk\Loading as DuskTraitLoading;
 use App\Traits\Tests\Dusk\Navbar as DuskTraitNavbar;
 use App\Traits\Tests\Dusk\Notification as DuskTraitNotification;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -172,6 +173,8 @@ class NotificationsTest extends DuskTestCase {
      * test 6/20
      */
     public function testNotificationDeleteAttachment404() {
+        $this->generatedEntryWithAttachmentOneMonthInTheFuture();
+
         $this->browse(function(Browser $browser) {
             $browser->visit(new HomePage());
             $this->waitForLoadingToStop($browser);
@@ -204,6 +207,8 @@ class NotificationsTest extends DuskTestCase {
      * test 7/20
      */
     public function testNotificationDeleteAttachment500() {
+        $this->generatedEntryWithAttachmentOneMonthInTheFuture();
+
         $table = Attachment::getTableName();
         $recreate_table_query = $this->getTableRecreationQuery($table);
 
@@ -238,6 +243,15 @@ class NotificationsTest extends DuskTestCase {
         });
 
         DB::statement($recreate_table_query);
+    }
+
+    private function generatedEntryWithAttachmentOneMonthInTheFuture() {
+        $account_type = AccountType::all()->random();
+        $new_entry = Entry::factory()->create([
+            'account_type_id'=>$account_type->id,
+            'entry_date'=>Carbon::now()->addDays(30)
+        ]);
+        Attachment::factory()->create(['entry_id'=>$new_entry->id]);
     }
 
     /**


### PR DESCRIPTION
- docs: added missing step when updating prod
- perf: improved query performance by getting tag ids from a subquery rather than "lazy" loading via eloquent
- chore: updated github actions `cache`, `checkout` and `upload-artifact` to `v4`
- fix: Corrected bug in entry-modal where toggling the lock state of an entry would reset the decimalised value in the `entry_value` field.
- fix: tests